### PR TITLE
Added `allowedNodeTypes` to ClusterSet, and fixed NetworkPolicy reconciliation

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -130,12 +130,16 @@ spec:
                     type: object
                 type: object
               mode:
+                allOf:
+                - enum:
+                  - shared
+                  - virtual
+                - enum:
+                  - shared
+                  - virtual
                 default: shared
                 description: Mode is the cluster provisioning mode which can be either
                   "shared" or "virtual". Defaults to "shared"
-                enum:
-                - shared
-                - virtual
                 type: string
                 x-kubernetes-validations:
                 - message: mode is immutable

--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -141,8 +141,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector is the node selector that will be applied
-                  to all server/agent pods
+                description: |-
+                  NodeSelector is the node selector that will be applied to all server/agent pods.
+                  In "shared" mode the node selector will be applied also to the workloads.
                 type: object
               persistence:
                 description: |-

--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -130,14 +130,16 @@ spec:
                     type: object
                 type: object
               mode:
+                default: shared
                 description: Mode is the cluster provisioning mode which can be either
-                  "virtual" or "shared". Defaults to "shared"
+                  "shared" or "virtual". Defaults to "shared"
+                enum:
+                - shared
+                - virtual
                 type: string
                 x-kubernetes-validations:
                 - message: mode is immutable
                   rule: self == oldSelf
-                - message: invalid value for mode
-                  rule: self == "virtual" || self == "shared"
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/charts/k3k/crds/k3k.io_clustersets.yaml
+++ b/charts/k3k/crds/k3k.io_clustersets.yaml
@@ -83,6 +83,18 @@ spec:
                 description: MaxLimits are the limits that apply to all clusters (server
                   + agent) in the set
                 type: object
+              mode:
+                description: |-
+                  Mode is the cluster provisioning mode that applies to all the clusters.
+                  It can be either "virtual" or "shared". Defaults to "shared".
+                type: string
+                x-kubernetes-validations:
+                - message: mode is immutable
+                  rule: self == oldSelf
+                - message: invalid value for mode
+                  rule: self == "virtual" || self == "shared"
+            required:
+            - mode
             type: object
           status:
             description: Status is the status of the ClusterSet

--- a/charts/k3k/crds/k3k.io_clustersets.yaml
+++ b/charts/k3k/crds/k3k.io_clustersets.yaml
@@ -84,17 +84,17 @@ spec:
                   + agent) in the set
                 type: object
               mode:
+                default: shared
                 description: |-
                   Mode is the cluster provisioning mode that applies to all the clusters.
-                  It can be either "virtual" or "shared". Defaults to "shared".
+                  It can be either "shared" or "virtual". Defaults to "shared".
+                enum:
+                - shared
+                - virtual
                 type: string
                 x-kubernetes-validations:
                 - message: mode is immutable
                   rule: self == oldSelf
-                - message: invalid value for mode
-                  rule: self == "virtual" || self == "shared"
-            required:
-            - mode
             type: object
           status:
             description: Status is the status of the ClusterSet

--- a/charts/k3k/crds/k3k.io_clustersets.yaml
+++ b/charts/k3k/crds/k3k.io_clustersets.yaml
@@ -36,8 +36,26 @@ spec:
           metadata:
             type: object
           spec:
+            default: {}
             description: Spec is the spec of the ClusterSet
             properties:
+              allowedNodeTypes:
+                default:
+                - shared
+                description: AllowedNodeTypes are the allowed cluster provisioning
+                  modes. Defaults to [shared].
+                items:
+                  description: ClusterMode is the possible provisioning mode of a
+                    Cluster.
+                  enum:
+                  - shared
+                  - virtual
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: mode is immutable
+                  rule: self == oldSelf
               defaultLimits:
                 description: DefaultLimits are the limits used for servers/agents
                   when a cluster in the set doesn't provide any
@@ -83,18 +101,6 @@ spec:
                 description: MaxLimits are the limits that apply to all clusters (server
                   + agent) in the set
                 type: object
-              mode:
-                default: shared
-                description: |-
-                  Mode is the cluster provisioning mode that applies to all the clusters.
-                  It can be either "shared" or "virtual". Defaults to "shared".
-                enum:
-                - shared
-                - virtual
-                type: string
-                x-kubernetes-validations:
-                - message: mode is immutable
-                  rule: self == oldSelf
             type: object
           status:
             description: Status is the status of the ClusterSet
