### PR TITLE
Added nodeSelector to workloads

### DIFF
--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -28,7 +28,8 @@ type ClusterSpec struct {
 	// Agents is the number of K3s pods to run in agent (worker) mode.
 	Agents *int32 `json:"agents"`
 	// +optional
-	// NodeSelector is the node selector that will be applied to all server/agent pods
+	// NodeSelector is the node selector that will be applied to all server/agent pods.
+	// In "shared" mode the node selector will be applied also to the workloads.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Limit is the limits that apply for the server/worker nodes.
 	Limit *ClusterLimit `json:"clusterLimit,omitempty"`


### PR DESCRIPTION
This PR adds the `nodeSelector` defined in the Cluster spec to the scheduled workloads in shared mode.

Ref:
- #118 