### PR TITLE
Initial networking support for shared mode

### DIFF
--- a/k3k-kubelet/config.go
+++ b/k3k-kubelet/config.go
@@ -17,7 +17,7 @@ type config struct {
 	HostConfigPath    string `yaml:"hostConfigPath,omitempty"`
 	VirtualConfigPath string `yaml:"virtualConfigPath,omitempty"`
 	KubeletPort       string `yaml:"kubeletPort,omitempty"`
-	AgentIP           string `yaml:"agentIP,omitempty"`
+	ServerIP          string `yaml:"serverIP,omitempty"`
 }
 
 func (c *config) unmarshalYAML(data []byte) error {
@@ -51,8 +51,8 @@ func (c *config) unmarshalYAML(data []byte) error {
 	if c.Token == "" {
 		c.Token = conf.Token
 	}
-	if c.AgentIP == "" {
-		c.AgentIP = conf.AgentIP
+	if c.ServerIP == "" {
+		c.ServerIP = conf.ServerIP
 	}
 	return nil
 }

--- a/k3k-kubelet/controller/service.go
+++ b/k3k-kubelet/controller/service.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+	"github.com/rancher/k3k/pkg/log"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	serviceSyncerController = "service-syncer-controller"
+	maxConcurrentReconciles = 1
+)
+
+// TODO: change into a generic syncer
+type ServiceReconciler struct {
+	virtualClient    ctrlruntimeclient.Client
+	hostClient       ctrlruntimeclient.Client
+	clusterName      string
+	clusterNamespace string
+	Scheme           *runtime.Scheme
+	logger           *log.Logger
+	Translater       translate.ToHostTranslater
+}
+
+// AddServiceSyncer adds service syncer controller to the manager of the virtual cluster
+func AddServiceSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clusterName, clusterNamespace string, logger *log.Logger) error {
+	translater := translate.ToHostTranslater{
+		ClusterName:      clusterName,
+		ClusterNamespace: clusterNamespace,
+	}
+	// initialize a new Reconciler
+	reconciler := ServiceReconciler{
+		virtualClient:    virtMgr.GetClient(),
+		hostClient:       hostMgr.GetClient(),
+		Scheme:           virtMgr.GetScheme(),
+		logger:           logger.Named(serviceSyncerController),
+		Translater:       translater,
+		clusterName:      clusterName,
+		clusterNamespace: clusterNamespace,
+	}
+	return ctrl.NewControllerManagedBy(virtMgr).
+		For(&v1.Service{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
+		Complete(&reconciler)
+}
+
+func (s *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := s.logger.With("Cluster", s.clusterName, "Service", req.NamespacedName)
+	// skip kubernetes service
+	if req.Name == "kubernetes" || req.Name == "kube-dns" {
+		return reconcile.Result{}, nil
+	}
+	var (
+		virtService v1.Service
+		hostService v1.Service
+	)
+	if err := s.virtualClient.Get(ctx, req.NamespacedName, &virtService); err != nil {
+		return reconcile.Result{}, err
+	}
+	syncedService := s.service(&virtService)
+	if err := s.hostClient.Get(ctx, types.NamespacedName{Name: syncedService.Name, Namespace: s.clusterNamespace}, &hostService); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("creating the service for the first time on the host cluster")
+			return reconcile.Result{}, s.hostClient.Create(ctx, syncedService)
+		}
+		return reconcile.Result{}, err
+	}
+	log.Info("updating service on the host cluster")
+	return reconcile.Result{}, s.hostClient.Update(ctx, syncedService)
+}
+
+func (s *ServiceReconciler) service(obj *v1.Service) *v1.Service {
+	hostService := obj.DeepCopy()
+	s.Translater.TranslateTo(hostService)
+	return hostService
+}

--- a/k3k-kubelet/controller/service.go
+++ b/k3k-kubelet/controller/service.go
@@ -122,6 +122,5 @@ func (s *ServiceReconciler) service(obj *v1.Service) *v1.Service {
 	hostService := obj.DeepCopy()
 	s.Translater.TranslateTo(hostService)
 	// don't sync finalizers to the host
-	hostService.Finalizers = nil
 	return hostService
 }

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -115,6 +115,9 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 			BindAddress: ":8084",
 		},
 	})
