### PR TITLE
Add structured logging via zap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ replace (
 )
 
 require (
+	github.com/go-logr/zapr v1.3.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/rancher/dynamiclistener v1.27.5
 	github.com/sirupsen/logrus v1.9.3
@@ -30,8 +31,6 @@ require (
 	k8s.io/apimachinery v0.31.1
 	k8s.io/apiserver v0.31.0
 	k8s.io/client-go v0.31.0
-	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.130.1
 	k8s.io/metrics v0.29.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.17.5
@@ -123,6 +122,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.2 // indirect
 	k8s.io/component-base v0.29.2 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kms v0.29.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,7 +57,6 @@ github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBd
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -396,8 +395,6 @@ k8s.io/client-go v0.29.1 h1:19B/+2NGEwnFLzt0uB5kNJnfTsbV8w6TgQRz9l7ti7A=
 k8s.io/client-go v0.29.1/go.mod h1:TDG/psL9hdet0TI9mGyHJSgRkW3H9JZk2dNEUS7bRks=
 k8s.io/component-base v0.29.2 h1:lpiLyuvPA9yV1aQwGLENYyK7n/8t6l3nn3zAtFTJYe8=
 k8s.io/component-base v0.29.2/go.mod h1:BfB3SLrefbZXiBfbM+2H1dlat21Uewg/5qtKOl8degM=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kms v0.29.2 h1:MDsbp98gSlEQs7K7dqLKNNTwKFQRYYvO4UOlBOjNy6Y=

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -109,7 +109,7 @@ func (k *kubelet) start(ctx context.Context) {
 	if err := k.node.Err(); err != nil {
 		k.logger.Fatalw("node stopped with an error", zap.Error(err))
 	}
-	k.logger.Info("node exited without an error")
+	k.logger.Info("node exited successfully")
 }
 
 func (k *kubelet) newProviderFunc(namespace, name, hostname string) nodeutil.NewProviderFunc {

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 		return nil
 	}
 	if err := app.Run(os.Args); err != nil {
-		logger.Fatalw("Failed to run k3k controller", zap.Error(err))
+		logger.Fatalw("failed to run k3k controller", zap.Error(err))
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -6,16 +6,19 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/zapr"
 	"github.com/rancher/k3k/cli/cmds"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	"github.com/rancher/k3k/pkg/controller/cluster"
 	"github.com/rancher/k3k/pkg/controller/clusterset"
+	"github.com/rancher/k3k/pkg/log"
 	"github.com/urfave/cli"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -30,6 +33,8 @@ var (
 	clusterCIDR      string
 	sharedAgentImage string
 	kubeconfig       string
+	debug            bool
+	logger           *log.Logger
 	flags            = []cli.Flag{
 		cli.StringFlag{
 			Name:        "kubeconfig",
@@ -46,9 +51,15 @@ var (
 		cli.StringFlag{
 			Name:        "shared-agent-image",
 			EnvVar:      "SHARED_AGENT_IMAGE",
-			Usage:       "K3K Virtual Kubelet image ",
+			Usage:       "K3K Virtual Kubelet image",
 			Value:       "rancher/k3k:k3k-kubelet-dev",
 			Destination: &sharedAgentImage,
+		},
+		cli.BoolFlag{
+			Name:        "debug",
+			EnvVar:      "DEBUG",
+			Usage:       "Debug level logging",
+			Destination: &debug,
 		},
 	}
 )
@@ -63,9 +74,12 @@ func main() {
 	app.Flags = flags
 	app.Action = run
 	app.Version = version + " (" + gitCommit + ")"
-
+	app.Before = func(clx *cli.Context) error {
+		logger = log.New(debug)
+		return nil
+	}
 	if err := app.Run(os.Args); err != nil {
-		klog.Fatal(err)
+		logger.Fatalw("Failed to run k3k controller", zap.Error(err))
 	}
 
 }
@@ -75,7 +89,7 @@ func run(clx *cli.Context) error {
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		return fmt.Errorf("Failed to create config from kubeconfig file: %v", err)
+		return fmt.Errorf("failed to create config from kubeconfig file: %v", err)
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, manager.Options{
@@ -83,33 +97,34 @@ func run(clx *cli.Context) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("Failed to create new controller runtime manager: %v", err)
-	}
-	if err := cluster.Add(ctx, mgr, sharedAgentImage); err != nil {
-		return fmt.Errorf("Failed to add the new cluster controller: %v", err)
+		return fmt.Errorf("failed to create new controller runtime manager: %v", err)
 	}
 
-	if err := cluster.AddPodController(ctx, mgr); err != nil {
-		return fmt.Errorf("Failed to add the new cluster controller: %v", err)
+	ctrlruntimelog.SetLogger(zapr.NewLogger(logger.Desugar().WithOptions(zap.AddCallerSkip(1))))
+	logger.Info("adding cluster controller")
+	if err := cluster.Add(ctx, mgr, sharedAgentImage, logger); err != nil {
+		return fmt.Errorf("failed to add the new cluster controller: %v", err)
 	}
-	klog.Info("adding clusterset controller")
-	if err := clusterset.Add(ctx, mgr, clusterCIDR); err != nil {
-		return fmt.Errorf("Failed to add the clusterset controller: %v", err)
+
+	logger.Info("adding etcd pod controller")
+	if err := cluster.AddPodController(ctx, mgr, logger); err != nil {
+		return fmt.Errorf("failed to add the new cluster controller: %v", err)
+	}
+
+	logger.Info("adding clusterset controller")
+	if err := clusterset.Add(ctx, mgr, clusterCIDR, logger); err != nil {
+		return fmt.Errorf("failed to add the clusterset controller: %v", err)
 	}
 
 	if clusterCIDR == "" {
-		klog.Info("adding networkpolicy node controller")
-		if err := clusterset.AddNodeController(ctx, mgr); err != nil {
-			return fmt.Errorf("Failed to add the clusterset node controller: %v", err)
+		logger.Info("adding networkpolicy node controller")
+		if err := clusterset.AddNodeController(ctx, mgr, logger); err != nil {
+			return fmt.Errorf("failed to add the clusterset node controller: %v", err)
 		}
 	}
 
-	if err := cluster.AddPodController(ctx, mgr); err != nil {
-		return fmt.Errorf("Failed to add the new cluster controller: %v", err)
-	}
-
 	if err := mgr.Start(ctx); err != nil {
-		return fmt.Errorf("Failed to start the manager: %v", err)
+		return fmt.Errorf("failed to start the manager: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -88,7 +88,7 @@ func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 	for _, pod := range podList.Items {
-		log.Infof("Handle etcd server pod [%s/%s]", pod.Namespace, pod.Name)
+		log.Info("Handle etcd server pod")
 		if err := p.handleServerPod(ctx, cluster, &pod, log); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -151,9 +151,9 @@ func (p *PodReconciler) handleServerPod(ctx context.Context, cluster v1alpha1.Cl
 }
 
 func (p *PodReconciler) getETCDTLS(cluster *v1alpha1.Cluster, log *zap.SugaredLogger) (*tls.Config, error) {
-	log.Infow("generating etcd TLS client certificate", "Cluster", cluster.Namespace+"/"+cluster.Name)
+	log.Infow("generating etcd TLS client certificate", "Cluster", cluster.Name, "Namespace", cluster.Namespace)
 	token := cluster.Spec.Token
-	endpoint := fmt.Sprintf("%s.%s", server.ServiceName(cluster.Name), cluster.Namespace)
+	endpoint := server.ServiceName(cluster.Name) + "." + cluster.Namespace
 	var b *bootstrap.ControlRuntimeBootstrap
 	if err := retry.OnError(k3kcontroller.Backoff, func(err error) bool {
 		return true

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -15,16 +15,16 @@ import (
 	"github.com/rancher/k3k/pkg/controller/cluster/server"
 	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
 	"github.com/rancher/k3k/pkg/controller/kubeconfig"
-	"github.com/sirupsen/logrus"
+	"github.com/rancher/k3k/pkg/log"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -41,14 +41,16 @@ const (
 type PodReconciler struct {
 	Client ctrlruntimeclient.Client
 	Scheme *runtime.Scheme
+	logger *log.Logger
 }
 
 // Add adds a new controller to the manager
-func AddPodController(ctx context.Context, mgr manager.Manager) error {
+func AddPodController(ctx context.Context, mgr manager.Manager, logger *log.Logger) error {
 	// initialize a new Reconciler
 	reconciler := PodReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		logger: logger.Named(podController),
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -61,9 +63,11 @@ func AddPodController(ctx context.Context, mgr manager.Manager) error {
 }
 
 func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := p.logger.With("Pod", req.NamespacedName)
+
 	s := strings.Split(req.Name, "-")
 	if len(s) < 1 {
-		return reconcile.Result{}, k3kcontroller.LogAndReturnErr("failed to get cluster namespace", nil)
+		return reconcile.Result{}, nil
 	}
 	if s[0] != "k3k" {
 		return reconcile.Result{}, nil
@@ -84,15 +88,15 @@ func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 	for _, pod := range podList.Items {
-		klog.Infof("Handle etcd server pod [%s/%s]", pod.Namespace, pod.Name)
-		if err := p.handleServerPod(ctx, cluster, &pod); err != nil {
-			return reconcile.Result{}, k3kcontroller.LogAndReturnErr("failed to handle etcd pod", err)
+		log.Infof("Handle etcd server pod [%s/%s]", pod.Namespace, pod.Name)
+		if err := p.handleServerPod(ctx, cluster, &pod, log); err != nil {
+			return reconcile.Result{}, err
 		}
 	}
 	return reconcile.Result{}, nil
 }
 
-func (p *PodReconciler) handleServerPod(ctx context.Context, cluster v1alpha1.Cluster, pod *v1.Pod) error {
+func (p *PodReconciler) handleServerPod(ctx context.Context, cluster v1alpha1.Cluster, pod *v1.Pod, log *zap.SugaredLogger) error {
 	if _, ok := pod.Labels["role"]; ok {
 		if pod.Labels["role"] != "server" {
 			return nil
@@ -112,7 +116,7 @@ func (p *PodReconciler) handleServerPod(ctx context.Context, cluster v1alpha1.Cl
 			}
 			return nil
 		}
-		tlsConfig, err := p.getETCDTLS(&cluster)
+		tlsConfig, err := p.getETCDTLS(&cluster, log)
 		if err != nil {
 			return err
 		}
@@ -127,7 +131,7 @@ func (p *PodReconciler) handleServerPod(ctx context.Context, cluster v1alpha1.Cl
 			return err
 		}
 
-		if err := removePeer(ctx, client, pod.Name, pod.Status.PodIP); err != nil {
+		if err := removePeer(ctx, client, pod.Name, pod.Status.PodIP, log); err != nil {
 			return err
 		}
 		// remove our finalizer from the list and update it.
@@ -146,8 +150,8 @@ func (p *PodReconciler) handleServerPod(ctx context.Context, cluster v1alpha1.Cl
 	return nil
 }
 
-func (p *PodReconciler) getETCDTLS(cluster *v1alpha1.Cluster) (*tls.Config, error) {
-	klog.Infof("generating etcd TLS client certificate for cluster [%s]", cluster.Name)
+func (p *PodReconciler) getETCDTLS(cluster *v1alpha1.Cluster, log *zap.SugaredLogger) (*tls.Config, error) {
+	log.Infow("generating etcd TLS client certificate", "Cluster", cluster.Namespace+"/"+cluster.Name)
 	token := cluster.Spec.Token
 	endpoint := fmt.Sprintf("%s.%s", server.ServiceName(cluster.Name), cluster.Namespace)
 	var b *bootstrap.ControlRuntimeBootstrap
@@ -184,7 +188,7 @@ func (p *PodReconciler) getETCDTLS(cluster *v1alpha1.Cluster) (*tls.Config, erro
 }
 
 // removePeer removes a peer from the cluster. The peer name and IP address must both match.
-func removePeer(ctx context.Context, client *clientv3.Client, name, address string) error {
+func removePeer(ctx context.Context, client *clientv3.Client, name, address string, log *zap.SugaredLogger) error {
 	ctx, cancel := context.WithTimeout(ctx, memberRemovalTimeout)
 	defer cancel()
 	members, err := client.MemberList(ctx)
@@ -202,7 +206,7 @@ func removePeer(ctx context.Context, client *clientv3.Client, name, address stri
 				return err
 			}
 			if u.Hostname() == address {
-				logrus.Infof("Removing name=%s id=%d address=%s from etcd", member.Name, member.ID, address)
+				log.Infow("Removing member from etcd", "name", member.Name, "id", member.ID, "address", address)
 				_, err := client.MemberRemove(ctx, member.ID)
 				if errors.Is(err, rpctypes.ErrGRPCMemberNotFound) {
 					return nil

--- a/pkg/controller/clusterset/node.go
+++ b/pkg/controller/clusterset/node.go
@@ -4,7 +4,8 @@ import (
 	"context"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
-	k3kcontroller "github.com/rancher/k3k/pkg/controller"
+	"github.com/rancher/k3k/pkg/log"
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,14 +24,16 @@ type NodeReconciler struct {
 	Client      ctrlruntimeclient.Client
 	Scheme      *runtime.Scheme
 	ClusterCIDR string
+	logger      *log.Logger
 }
 
 // AddNodeController adds a new controller to the manager
-func AddNodeController(ctx context.Context, mgr manager.Manager) error {
+func AddNodeController(ctx context.Context, mgr manager.Manager, logger *log.Logger) error {
 	// initialize a new Reconciler
 	reconciler := NodeReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		logger: logger.Named(nodeController),
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -43,33 +46,36 @@ func AddNodeController(ctx context.Context, mgr manager.Manager) error {
 }
 
 func (n *NodeReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := n.logger.With("Node", req.NamespacedName)
 	var clusterSetList v1alpha1.ClusterSetList
 	if err := n.Client.List(ctx, &clusterSetList); err != nil {
-		return reconcile.Result{}, k3kcontroller.LogAndReturnErr("failed to list clusterSets", err)
+		return reconcile.Result{}, err
 	}
 
 	if len(clusterSetList.Items) <= 0 {
 		return reconcile.Result{}, nil
 	}
 
-	if err := n.ensureNetworkPolicies(ctx, clusterSetList); err != nil {
+	if err := n.ensureNetworkPolicies(ctx, clusterSetList, log); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetList v1alpha1.ClusterSetList) error {
+func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetList v1alpha1.ClusterSetList, log *zap.SugaredLogger) error {
 	var setNetworkPolicy *networkingv1.NetworkPolicy
 	for _, cs := range clusterSetList.Items {
 		if cs.Spec.DisableNetworkPolicy {
 			continue
 		}
 		var err error
+		log.Infow("Updating NetworkPolicy for ClusterSet", "name", cs.Name, "namespace", cs.Namespace)
 		setNetworkPolicy, err = netpol(ctx, "", &cs, n.Client)
 		if err != nil {
 			return err
 		}
+		log.Debugw("New NetworkPolicy for clusterset", "name", cs.Name, "namespace", cs.Namespace)
 		if err := n.Client.Update(ctx, setNetworkPolicy); err != nil {
 			return err
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,12 +30,6 @@ var Backoff = wait.Backoff{
 func K3SImage(cluster *v1alpha1.Cluster) string {
 	return k3SImageName + ":" + cluster.Spec.Version
 }
-
-func LogAndReturnErr(errString string, err error) error {
-	klog.Errorf("%s: %v", errString, err)
-	return err
-}
-
 func nodeAddress(node *v1.Node) string {
 	var externalIP string
 	var internalIP string

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -1,0 +1,51 @@
+package log
+
+import (
+	"os"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	ctrlruntimezap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type Logger struct {
+	*zap.SugaredLogger
+}
+
+func New(debug bool) *Logger {
+	return &Logger{newZappLogger(debug).Sugar()}
+}
+
+func (k *Logger) WithError(err error) log.Logger {
+	return k
+}
+
+func (k *Logger) WithField(string, interface{}) log.Logger {
+	return k
+}
+
+func (k *Logger) WithFields(field log.Fields) log.Logger {
+	return k
+}
+
+func (k *Logger) Named(name string) *Logger {
+	k.SugaredLogger = k.SugaredLogger.Named(name)
+	return k
+}
+
+func newZappLogger(debug bool) *zap.Logger {
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.TimeKey = "timestamp"
+	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
+	if debug {
+		lvl = zap.NewAtomicLevelAt(zap.DebugLevel)
+	}
+
+	encoder := zapcore.NewJSONEncoder(encCfg)
+	core := zapcore.NewCore(&ctrlruntimezap.KubeAwareEncoder{Encoder: encoder}, zapcore.AddSync(os.Stderr), lvl)
+
+	return zap.New(core)
+}

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -17,21 +17,21 @@ func New(debug bool) *Logger {
 	return &Logger{newZappLogger(debug).Sugar()}
 }
 
-func (k *Logger) WithError(err error) log.Logger {
-	return k
+func (l *Logger) WithError(err error) log.Logger {
+	return l
 }
 
-func (k *Logger) WithField(string, interface{}) log.Logger {
-	return k
+func (l *Logger) WithField(string, interface{}) log.Logger {
+	return l
 }
 
-func (k *Logger) WithFields(field log.Fields) log.Logger {
-	return k
+func (l *Logger) WithFields(field log.Fields) log.Logger {
+	return l
 }
 
-func (k *Logger) Named(name string) *Logger {
-	k.SugaredLogger = k.SugaredLogger.Named(name)
-	return k
+func (l *Logger) Named(name string) *Logger {
+	l.SugaredLogger = l.SugaredLogger.Named(name)
+	return l
 }
 
 func newZappLogger(debug bool) *zap.Logger {


### PR DESCRIPTION
The PR adds the following:
- Removes different log messages
- Removes the wrong wrapper function
- Adds structured logging (zap) with a wrapper to be used in `virtual-kubelet` as well
- Configure controller-runtime with the reconciler logger
- Configure the logger for each controller to have a different fields according to the controller logic

Issue:
- https://github.com/rancher/k3k/issues/127