### PR TITLE
Add real node resources to virtual node

### DIFF
--- a/k3k-kubelet/provider/configure.go
+++ b/k3k-kubelet/provider/configure.go
@@ -1,12 +1,21 @@
 package provider
 
 import (
+	"context"
+	"time"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	k3klog "github.com/rancher/k3k/pkg/log"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ConfigureNode(node *v1.Node, hostname string, servicePort int, ip string) {
+func ConfigureNode(logger *k3klog.Logger, node *v1.Node, hostname string, servicePort int, ip string, coreClient typedv1.CoreV1Interface, virtualClient client.Client, virtualCluster v1alpha1.Cluster) {
 	node.Status.Conditions = nodeConditions()
 	node.Status.DaemonEndpoints.KubeletEndpoint.Port = int32(servicePort)
 	node.Status.Addresses = []v1.NodeAddress{
@@ -19,15 +28,20 @@ func ConfigureNode(node *v1.Node, hostname string, servicePort int, ip string) {
 			Address: ip,
 		},
 	}
-	node.Status.Capacity = v1.ResourceList{
-		// TODO: Make this more dynamic based on the sum of existing nodes
-		v1.ResourceCPU:    resource.MustParse("8"),
-		v1.ResourceMemory: resource.MustParse("326350752922"),
-		v1.ResourcePods:   resource.MustParse("110"),
-	}
-	node.Status.Allocatable = node.Status.Capacity
+
 	node.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
 	node.Labels["kubernetes.io/os"] = "linux"
+
+	updateNodeCapacityInterval := 10 * time.Second
+	ticker := time.NewTicker(updateNodeCapacityInterval)
+
+	go func() {
+		for range ticker.C {
+			if err := updateNodeCapacity(coreClient, virtualClient, node.Name, virtualCluster.Spec.NodeSelector); err != nil {
+				logger.Error("error updating node capacity", err)
+			}
+		}
+	}()
 }
 
 // nodeConditions returns the basic conditions which mark the node as ready
@@ -74,4 +88,68 @@ func nodeConditions() []v1.NodeCondition {
 			Message:            "RouteController created a route",
 		},
 	}
+}
+
+// updateNodeCapacity will update the virtual node capacity (and the allocatable field) with the sum of all the available nodes.
+// If the nodeLabels are specified only the matching nodes will be considered.
+func updateNodeCapacity(coreClient typedv1.CoreV1Interface, virtualClient client.Client, virtualNodeName string, nodeLabels map[string]string) error {
+	ctx := context.Background()
+
+	capacity, err := getCapacityFromNodes(ctx, coreClient, nodeLabels)
+	if err != nil {
+		return err
+	}
+
+	var virtualNode corev1.Node
+	if err := virtualClient.Get(ctx, types.NamespacedName{Name: virtualNodeName}, &virtualNode); err != nil {
+		return err
+	}
+
+	virtualNode.Status.Capacity = capacity
+	virtualNode.Status.Allocatable = capacity
+
+	return virtualClient.Status().Update(ctx, &virtualNode)
+}
+
+// getCapacityFromNodes will return a sum of all the resource capacities of the host nodes.
+// If some node labels are specified only the matching nodes will be considered.
+func getCapacityFromNodes(ctx context.Context, coreClient typedv1.CoreV1Interface, nodeLabels map[string]string) (v1.ResourceList, error) {
+	listOpts := metav1.ListOptions{}
+	if nodeLabels != nil {
+		labelSelector := metav1.LabelSelector{MatchLabels: nodeLabels}
+		listOpts.LabelSelector = labels.Set(labelSelector.MatchLabels).String()
+	}
+
+	nodeList, err := coreClient.Nodes().List(ctx, listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// sum all
+	allVirtualResources := corev1.ResourceList{}
+
+	for _, node := range nodeList.Items {
+
+		// check if the node is Ready
+		for _, condition := range node.Status.Conditions {
+			if condition.Type != corev1.NodeReady {
+				continue
+			}
+
+			// if the node is not Ready then we can skip it
+			if condition.Status != corev1.ConditionTrue {
+				break
+			}
+		}
+
+		// add all the available metrics to the virtual node
+		for resourceName, resourceQuantity := range node.Status.Capacity {
+			virtualResource := allVirtualResources[resourceName]
+
+			(&virtualResource).Add(resourceQuantity)
+			allVirtualResources[resourceName] = virtualResource
+		}
+	}
+
+	return allVirtualResources, nil
 }


### PR DESCRIPTION
Ref:
- #117
---

This PR adds the real capacity and allocatable resources of the virtual node.

It will get all the nodes, filtered by the nodeSelector field if present, sum the capacity and the allocatable resources, and updating the virtual node. Since the nodes in the host cluster could change (adding or removing), the update will be done every `10s`.