@@ -180,7 +186,7 @@ spec:
                 format: int64
                 type: integer
               summary:
-                description: Sumamry is a summary of the status (error, ready)
+                description: Summary is a summary of the status
                 type: string
             type: object
         required:

--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -226,6 +226,9 @@ func validateCreateFlags() error {
 	if cmds.Kubeconfig == "" && os.Getenv("KUBECONFIG") == "" {
 		return errors.New("empty kubeconfig")
 	}
+	if mode != "shared" && mode != "virtual" {
+		return errors.New(`mode should be one of "shared" or "virtual"`)
+	}
 
 	return nil
 }
@@ -248,7 +251,7 @@ func newCluster(name, namespace, mode, token string, servers, agents int32, clus
 			ServerArgs:  serverArgs,
 			AgentArgs:   agentArgs,
 			Version:     version,
-			Mode:        mode,
+			Mode:        v1alpha1.ClusterMode(mode),
 			Persistence: &v1alpha1.PersistenceConfig{
 				Type:             persistenceType,
 				StorageClassName: storageClassName,

--- a/examples/clusterset.yaml
+++ b/examples/clusterset.yaml
@@ -2,5 +2,8 @@ apiVersion: k3k.io/v1alpha1
 kind: ClusterSet
 metadata:
   name: clusterset-example
-spec:
-  mode: "shared"
+# spec:
+  # disableNetworkPolicy: false
+  # allowedNodeTypes:
+  # - "shared"
+  # - "virtual"

--- a/examples/clusterset.yaml
+++ b/examples/clusterset.yaml
@@ -1,0 +1,6 @@
+apiVersion: k3k.io/v1alpha1
+kind: ClusterSet
+metadata:
+  name: clusterset-example
+spec:
+  mode: "shared"

--- a/examples/multiple-servers.yaml
+++ b/examples/multiple-servers.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   name: example1
 spec:
+  mode: "shared"
   servers: 1
   agents: 3
   token: test

--- a/examples/single-server.yaml
+++ b/examples/single-server.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   name: single-server
 spec:
+  mode: "shared"
   servers: 1
   agents: 3
   token: test

--- a/pkg/apis/k3k.io/v1alpha1/set_types.go
+++ b/pkg/apis/k3k.io/v1alpha1/set_types.go
@@ -14,8 +14,11 @@ type ClusterSet struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	metav1.TypeMeta   `json:",inline"`
 
+	// +kubebuilder:default={}
+	//
 	// Spec is the spec of the ClusterSet
 	Spec ClusterSetSpec `json:"spec"`
+
 	// Status is the status of the ClusterSet
 	Status ClusterSetStatus `json:"status,omitempty"`
 }
@@ -33,21 +36,25 @@ type ClusterSetSpec struct {
 	// DisableNetworkPolicy is an option that will disable the creation of a default networkpolicy for cluster isolation
 	DisableNetworkPolicy bool `json:"disableNetworkPolicy,omitempty"`
 
-	// Mode is the cluster provisioning mode that applies to all the clusters.
-	// It can be either "shared" or "virtual". Defaults to "shared".
-	// +kubebuilder:default="shared"
-	// +kubebuilder:validation:Enum=shared;virtual
+	// +kubebuilder:default={shared}
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
-	Mode ClusterMode `json:"mode,omitempty"`
+	// +kubebuilder:validation:MinItems=1
+	//
+	// AllowedNodeTypes are the allowed cluster provisioning modes. Defaults to [shared].
+	AllowedNodeTypes []ClusterMode `json:"allowedNodeTypes,omitempty"`
 }
 
 type ClusterSetStatus struct {
+
 	// ObservedGeneration was the generation at the time the status was updated.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// LastUpdate is the timestamp when the status was last updated
 	LastUpdate string `json:"lastUpdateTime,omitempty"`
-	// Sumamry is a summary of the status (error, ready)
+
+	// Summary is a summary of the status
 	Summary string `json:"summary,omitempty"`
+
 	// Conditions are the invidual conditions for the cluster set
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }

--- a/pkg/apis/k3k.io/v1alpha1/set_types.go
+++ b/pkg/apis/k3k.io/v1alpha1/set_types.go
@@ -23,12 +23,21 @@ type ClusterSet struct {
 type ClusterSetSpec struct {
 	// MaxLimits are the limits that apply to all clusters (server + agent) in the set
 	MaxLimits v1.ResourceList `json:"maxLimits,omitempty"`
+
 	// DefaultLimits are the limits used for servers/agents when a cluster in the set doesn't provide any
 	DefaultLimits *ClusterLimit `json:"defaultLimits,omitempty"`
+
 	// DefaultNodeSelector is the node selector that applies to all clusters (server + agent) in the set
 	DefaultNodeSelector map[string]string `json:"defaultNodeSelector,omitempty"`
+
 	// DisableNetworkPolicy is an option that will disable the creation of a default networkpolicy for cluster isolation
 	DisableNetworkPolicy bool `json:"disableNetworkPolicy,omitempty"`
+
+	// Mode is the cluster provisioning mode that applies to all the clusters.
+	// It can be either "virtual" or "shared". Defaults to "shared".
+	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
+	// +kubebuilder:validation:XValidation:message="invalid value for mode",rule="self == \"virtual\" || self == \"shared\""
+	Mode string `json:"mode"`
 }
 
 type ClusterSetStatus struct {

--- a/pkg/apis/k3k.io/v1alpha1/set_types.go
+++ b/pkg/apis/k3k.io/v1alpha1/set_types.go
@@ -34,10 +34,11 @@ type ClusterSetSpec struct {
 	DisableNetworkPolicy bool `json:"disableNetworkPolicy,omitempty"`
 
 	// Mode is the cluster provisioning mode that applies to all the clusters.
-	// It can be either "virtual" or "shared". Defaults to "shared".
+	// It can be either "shared" or "virtual". Defaults to "shared".
+	// +kubebuilder:default="shared"
+	// +kubebuilder:validation:Enum=shared;virtual
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
-	// +kubebuilder:validation:XValidation:message="invalid value for mode",rule="self == \"virtual\" || self == \"shared\""
-	Mode string `json:"mode"`
+	Mode ClusterMode `json:"mode,omitempty"`
 }
 
 type ClusterSetStatus struct {

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -88,8 +88,8 @@ type ClusterSpec struct {
 type ClusterMode string
 
 const (
-	Shared  = ClusterMode("shared")  // e.g., 12e6
-	Virtual = ClusterMode("virtual") // e.g., 12Mi (12 * 2^20)
+	Shared  = ClusterMode("shared")
+	Virtual = ClusterMode("virtual")
 )
 
 type ClusterLimit struct {

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -84,7 +84,10 @@ type ClusterSpec struct {
 	Expose *ExposeConfig `json:"expose,omitempty"`
 }
 
-// ClusterMode lists the two possible provisioning mode of a Cluster.
+// +kubebuilder:validation:Enum=shared;virtual
+// +kubebuilder:default="shared"
+//
+// ClusterMode is the possible provisioning mode of a Cluster.
 type ClusterMode string
 
 const (

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -88,8 +88,8 @@ type ClusterSpec struct {
 type ClusterMode string
 
 const (
-	Shared  = ClusterMode("shared")
-	Virtual = ClusterMode("virtual")
+	SharedClusterMode  = ClusterMode("shared")
+	VirtualClusterMode = ClusterMode("virtual")
 )
 
 type ClusterLimit struct {

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -21,53 +21,76 @@ type Cluster struct {
 type ClusterSpec struct {
 	// Version is a string representing the Kubernetes version to be used by the virtual nodes.
 	Version string `json:"version"`
-	// +kubebuilder:validation:XValidation:message="cluster must have at least one server",rule="self >= 1"
+
 	// Servers is the number of K3s pods to run in server (controlplane) mode.
+	// +kubebuilder:validation:XValidation:message="cluster must have at least one server",rule="self >= 1"
 	Servers *int32 `json:"servers"`
-	// +kubebuilder:validation:XValidation:message="invalid value for agents",rule="self >= 0"
+
 	// Agents is the number of K3s pods to run in agent (worker) mode.
+	// +kubebuilder:validation:XValidation:message="invalid value for agents",rule="self >= 0"
 	Agents *int32 `json:"agents"`
-	// +optional
+
 	// NodeSelector is the node selector that will be applied to all server/agent pods.
 	// In "shared" mode the node selector will be applied also to the workloads.
+	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// Limit is the limits that apply for the server/worker nodes.
 	Limit *ClusterLimit `json:"clusterLimit,omitempty"`
-	// +optional
+
 	// TokenSecretRef is Secret reference used as a token join server and worker nodes to the cluster. The controller
 	// assumes that the secret has a field "token" in its data, any other fields in the secret will be ignored.
+	// +optional
 	TokenSecretRef *v1.SecretReference `json:"tokenSecretRef"`
-	// +kubebuilder:validation:XValidation:message="clusterCIDR is immutable",rule="self == oldSelf"
+
 	// ClusterCIDR is the CIDR range for the pods of the cluster. Defaults to 10.42.0.0/16.
+	// +kubebuilder:validation:XValidation:message="clusterCIDR is immutable",rule="self == oldSelf"
 	ClusterCIDR string `json:"clusterCIDR,omitempty"`
-	// +kubebuilder:validation:XValidation:message="serviceCIDR is immutable",rule="self == oldSelf"
+
 	// ServiceCIDR is the CIDR range for the services in the cluster. Defaults to 10.43.0.0/16.
+	// +kubebuilder:validation:XValidation:message="serviceCIDR is immutable",rule="self == oldSelf"
 	ServiceCIDR string `json:"serviceCIDR,omitempty"`
-	// +kubebuilder:validation:XValidation:message="clusterDNS is immutable",rule="self == oldSelf"
+
 	// ClusterDNS is the IP address for the coredns service. Needs to be in the range provided by ServiceCIDR or CoreDNS may not deploy.
 	// Defaults to 10.43.0.10.
+	// +kubebuilder:validation:XValidation:message="clusterDNS is immutable",rule="self == oldSelf"
 	ClusterDNS string `json:"clusterDNS,omitempty"`
+
 	// ServerArgs are the ordered key value pairs (e.x. "testArg", "testValue") for the K3s pods running in server mode.
 	ServerArgs []string `json:"serverArgs,omitempty"`
+
 	// AgentArgs are the ordered key value pairs (e.x. "testArg", "testValue") for the K3s pods running in agent mode.
 	AgentArgs []string `json:"agentArgs,omitempty"`
+
 	// TLSSANs are the subjectAlternativeNames for the certificate the K3s server will use.
 	TLSSANs []string `json:"tlsSANs,omitempty"`
+
 	// Addons is a list of secrets containing raw YAML which will be deployed in the virtual K3k cluster on startup.
 	Addons []Addon `json:"addons,omitempty"`
+
+	// Mode is the cluster provisioning mode which can be either "shared" or "virtual". Defaults to "shared"
+	// +kubebuilder:default="shared"
+	// +kubebuilder:validation:Enum=shared;virtual
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
-	// +kubebuilder:validation:XValidation:message="invalid value for mode",rule="self == \"virtual\" || self == \"shared\""
-	// Mode is the cluster provisioning mode which can be either "virtual" or "shared". Defaults to "shared"
-	Mode string `json:"mode"`
+	Mode ClusterMode `json:"mode"`
 
 	// Persistence contains options controlling how the etcd data of the virtual cluster is persisted. By default, no data
 	// persistence is guaranteed, so restart of a virtual cluster pod may result in data loss without this field.
 	Persistence *PersistenceConfig `json:"persistence,omitempty"`
-	// +optional
+
 	// Expose contains options for exposing the apiserver inside/outside of the cluster. By default, this is only exposed as a
 	// clusterIP which is relatively secure, but difficult to access outside of the cluster.
+	// +optional
 	Expose *ExposeConfig `json:"expose,omitempty"`
 }
+
+// ClusterMode lists the two possible provisioning mode of a Cluster.
+type ClusterMode string
+
+const (
+	Shared  = ClusterMode("shared")  // e.g., 12e6
+	Virtual = ClusterMode("virtual") // e.g., 12Mi (12 * 2^20)
+)
 
 type ClusterLimit struct {
 	// ServerLimit is the limits (cpu/mem) that apply to the server nodes

--- a/pkg/controller/clusterset/clusterset.go
+++ b/pkg/controller/clusterset/clusterset.go
@@ -2,6 +2,7 @@ package clusterset
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	k3kcontroller "github.com/rancher/k3k/pkg/controller"
@@ -11,7 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -50,12 +51,32 @@ func Add(ctx context.Context, mgr manager.Manager, clusterCIDR string, logger *l
 }
 
 func (c *ClusterSetReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	var (
-		clusterSet v1alpha1.ClusterSet
-		log        = c.logger.With("ClusterSet", req.NamespacedName)
-	)
-	if err := c.Client.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, &clusterSet); err != nil {
+	log := c.logger.With("ClusterSet", req.NamespacedName)
+
+	var clusterSet v1alpha1.ClusterSet
+	if err := c.Client.Get(ctx, req.NamespacedName, &clusterSet); err != nil {
 		return reconcile.Result{}, err
+	}
+
+	// Check if a ClusterSet in the same namespace already exists.
+	// We retry in case of timeout because it could happen the Informer needs to sync
+	clusterSetList := &v1alpha1.ClusterSetList{}
+	listOpts := &ctrlruntimeclient.ListOptions{Namespace: req.Namespace}
+	err := retry.OnError(retry.DefaultBackoff, apierrors.IsTimeout, func() error {
+		return c.Client.List(ctx, clusterSetList, listOpts)
+	})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	for _, cs := range clusterSetList.Items {
+		if cs.Name != req.Name {
+			//TODO: should we update the Status condition of the ClusterSet, instead of deleting it?
+			if err := c.Client.Delete(context.Background(), &clusterSet); err != nil {
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{}, fmt.Errorf("a ClusterSet in this namespace already exists: %s", cs.Name)
+		}
 	}
 
 	if !clusterSet.Spec.DisableNetworkPolicy {

--- a/pkg/controller/clusterset/clusterset_test.go
+++ b/pkg/controller/clusterset/clusterset_test.go
@@ -49,11 +49,11 @@ var _ = Describe("ClusterSet Controller", func() {
 				clusterSetNetworkPolicy := &networkingv1.NetworkPolicy{}
 
 				Eventually(func() bool {
-					deployKey := types.NamespacedName{
+					key := types.NamespacedName{
 						Name:      k3kcontroller.SafeConcatNameWithPrefix(clusterSet.Name),
 						Namespace: namespace,
 					}
-					err := k8sClient.Get(ctx, deployKey, clusterSetNetworkPolicy)
+					err := k8sClient.Get(ctx, key, clusterSetNetworkPolicy)
 					return err == nil
 				}, time.Minute, time.Second).Should(BeTrue())
 
@@ -113,11 +113,11 @@ var _ = Describe("ClusterSet Controller", func() {
 
 				// wait for a bit for the network policy, but it should not be created
 				Eventually(func() bool {
-					deployKey := types.NamespacedName{
+					key := types.NamespacedName{
 						Name:      k3kcontroller.SafeConcatNameWithPrefix(clusterSet.Name),
 						Namespace: namespace,
 					}
-					err := k8sClient.Get(ctx, deployKey, &networkingv1.NetworkPolicy{})
+					err := k8sClient.Get(ctx, key, &networkingv1.NetworkPolicy{})
 					return apierrors.IsNotFound(err)
 				}).
 					MustPassRepeatedly(5).

--- a/pkg/controller/clusterset/clusterset_test.go
+++ b/pkg/controller/clusterset/clusterset_test.go
@@ -104,6 +104,7 @@ var _ = Describe("ClusterSet Controller", func() {
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DisableNetworkPolicy: true,
+						Mode:                 v1alpha1.Virtual,
 					},
 				}
 
@@ -123,6 +124,52 @@ var _ = Describe("ClusterSet Controller", func() {
 					WithTimeout(time.Second * 10).
 					WithPolling(time.Second).
 					Should(BeTrue())
+			})
+		})
+
+		When("created specifing the mode", func() {
+			It("should create a shared mode by default", func() {
+				clusterSet := &v1alpha1.ClusterSet{
+					ObjectMeta: v1.ObjectMeta{
+						GenerateName: "clusterset-",
+						Namespace:    namespace,
+					},
+				}
+
+				err := k8sClient.Create(ctx, clusterSet)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(clusterSet.Spec.Mode).To(Equal(v1alpha1.Shared))
+			})
+
+			It("should create a virtual mode if specified", func() {
+				clusterSet := &v1alpha1.ClusterSet{
+					ObjectMeta: v1.ObjectMeta{
+						GenerateName: "clusterset-",
+						Namespace:    namespace,
+					},
+					Spec: v1alpha1.ClusterSetSpec{
+						Mode: v1alpha1.Virtual,
+					},
+				}
+
+				err := k8sClient.Create(ctx, clusterSet)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(clusterSet.Spec.Mode).To(Equal(v1alpha1.Virtual))
+			})
+
+			It("should fail for a non-existing mode", func() {
+				clusterSet := &v1alpha1.ClusterSet{
+					ObjectMeta: v1.ObjectMeta{
+						GenerateName: "clusterset-",
+						Namespace:    namespace,
+					},
+					Spec: v1alpha1.ClusterSetSpec{
+						Mode: "foobar",
+					},
+				}
+
+				err := k8sClient.Create(ctx, clusterSet)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/controller/clusterset/clusterset_test.go
+++ b/pkg/controller/clusterset/clusterset_test.go
@@ -104,7 +104,7 @@ var _ = Describe("ClusterSet Controller", func() {
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DisableNetworkPolicy: true,
-						Mode:                 v1alpha1.Virtual,
+						Mode:                 v1alpha1.VirtualClusterMode,
 					},
 				}
 
@@ -138,7 +138,7 @@ var _ = Describe("ClusterSet Controller", func() {
 
 				err := k8sClient.Create(ctx, clusterSet)
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(clusterSet.Spec.Mode).To(Equal(v1alpha1.Shared))
+				Expect(clusterSet.Spec.Mode).To(Equal(v1alpha1.SharedClusterMode))
 			})
 
 			It("should create a virtual mode if specified", func() {
@@ -148,13 +148,13 @@ var _ = Describe("ClusterSet Controller", func() {
 						Namespace:    namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
-						Mode: v1alpha1.Virtual,
+						Mode: v1alpha1.VirtualClusterMode,
 					},
 				}
 
 				err := k8sClient.Create(ctx, clusterSet)
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(clusterSet.Spec.Mode).To(Equal(v1alpha1.Virtual))
+				Expect(clusterSet.Spec.Mode).To(Equal(v1alpha1.VirtualClusterMode))
 			})
 
 			It("should fail for a non-existing mode", func() {

--- a/pkg/controller/clusterset/clusterset_test.go
+++ b/pkg/controller/clusterset/clusterset_test.go
@@ -173,7 +173,7 @@ var _ = Describe("ClusterSet Controller", func() {
 			})
 		})
 
-		FWhen("a ClusterSet in the same namespace was already there", func() {
+		When("a ClusterSet in the same namespace was already there", func() {
 			It("should delete the last one", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
Ref:
- #121

This PR adds the `allowedNodeTypes` to the ClusterSet CRD, as per RFC. It uses a enum to enforce the value to be `shared` or `virtual`, also using kubebuilder annotations for the validation, and default value:

```go
// +kubebuilder:default={shared}
// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
// +kubebuilder:validation:MinItems=1
//
// AllowedNodeTypes are the allowed cluster provisioning modes. Defaults to [shared].
AllowedNodeTypes []ClusterMode `json:"allowedNodeTypes,omitempty"`
```

```go
// +kubebuilder:validation:Enum=shared;virtual
// +kubebuilder:default="shared"
//
// ClusterMode is the possible provisioning mode of a Cluster.
type ClusterMode string

const (
	SharedClusterMode  = ClusterMode("shared")
	VirtualClusterMode = ClusterMode("virtual")
)
```

Updated the Cluster spec, added some tests, and an example.

This PR also adds a couple of fixes to the associated NetworkPolicy. It fixes the reconciliation loop, deleting the NetPol if the `disableNetworkPolicy` is changed, and it adds the ClusterSet owner reference, to allow the garbage collection when the ClusterSet is deleted.

