### PR TITLE
Allow exec into pod and fetching log in shared mode

### DIFF
--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -245,7 +245,7 @@ func (s *SharedAgent) role() *rbacv1.Role {
 			{
 				Verbs:     []string{"*"},
 				APIGroups: []string{""},
-				Resources: []string{"pods", "secrets", "configmaps", "services"},
+				Resources: []string{"pods", "pods/log", "pods/exec", "secrets", "configmaps", "services"},
 			},
 			{
 				Verbs:     []string{"get", "watch", "list"},


### PR DESCRIPTION
I added `pods/log` and `pods/exec` in the `kubelet` role to allow user in a `shared` mode virtual cluster to exec to his pods and fetch logs 