### PR TITLE
Token random generation

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -129,12 +129,6 @@ spec:
                     - enabled
                     type: object
                 type: object
-              nodeSelector:
-                additionalProperties:
-                  type: string
-                description: NodeSelector is the node selector that will be applied
-                  to all server/agent pods
-                type: object
               mode:
                 description: Mode is the cluster provisioning mode which can be either
                   "virtual" or "shared". Defaults to "shared"
@@ -144,6 +138,12 @@ spec:
                   rule: self == oldSelf
                 - message: invalid value for mode
                   rule: self == "virtual" || self == "shared"
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector is the node selector that will be applied
+                  to all server/agent pods
+                type: object
               persistence:
                 description: |-
                   Persistence contains options controlling how the etcd data of the virtual cluster is persisted. By default, no data
@@ -187,13 +187,21 @@ spec:
                 items:
                   type: string
                 type: array
-              token:
-                description: Token is the token used to join the worker nodes to the
-                  cluster.
-                type: string
-                x-kubernetes-validations:
-                - message: token is immutable
-                  rule: self == oldSelf
+              tokenSecretRef:
+                description: |-
+                  TokenSecretRef is Secret reference used as a token join server and worker nodes to the cluster. The controller
+                  assumes that the secret has a field "token" in its data, any other fields in the secret will be ignored.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               version:
                 description: Version is a string representing the Kubernetes version
                   to be used by the virtual nodes.
@@ -202,7 +210,6 @@ spec:
             - agents
             - mode
             - servers
-            - token
             - version
             type: object
           status:

