### PR TITLE
Cluster type validations

### DIFF
--- a/charts/k3k/crds/cluster.yaml
+++ b/charts/k3k/crds/cluster.yaml
@@ -21,16 +21,34 @@ spec:
                   type: string
                 servers:
                   type: integer
+                  x-kubernetes-validations:
+                  - message: cluster must have at least one server
+                    rule: self >= 1
                 agents:
                   type: integer
+                  x-kubernetes-validations:
+                  - message: invalid value for agents
+                    rule: self >= 0
                 token:
                   type: string
+                  x-kubernetes-validations:
+                  - message: token is immutable
+                    rule: self == oldSelf
                 clusterCIDR:
                   type: string
+                  x-kubernetes-validations:
+                  - message: clusterCIDR is immutable
+                    rule: self == oldSelf
                 serviceCIDR:
                   type: string
+                  x-kubernetes-validations:
+                  - message: serviceCIDR is immutable
+                    rule: self == oldSelf
                 clusterDNS:
                   type: string
+                  x-kubernetes-validations:
+                  - message: clusterDNS is immutable
+                    rule: self == oldSelf
                 serverArgs:
                   type: array
                   items:

--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -236,7 +236,6 @@ func newCluster(name, token string, servers, agents int32, clusterCIDR, serviceC
 			APIVersion: "k3k.io/v1alpha1",
 		},
 		Spec: v1alpha1.ClusterSpec{
-			Name:        name,
 			Token:       token,
 			Servers:     &servers,
 			Agents:      &agents,

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -16,7 +16,6 @@ type Cluster struct {
 }
 
 type ClusterSpec struct {
-	Name        string   `json:"name"`
 	Version     string   `json:"version"`
 	Servers     *int32   `json:"servers"`
 	Agents      *int32   `json:"agents"`

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -577,16 +577,16 @@ func (c *ClusterReconciler) getETCDTLS(cluster *v1alpha1.Cluster) (*tls.Config, 
 
 func (c *ClusterReconciler) validate(cluster *v1alpha1.Cluster) error {
 	if cluster.Name == ClusterInvalidName {
-		return errors.New("Invalid cluster name " + cluster.Name + " no action will be taken")
+		return errors.New("invalid cluster name " + cluster.Name + " no action will be taken")
 	}
 	if cluster.Spec.ClusterCIDR != cluster.Status.ClusterCIDR {
-		return errors.New("Immutable field: ClusterCIDR cant be changed once set")
+		return errors.New("immutable field: ClusterCIDR cant be changed once set")
 	}
 	if cluster.Spec.ServiceCIDR != cluster.Status.ServiceCIDR {
-		return errors.New("Immutable field: ServiceCIDR cant be changed once set")
+		return errors.New("immutable field: ServiceCIDR cant be changed once set")
 	}
 	if cluster.Spec.ClusterDNS != cluster.Status.ClusterDNS {
-		return errors.New("Immutable field: ClusterDNS cant be changed once set")
+		return errors.New("immutable field: ClusterDNS cant be changed once set")
 	}
 	return nil
 }


### PR DESCRIPTION
preventing the change of certain spec in the cluster type after the initial creation, that includes:
- ClusterCIDR
- ServiceCIDR
- Token
- ClusterDNS