### PR TITLE
Fix removed `id-token` permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 permissions:
     contents: write
     packages: write
+    id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
Readd removed `id-token` permission needed for Vault authentication.