### PR TITLE
Fixing bugs with namespaced clusters

### DIFF
--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -147,7 +147,7 @@ func (a *Agent) podSpec(image, name string, args []string, statefulSet bool, aff
 				Name: "config",
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
-						SecretName: name + "-config",
+						SecretName: util.AgentConfigName(a.cluster),
 						Items: []v1.KeyToPath{
 							{
 								Key:  "config.yaml",

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"github.com/rancher/k3k/pkg/controller/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -60,7 +61,7 @@ func Generate(ctx context.Context, cluster *v1alpha1.Cluster, ip string) (*v1.Se
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name + "-bootstrap",
-			Namespace: "k3k-" + cluster.Name,
+			Namespace: util.ClusterNamespace(cluster),
 		},
 		Data: map[string][]byte{
 			"bootstrap": bootstrapData,

--- a/pkg/controller/cluster/server/service.go
+++ b/pkg/controller/cluster/server/service.go
@@ -56,7 +56,7 @@ func (s *Server) StatefulServerService(cluster *v1alpha1.Cluster) *v1.Service {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name + "-" + name + "-headless",
+			Name:      cluster.Name + "-" + name + "headless",
 			Namespace: util.ClusterNamespace(cluster),
 		},
 		Spec: v1.ServiceSpec{


### PR DESCRIPTION
Fixes a few bugs with namespaced clusters, specifically:
- The agent config still used a hardcoded value for the config secret mount
- The kubeconfig generation still used the old "cluster namespace" as the destination In addition, changes the headless service name to not have two "-".