### PR TITLE
Implementation of `GetStatsSummary` and `GetMetricsResource` for Virtual Kubelet

### DIFF
--- a/charts/k3k/templates/rbac.yaml
+++ b/charts/k3k/templates/rbac.yaml
@@ -24,7 +24,8 @@ rules:
   - "nodes"
   - "nodes/proxy"
   verbs:
-  - "*"
+  - "get"
+  - "list"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/k3k/templates/rbac.yaml
+++ b/charts/k3k/templates/rbac.yaml
@@ -12,3 +12,25 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "k3k.serviceAccountName" . }}
     namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k3k.fullname" . }}-node-proxy
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "nodes"
+  - "nodes/proxy"
+  verbs:
+  - "*"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "k3k.fullname" . }}-node-proxy
+roleRef:
+  kind: ClusterRole
+  name: {{ include "k3k.fullname" . }}-node-proxy
+  apiGroup: rbac.authorization.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.36.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/rancher/dynamiclistener v1.27.5
 	github.com/sirupsen/logrus v1.9.3
@@ -29,6 +30,7 @@ require (
 	k8s.io/apimachinery v0.29.11
 	k8s.io/apiserver v0.29.11
 	k8s.io/client-go v0.29.11
+	k8s.io/component-base v0.29.11
 	k8s.io/metrics v0.29.11
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.17.5
@@ -80,7 +82,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -119,7 +120,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.2 // indirect
-	k8s.io/component-base v0.29.11 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kms v0.31.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -214,10 +214,10 @@ func (k *kubelet) newProviderFunc(namespace, name, hostname, agentIP, serverIP, 
 		if err != nil {
 			return nil, nil, errors.New("unable to make nodeutil provider: " + err.Error())
 		}
-		nodeProvider := provider.Node{}
 
 		provider.ConfigureNode(pc.Node, hostname, k.port, agentIP)
-		return utilProvider, &nodeProvider, nil
+
+		return utilProvider, &provider.Node{}, nil
 	}
 }
 