--- a/k3k-kubelet/config.go
+++ b/k3k-kubelet/config.go
@@ -47,6 +47,9 @@ func (c *config) unmarshalYAML(data []byte) error {
 	if c.NodeName == "" {
 		c.NodeName = conf.NodeName
 	}
+	if c.Token == "" {
+		c.Token = conf.Token
+	}
 	return nil
 }
 

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -27,13 +27,15 @@ type ClusterSpec struct {
 	// +kubebuilder:validation:XValidation:message="invalid value for agents",rule="self >= 0"
 	// Agents is the number of K3s pods to run in agent (worker) mode.
 	Agents *int32 `json:"agents"`
+	// +optional
 	// NodeSelector is the node selector that will be applied to all server/agent pods
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Limit is the limits that apply for the server/worker nodes.
 	Limit *ClusterLimit `json:"clusterLimit,omitempty"`
-	// +kubebuilder:validation:XValidation:message="token is immutable",rule="self == oldSelf"
-	// Token is the token used to join the worker nodes to the cluster.
-	Token string `json:"token"`
+	// +optional
+	// TokenSecretRef is Secret reference used as a token join server and worker nodes to the cluster. The controller
+	// assumes that the secret has a field "token" in its data, any other fields in the secret will be ignored.
+	TokenSecretRef *v1.SecretReference `json:"tokenSecretRef"`
 	// +kubebuilder:validation:XValidation:message="clusterCIDR is immutable",rule="self == oldSelf"
 	// ClusterCIDR is the CIDR range for the pods of the cluster. Defaults to 10.42.0.0/16.
 	ClusterCIDR string `json:"clusterCIDR,omitempty"`
@@ -53,7 +55,7 @@ type ClusterSpec struct {
 	// Addons is a list of secrets containing raw YAML which will be deployed in the virtual K3k cluster on startup.
 	Addons []Addon `json:"addons,omitempty"`
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
-	// +kubebuilder:validation:XValidation:message="invalid value for mode",rule="self == virtual || self == shared"
+	// +kubebuilder:validation:XValidation:message="invalid value for mode",rule="self == \"virtual\" || self == \"shared\""
 	// Mode is the cluster provisioning mode which can be either "virtual" or "shared". Defaults to "shared"
 	Mode string `json:"mode"`
 

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -16,11 +16,11 @@ type Agent interface {
 	Resources() []ctrlruntimeclient.Object
 }
 
-func New(cluster *v1alpha1.Cluster, serviceIP, sharedAgentImage string) Agent {
+func New(cluster *v1alpha1.Cluster, serviceIP, sharedAgentImage, token string) Agent {
 	if cluster.Spec.Mode == VirtualNodeMode {
-		return NewVirtualAgent(cluster, serviceIP)
+		return NewVirtualAgent(cluster, serviceIP, token)
 	}
-	return NewSharedAgent(cluster, serviceIP, sharedAgentImage)
+	return NewSharedAgent(cluster, serviceIP, sharedAgentImage, token)
 }
 
 func configSecretName(clusterName string) string {

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -22,18 +22,20 @@ type SharedAgent struct {
 	cluster          *v1alpha1.Cluster
 	serviceIP        string
 	sharedAgentImage string
+	token            string
 }
 
-func NewSharedAgent(cluster *v1alpha1.Cluster, serviceIP, sharedAgentImage string) Agent {
+func NewSharedAgent(cluster *v1alpha1.Cluster, serviceIP, sharedAgentImage, token string) Agent {
 	return &SharedAgent{
 		cluster:          cluster,
 		serviceIP:        serviceIP,
 		sharedAgentImage: sharedAgentImage,
+		token:            token,
 	}
 }
 
 func (s *SharedAgent) Config() (ctrlruntimeclient.Object, error) {
-	config := sharedAgentData(s.cluster)
+	config := sharedAgentData(s.cluster, s.token, s.Name())
 
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -50,14 +52,13 @@ func (s *SharedAgent) Config() (ctrlruntimeclient.Object, error) {
 	}, nil
 }
 
-func sharedAgentData(cluster *v1alpha1.Cluster) string {
-	nodeName := cluster.Name + "-" + "k3k-kubelet"
+func sharedAgentData(cluster *v1alpha1.Cluster, token, nodeName string) string {
 	return fmt.Sprintf(`clusterName: %s
 clusterNamespace: %s
 nodeName: %s
 agentHostname: %s
 token: %s`,
-		cluster.Name, cluster.Namespace, nodeName, nodeName, cluster.Spec.Token)
+		cluster.Name, cluster.Namespace, nodeName, nodeName, token)
 }
 
 func (s *SharedAgent) Resources() []ctrlruntimeclient.Object {

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -20,17 +20,19 @@ const (
 type VirtualAgent struct {
 	cluster   *v1alpha1.Cluster
 	serviceIP string
+	token     string
 }
 
-func NewVirtualAgent(cluster *v1alpha1.Cluster, serviceIP string) Agent {
+func NewVirtualAgent(cluster *v1alpha1.Cluster, serviceIP, token string) Agent {
 	return &VirtualAgent{
 		cluster:   cluster,
 		serviceIP: serviceIP,
+		token:     token,
 	}
 }
 
 func (v *VirtualAgent) Config() (ctrlruntimeclient.Object, error) {
-	config := virtualAgentData(v.serviceIP, v.cluster.Spec.Token)
+	config := virtualAgentData(v.serviceIP, v.token)
 
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -32,9 +32,7 @@ type content struct {
 // Generate generates the bootstrap for the cluster:
 // 1- use the server token to get the bootstrap data from k3s
 // 2- save the bootstrap data as a secret
-func Generate(ctx context.Context, cluster *v1alpha1.Cluster, ip string) (*v1.Secret, error) {
-	token := cluster.Spec.Token
-
+func Generate(ctx context.Context, cluster *v1alpha1.Cluster, ip, token string) (*v1.Secret, error) {
 	var bootstrap *ControlRuntimeBootstrap
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
 		return true

--- a/pkg/controller/cluster/server/config.go
+++ b/pkg/controller/cluster/server/config.go
@@ -18,9 +18,9 @@ func (s *Server) Config(init bool, serviceIP string) (*v1.Secret, error) {
 		fmt.Sprintf("%s.%s", ServiceName(s.cluster.Name), s.cluster.Namespace),
 	)
 
-	config := serverConfigData(serviceIP, s.cluster)
+	config := serverConfigData(serviceIP, s.cluster, s.token)
 	if init {
-		config = initConfigData(s.cluster)
+		config = initConfigData(s.cluster, s.token)
 	}
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -37,20 +37,20 @@ func (s *Server) Config(init bool, serviceIP string) (*v1.Secret, error) {
 	}, nil
 }
 
-func serverConfigData(serviceIP string, cluster *v1alpha1.Cluster) string {
-	return "cluster-init: true\nserver: https://" + serviceIP + ":6443\n" + serverOptions(cluster)
+func serverConfigData(serviceIP string, cluster *v1alpha1.Cluster, token string) string {
+	return "cluster-init: true\nserver: https://" + serviceIP + ":6443\n" + serverOptions(cluster, token)
 }
 
-func initConfigData(cluster *v1alpha1.Cluster) string {
-	return "cluster-init: true\n" + serverOptions(cluster)
+func initConfigData(cluster *v1alpha1.Cluster, token string) string {
+	return "cluster-init: true\n" + serverOptions(cluster, token)
 }
 
-func serverOptions(cluster *v1alpha1.Cluster) string {
+func serverOptions(cluster *v1alpha1.Cluster, token string) string {
 	var opts string
 
 	// TODO: generate token if not found
-	if cluster.Spec.Token != "" {
-		opts = "token: " + cluster.Spec.Token + "\n"
+	if token != "" {
+		opts = "token: " + token + "\n"
 	}
 	if cluster.Status.ClusterCIDR != "" {
 		opts = opts + "cluster-cidr: " + cluster.Status.ClusterCIDR + "\n"

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -31,12 +31,14 @@ const (
 type Server struct {
 	cluster *v1alpha1.Cluster
 	client  client.Client
+	token   string
 }
 
-func New(cluster *v1alpha1.Cluster, client client.Client) *Server {
+func New(cluster *v1alpha1.Cluster, client client.Client, token string) *Server {
 	return &Server{
 		cluster: cluster,
 		client:  client,
+		token:   token,
 	}
 }
 

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -1,0 +1,98 @@
+package cluster
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"github.com/rancher/k3k/pkg/controller"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (c *ClusterReconciler) token(ctx context.Context, cluster *v1alpha1.Cluster) (string, error) {
+	if cluster.Spec.TokenSecretRef == nil {
+		return c.ensureTokenSecret(ctx, cluster)
+	}
+	// get token data from secretRef
+	nn := types.NamespacedName{
+		Name:      cluster.Spec.TokenSecretRef.Name,
+		Namespace: cluster.Spec.TokenSecretRef.Namespace,
+	}
+	var tokenSecret v1.Secret
+	if err := c.Client.Get(ctx, nn, &tokenSecret); err != nil {
+		return "", err
+	}
+	if _, ok := tokenSecret.Data["token"]; !ok {
+		return "", fmt.Errorf("no token field in secret %s/%s", nn.Namespace, nn.Name)
+	}
+	return string(tokenSecret.Data["token"]), nil
+}
+
+func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1alpha1.Cluster) (string, error) {
+	// check if the secret is already created
+	var (
+		tokenSecret v1.Secret
+		nn          = types.NamespacedName{
+			Name:      TokenSecretName(cluster.Name),
+			Namespace: cluster.Namespace,
+		}
+	)
+	if err := c.Client.Get(ctx, nn, &tokenSecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", err
+		}
+	}
+
+	if tokenSecret.Data != nil {
+		return string(tokenSecret.Data["token"]), nil
+	}
+	c.logger.Info("Token secret is not specified, creating a random token")
+	token, err := random(16)
+	if err != nil {
+		return "", err
+	}
+	tokenSecret = TokenSecretObj(token, cluster.Name, cluster.Namespace)
+	if err := controllerutil.SetControllerReference(cluster, &tokenSecret, c.Scheme); err != nil {
+		return "", err
+	}
+	if err := c.ensure(ctx, &tokenSecret, false); err != nil {
+		return "", err
+	}
+	return token, nil
+
+}
+
+func random(size int) (string, error) {
+	token := make([]byte, size)
+	_, err := rand.Read(token)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(token), err
+}
+
+func TokenSecretObj(token, name, namespace string) v1.Secret {
+	return v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TokenSecretName(name),
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"token": []byte(token),
+		},
+	}
+}
+
+func TokenSecretName(clusterName string) string {
+	return controller.SafeConcatNameWithPrefix(clusterName, "token")
+}


### PR DESCRIPTION
- Remove the token spec, and instead add the `TokenSecretRef` spec to point to the secret that has the token
- If the `spec.TokenSecretRef` is not specified then a new secret with the name `k3k-<cluster-name>-token` will be created for the cluster in the same namespace.
  - The secret will contain a 16 Byte randomly generated token 
- If the `spec.TokenSecretRef` is specified in the spec, the controller will lookup this secret and fetch the map item "token" from data.

- #113 