+	if err != nil {
+		return nil, errors.New("unable to create controller-runtime mgr for virtual cluster: " + err.Error())
+	}
 
 	logger.Info("adding service syncer controller")
 	if err := k3kkubeletcontroller.AddServiceSyncer(ctx, virtualMgr, hostMgr, c.ClusterName, c.ClusterNamespace, k3klog.New(false)); err != nil {

--- a/k3k-kubelet/main.go
+++ b/k3k-kubelet/main.go
@@ -59,7 +59,7 @@ func main() {
 			Usage:       "kubelet API port number",
 			Destination: &cfg.KubeletPort,
 			EnvVar:      "SERVER_PORT",
-			Value:       "9443",
+			Value:       "10250",
 		},
 		cli.StringFlag{
 			Name:        "agent-hostname",
@@ -68,10 +68,10 @@ func main() {
 			EnvVar:      "AGENT_HOSTNAME",
 		},
 		cli.StringFlag{
-			Name:        "agent-ip",
-			Usage:       "Agent IP used for registering the virtual kubelet to the cluster",
-			Destination: &cfg.AgentIP,
-			EnvVar:      "AGENT_IP",
+			Name:        "server-ip",
+			Usage:       "Server IP used for registering the virtual kubelet to the cluster",
+			Destination: &cfg.ServerIP,
+			EnvVar:      "SERVER_IP",
 		},
 		cli.StringFlag{
 			Name:        "config",
@@ -112,7 +112,7 @@ func run(clx *cli.Context) {
 		logger.Fatalw("failed to create new virtual kubelet instance", zap.Error(err))
 	}
 
-	if err := k.registerNode(ctx, cfg.AgentIP, cfg.KubeletPort, cfg.ClusterNamespace, cfg.ClusterName, cfg.AgentHostname); err != nil {
+	if err := k.registerNode(ctx, k.agentIP, cfg.KubeletPort, cfg.ClusterNamespace, cfg.ClusterName, cfg.AgentHostname, cfg.ServerIP, k.dnsIP); err != nil {
 		logger.Fatalw("failed to register new node", zap.Error(err))
 	}
 

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -537,7 +537,7 @@ func (p *Provider) configureNetworking(podName, podNamespace string, pod *corev1
 				p.dnsIP,
 			},
 			Searches: []string{
-				podNamespace + ".svc.cluster.local", "svc.cluster.local", "cluster.local", "hgalal.az",
+				podNamespace + ".svc.cluster.local", "svc.cluster.local", "cluster.local",
 			},
 		}
 	}

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -45,17 +45,19 @@ type Provider struct {
 	MetricsClient    metricset.Interface
 	ClusterNamespace string
 	ClusterName      string
+	serverIP         string
+	dnsIP            string
 	logger           *k3klog.Logger
 }
 
-func New(hostConfig rest.Config, hostMgr, virtualMgr manager.Manager, logger *k3klog.Logger, Namespace, Name string) (*Provider, error) {
+func New(hostConfig rest.Config, hostMgr, virtualMgr manager.Manager, logger *k3klog.Logger, namespace, name, serverIP, dnsIP string) (*Provider, error) {
 	coreClient, err := cv1.NewForConfig(&hostConfig)
 	if err != nil {
 		return nil, err
 	}
 	translater := translate.ToHostTranslater{
-		ClusterName:      Name,
-		ClusterNamespace: Namespace,
+		ClusterName:      name,
+		ClusterNamespace: namespace,
 	}
 	p := Provider{
 		Handler: controller.ControllerHandler{
@@ -71,9 +73,11 @@ func New(hostConfig rest.Config, hostMgr, virtualMgr manager.Manager, logger *k3
 		Translater:       translater,
 		ClientConfig:     hostConfig,
 		CoreClient:       coreClient,
-		ClusterNamespace: Namespace,
-		ClusterName:      Name,
+		ClusterNamespace: namespace,
+		ClusterName:      name,
 		logger:           logger,
+		serverIP:         serverIP,
+		dnsIP:            dnsIP,
 	}
 
 	return &p, nil
@@ -246,8 +250,11 @@ func (p *Provider) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 	if err := p.transformTokens(ctx, pod, tPod); err != nil {
 		return fmt.Errorf("unable to transform tokens for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
+	// inject networking information to the pod including the virtual cluster controlplane endpoint
+	p.configureNetworking(pod.Name, pod.Namespace, tPod)
+
 	p.logger.Infow("Creating pod", "Host Namespace", tPod.Namespace, "Host Name", tPod.Name,
-		"Virtual Namespace", pod.Namespace, "Virtual Name", pod.Name)
+		"Virtual Namespace", pod.Namespace, "Virtual Name", "env", pod.Name, pod.Spec.Containers[0].Env)
 	return p.HostClient.Create(ctx, tPod)
 }
 
@@ -444,7 +451,7 @@ func (p *Provider) pruneUnusedVolumes(ctx context.Context, pod *corev1.Pod) erro
 // concurrently outside of the calling goroutine. Therefore it is recommended
 // to return a version after DeepCopy.
 func (p *Provider) GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
-	p.logger.Infow("got a request for get pod", "Namespace", namespace, "Name", name)
+	p.logger.Debugw("got a request for get pod", "Namespace", namespace, "Name", name)
 	hostNamespaceName := types.NamespacedName{
 		Namespace: p.ClusterNamespace,
 		Name:      p.Translater.TranslateName(namespace, name),
@@ -463,7 +470,7 @@ func (p *Provider) GetPod(ctx context.Context, namespace, name string) (*corev1.
 // concurrently outside of the calling goroutine. Therefore it is recommended
 // to return a version after DeepCopy.
 func (p *Provider) GetPodStatus(ctx context.Context, namespace, name string) (*corev1.PodStatus, error) {
-	p.logger.Infow("got a request for pod status", "Namespace", namespace, "Name", name)
+	p.logger.Debugw("got a request for pod status", "Namespace", namespace, "Name", name)
 	pod, err := p.GetPod(ctx, namespace, name)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get pod for status: %w", err)
@@ -494,6 +501,47 @@ func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 		retPods = append(retPods, &pod)
 	}
 	return retPods, nil
+}
+
+func (p *Provider) configureNetworking(podName, podNamespace string, pod *corev1.Pod) {
+	// inject networking information to the pod's environment variables
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env,
+			corev1.EnvVar{
+				Name:  "KUBERNETES_PORT_443_TCP",
+				Value: "tcp://" + p.serverIP + ":6443",
+			},
+			corev1.EnvVar{
+				Name:  "KUBERNETES_PORT",
+				Value: "tcp://" + p.serverIP + ":6443",
+			},
+			corev1.EnvVar{
+				Name:  "KUBERNETES_PORT_443_TCP_ADDR",
+				Value: p.serverIP,
+			},
+			corev1.EnvVar{
+				Name:  "KUBERNETES_SERVICE_HOST",
+				Value: p.serverIP,
+			},
+			corev1.EnvVar{
+				Name:  "KUBERNETES_SERVICE_PORT",
+				Value: "6443",
+			},
+		)
+	}
+	// injecting cluster DNS IP to the pods except for coredns pod
+	if !strings.HasPrefix(podName, "coredns") {
+		pod.Spec.DNSPolicy = corev1.DNSNone
+		pod.Spec.DNSConfig = &corev1.PodDNSConfig{
+			Nameservers: []string{
+				p.dnsIP,
+			},
+			Searches: []string{
+				podNamespace + ".svc.cluster.local", "svc.cluster.local", "cluster.local", "hgalal.az",
+			},
+		}
+	}
+
 }
 
 // getSecretsAndConfigmaps retrieves a list of all secrets/configmaps that are in use by a given pod. Useful

--- a/k3k-kubelet/translate/host.go
+++ b/k3k-kubelet/translate/host.go
@@ -60,6 +60,7 @@ func (t *ToHostTranslater) TranslateTo(obj client.Object) {
 	// and doesn't collide with other resources
 	obj.SetName(t.TranslateName(obj.GetNamespace(), obj.GetName()))
 	obj.SetNamespace(t.ClusterNamespace)
+	obj.SetFinalizers(nil)
 }
 
 func (t *ToHostTranslater) TranslateFrom(obj client.Object) {

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -121,7 +121,7 @@ func (c *ClusterReconciler) createCluster(ctx context.Context, cluster *v1alpha1
 		return err
 	}
 
-	s := server.New(cluster, c.Client, token)
+	s := server.New(cluster, c.Client, token, string(cluster.Spec.Mode))
 
 	if cluster.Spec.Persistence != nil {
 		cluster.Status.Persistence = cluster.Spec.Persistence

--- a/pkg/controller/cluster/server/config.go
+++ b/pkg/controller/cluster/server/config.go
@@ -68,7 +68,7 @@ func serverOptions(cluster *v1alpha1.Cluster, token string) string {
 		}
 	}
 	if cluster.Spec.Mode != agent.VirtualNodeMode {
-		opts = opts + "disable-agent: true\negress-selector-mode: disabled\n"
+		opts = opts + "disable-agent: true\negress-selector-mode: disabled\ndisable:\n- servicelb\n- traefik\n- metrics-server"
 	}
 	// TODO: Add extra args to the options
 


### PR DESCRIPTION
The PR does the following:

- Syncs all the services created in the virtual cluster to the host cluster
- Creates a coredns service for each virtual cluster
- In k3k-kubelet, it injects networking information to each pod created including:
  - connection information to the virtual cluster API.
  - DNS information to the coredns service created in the second point.