--- a/k3k-kubelet/provider/collectors/kubelet_resource_metrics.go
+++ b/k3k-kubelet/provider/collectors/kubelet_resource_metrics.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+
+See https://github.com/virtual-kubelet/azure-aci/tree/master/pkg/metrics/collectors
+*/
+
+package collectors
+
+import (
+	"time"
+
+	stats "github.com/virtual-kubelet/virtual-kubelet/node/api/statsv1alpha1"
+	compbasemetrics "k8s.io/component-base/metrics"
+)
+
+// defining metrics
+var (
+	nodeCPUUsageDesc = compbasemetrics.NewDesc("node_cpu_usage_seconds_total",
+		"Cumulative cpu time consumed by the node in core-seconds",
+		nil,
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	nodeMemoryUsageDesc = compbasemetrics.NewDesc("node_memory_working_set_bytes",
+		"Current working set of the node in bytes",
+		nil,
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	containerCPUUsageDesc = compbasemetrics.NewDesc("container_cpu_usage_seconds_total",
+		"Cumulative cpu time consumed by the container in core-seconds",
+		[]string{"container", "pod", "namespace"},
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	containerMemoryUsageDesc = compbasemetrics.NewDesc("container_memory_working_set_bytes",
+		"Current working set of the container in bytes",
+		[]string{"container", "pod", "namespace"},
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	podCPUUsageDesc = compbasemetrics.NewDesc("pod_cpu_usage_seconds_total",
+		"Cumulative cpu time consumed by the pod in core-seconds",
+		[]string{"pod", "namespace"},
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	podMemoryUsageDesc = compbasemetrics.NewDesc("pod_memory_working_set_bytes",
+		"Current working set of the pod in bytes",
+		[]string{"pod", "namespace"},
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	resourceScrapeResultDesc = compbasemetrics.NewDesc("scrape_error",
+		"1 if there was an error while getting container metrics, 0 otherwise",
+		nil,
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+
+	containerStartTimeDesc = compbasemetrics.NewDesc("container_start_time_seconds",
+		"Start time of the container since unix epoch in seconds",
+		[]string{"container", "pod", "namespace"},
+		nil,
+		compbasemetrics.ALPHA,
+		"")
+)
+
+// NewResourceMetricsCollector returns a metrics.StableCollector which exports resource metrics
+func NewKubeletResourceMetricsCollector(podStats *stats.Summary) compbasemetrics.StableCollector {
+	return &resourceMetricsCollector{
+		providerPodStats: podStats,
+	}
+}
+
+type resourceMetricsCollector struct {
+	compbasemetrics.BaseStableCollector
+
+	providerPodStats *stats.Summary
+}
+
+// Check if resourceMetricsCollector implements necessary interface
+var _ compbasemetrics.StableCollector = &resourceMetricsCollector{}
+
+// DescribeWithStability implements compbasemetrics.StableCollector
+func (rc *resourceMetricsCollector) DescribeWithStability(ch chan<- *compbasemetrics.Desc) {
+	ch <- nodeCPUUsageDesc
+	ch <- nodeMemoryUsageDesc
+	ch <- containerStartTimeDesc
+	ch <- containerCPUUsageDesc
+	ch <- containerMemoryUsageDesc
+	ch <- podCPUUsageDesc
+	ch <- podMemoryUsageDesc
+	ch <- resourceScrapeResultDesc
+}
+
+// CollectWithStability implements compbasemetrics.StableCollector
+// Since new containers are frequently created and removed, using the Gauge would
+// leak metric collectors for containers or pods that no longer exist.  Instead, implement
+// custom collector in a way that only collects metrics for active containers.
+func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- compbasemetrics.Metric) {
+	var errorCount float64
+	defer func() {
+		ch <- compbasemetrics.NewLazyConstMetric(resourceScrapeResultDesc, compbasemetrics.GaugeValue, errorCount)
+	}()
+
+	statsSummary := *rc.providerPodStats
+	rc.collectNodeCPUMetrics(ch, statsSummary.Node)
+	rc.collectNodeMemoryMetrics(ch, statsSummary.Node)
+
+	for _, pod := range statsSummary.Pods {
+		for _, container := range pod.Containers {
+			rc.collectContainerStartTime(ch, pod, container)
+			rc.collectContainerCPUMetrics(ch, pod, container)
+			rc.collectContainerMemoryMetrics(ch, pod, container)
+		}
+		rc.collectPodCPUMetrics(ch, pod)
+		rc.collectPodMemoryMetrics(ch, pod)
+	}
+}
+
+// implement collector methods and validate that correct data is used
+
+func (rc *resourceMetricsCollector) collectNodeCPUMetrics(ch chan<- compbasemetrics.Metric, s stats.NodeStats) {
+	if s.CPU == nil || s.CPU.UsageCoreNanoSeconds == nil {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(s.CPU.Time.Time,
+		compbasemetrics.NewLazyConstMetric(nodeCPUUsageDesc, compbasemetrics.CounterValue, float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second)))
+}
+
+func (rc *resourceMetricsCollector) collectNodeMemoryMetrics(ch chan<- compbasemetrics.Metric, s stats.NodeStats) {
+	if s.Memory == nil || s.Memory.WorkingSetBytes == nil {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(s.Memory.Time.Time,
+		compbasemetrics.NewLazyConstMetric(nodeMemoryUsageDesc, compbasemetrics.GaugeValue, float64(*s.Memory.WorkingSetBytes)))
+}
+
+func (rc *resourceMetricsCollector) collectContainerStartTime(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
+	if s.StartTime.Unix() <= 0 {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(s.StartTime.Time,
+		compbasemetrics.NewLazyConstMetric(containerStartTimeDesc, compbasemetrics.GaugeValue, float64(s.StartTime.UnixNano())/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
+}
+
+func (rc *resourceMetricsCollector) collectContainerCPUMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
+	if s.CPU == nil || s.CPU.UsageCoreNanoSeconds == nil {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(s.CPU.Time.Time,
+		compbasemetrics.NewLazyConstMetric(containerCPUUsageDesc, compbasemetrics.CounterValue,
+			float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
+}
+
+func (rc *resourceMetricsCollector) collectContainerMemoryMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
+	if s.Memory == nil || s.Memory.WorkingSetBytes == nil {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(s.Memory.Time.Time,
+		compbasemetrics.NewLazyConstMetric(containerMemoryUsageDesc, compbasemetrics.GaugeValue,
+			float64(*s.Memory.WorkingSetBytes), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
+}
+
+func (rc *resourceMetricsCollector) collectPodCPUMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats) {
+	if pod.CPU == nil || pod.CPU.UsageCoreNanoSeconds == nil {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(pod.CPU.Time.Time,
+		compbasemetrics.NewLazyConstMetric(podCPUUsageDesc, compbasemetrics.CounterValue,
+			float64(*pod.CPU.UsageCoreNanoSeconds)/float64(time.Second), pod.PodRef.Name, pod.PodRef.Namespace))
+}
+
+func (rc *resourceMetricsCollector) collectPodMemoryMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats) {
+	if pod.Memory == nil || pod.Memory.WorkingSetBytes == nil {
+		return
+	}
+
+	ch <- compbasemetrics.NewLazyMetricWithTimestamp(pod.Memory.Time.Time,
+		compbasemetrics.NewLazyConstMetric(podMemoryUsageDesc, compbasemetrics.GaugeValue,
+			float64(*pod.Memory.WorkingSetBytes), pod.PodRef.Name, pod.PodRef.Namespace))
+}

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 	compbasemetrics "k8s.io/component-base/metrics"
-	metricset "k8s.io/metrics/pkg/client/clientset/versioned"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -48,7 +47,6 @@ type Provider struct {
 	VirtualClient    client.Client
 	ClientConfig     rest.Config
 	CoreClient       cv1.CoreV1Interface
-	MetricsClient    metricset.Interface // TODO: do we need this?
 	ClusterNamespace string
 	ClusterName      string
 	serverIP         string

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	sharedKubeletConfigPath = "/opt/rancher/k3k/config.yaml"
-	sharedNodeAgentName     = "kubelet"
+	SharedNodeAgentName     = "kubelet"
 	SharedNodeMode          = "shared"
 )
 
@@ -69,8 +69,6 @@ func (s *SharedAgent) Resources() []ctrlruntimeclient.Object {
 		s.serviceAccount(),
 		s.role(),
 		s.roleBinding(),
-		s.clusterRole(),
-		s.clusterRoleBinding(),
 		s.service(),
 		s.deployment(),
 		s.dnsService(),
@@ -293,55 +291,8 @@ func (s *SharedAgent) roleBinding() *rbacv1.RoleBinding {
 	}
 }
 
-func (s *SharedAgent) clusterRole() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: "rbac.authorization.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name(),
-			Namespace: s.cluster.Namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				// nodes and nodes/proxy are needed to gather the stats and metrics from the host from
-				// '/api/v1/nodes/<node>/proxy/stats/summary' and '/api/v1/nodes/<node>/proxy/metrics/resource' endpoints
-				// in the GetStatsSummary and GetMetricsResource provider implementation of the Virtual Kubelet
-				Resources: []string{"nodes", "nodes/proxy"},
-				Verbs:     []string{"*"},
-			},
-		},
-	}
-}
-
-func (s *SharedAgent) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRoleBinding",
-			APIVersion: "rbac.authorization.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name(),
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     s.Name(),
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      s.Name(),
-				Namespace: s.cluster.Namespace,
-			},
-		},
-	}
-}
-
 func (s *SharedAgent) Name() string {
-	return controller.SafeConcatNameWithPrefix(s.cluster.Name, sharedNodeAgentName)
+	return controller.SafeConcatNameWithPrefix(s.cluster.Name, SharedNodeAgentName)
 }
 
 func (s *SharedAgent) DNSName() string {

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -65,43 +65,52 @@ token: %s`,
 }
 
 func (s *SharedAgent) Resources() []ctrlruntimeclient.Object {
-	return []ctrlruntimeclient.Object{s.serviceAccount(), s.role(), s.roleBinding(), s.service(), s.deployment(), s.dnsService()}
+	return []ctrlruntimeclient.Object{
+		s.serviceAccount(),
+		s.role(),
+		s.roleBinding(),
+		s.clusterRole(),
+		s.clusterRoleBinding(),
+		s.service(),
+		s.deployment(),
+		s.dnsService(),
+	}
 }
 
 func (s *SharedAgent) deployment() *apps.Deployment {
-	selector := metav1.LabelSelector{
+	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"cluster": s.cluster.Name,
 			"type":    "agent",
 			"mode":    "shared",
 		},
 	}
-	name := s.Name()
+
 	return &apps.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      s.Name(),
 			Namespace: s.cluster.Namespace,
 			Labels:    selector.MatchLabels,
 		},
 		Spec: apps.DeploymentSpec{
-			Selector: &selector,
+			Selector: selector,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: selector.MatchLabels,
 				},
-				Spec: s.podSpec(s.sharedAgentImage, name, &selector),
+				Spec: s.podSpec(selector),
 			},
 		},
 	}
 }
 
-func (s *SharedAgent) podSpec(image, name string, affinitySelector *metav1.LabelSelector) v1.PodSpec {
-	args := []string{"--config", sharedKubeletConfigPath}
+func (s *SharedAgent) podSpec(affinitySelector *metav1.LabelSelector) v1.PodSpec {
 	var limit v1.ResourceList
+
 	return v1.PodSpec{
 		Affinity: &v1.Affinity{
 			PodAntiAffinity: &v1.PodAntiAffinity{
@@ -132,13 +141,16 @@ func (s *SharedAgent) podSpec(image, name string, affinitySelector *metav1.Label
 		},
 		Containers: []v1.Container{
 			{
-				Name:            name,
-				Image:           image,
+				Name:            s.Name(),
+				Image:           s.sharedAgentImage,
 				ImagePullPolicy: v1.PullAlways,
 				Resources: v1.ResourceRequirements{
 					Limits: limit,
 				},
-				Args: args,
+				Args: []string{
+					"--config",
+					sharedKubeletConfigPath,
+				},
 				VolumeMounts: []v1.VolumeMount{
 					{
 						Name:      "config",
@@ -243,14 +255,14 @@ func (s *SharedAgent) role() *rbacv1.Role {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				Verbs:     []string{"*"},
 				APIGroups: []string{""},
 				Resources: []string{"pods", "pods/log", "pods/exec", "secrets", "configmaps", "services"},
+				Verbs:     []string{"*"},
 			},
 			{
-				Verbs:     []string{"get", "watch", "list"},
 				APIGroups: []string{"k3k.io"},
 				Resources: []string{"clusters"},
+				Verbs:     []string{"get", "watch", "list"},
 			},
 		},
 	}
@@ -269,6 +281,53 @@ func (s *SharedAgent) roleBinding() *rbacv1.RoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
+			Name:     s.Name(),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      s.Name(),
+				Namespace: s.cluster.Namespace,
+			},
+		},
+	}
+}
+
+func (s *SharedAgent) clusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.Name(),
+			Namespace: s.cluster.Namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				// nodes and nodes/proxy are needed to gather the stats and metrics from the host from
+				// '/api/v1/nodes/<node>/proxy/stats/summary' and '/api/v1/nodes/<node>/proxy/metrics/resource' endpoints
+				// in the GetStatsSummary and GetMetricsResource provider implementation of the Virtual Kubelet
+				Resources: []string{"nodes", "nodes/proxy"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+}
+
+func (s *SharedAgent) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.Name(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
 			Name:     s.Name(),
 		},
 		Subjects: []rbacv1.Subject{


### PR DESCRIPTION
Ref:
- #119 
---

This PR implements the `GetStatsSummary` and `GetMetricsResource` methods for Virtual Kubelet.

To check the metrics these two commands can be run against the virtual cluster:

```
kubectl get --raw "/api/v1/nodes/k3k-example-cluster-kubelet/proxy/metrics/resource"
kubectl get --raw "/api/v1/nodes/k3k-example-cluster-kubelet/proxy/stats/summary"
```

The data from the Node are the one of the node where the virtual kubelet is running, while the pods are the one owned by the virtual clusters.

To use the `node` and `node/proxy` we'll need a new ClusterRole, and a ClusterRoleBinding for the kubelet. The ClusterRoleBinding will be updated from the K3k controller when a new cluster is created or deleted, adding or removing the kubelet ServiceAccount.

Note: the collector used is copied from the [Azure ACI virtual kubelet](https://github.com/virtual-kubelet/azure-aci/tree/master/pkg/metrics/collectors) implementation.
