### PR TITLE
Added priorityClass to Clusters and ClusterSets

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -167,6 +167,11 @@ spec:
                 required:
                 - type
                 type: object
+              priorityClass:
+                description: |-
+                  PriorityClass is the priorityClassName that will be applied to all server/agent pods.
+                  In "shared" mode the priorityClassName will be applied also to the workloads.
+                type: string
               serverArgs:
                 description: ServerArgs are the ordered key value pairs (e.x. "testArg",
                   "testValue") for the K3s pods running in server mode.

--- a/charts/k3k/crds/k3k.io_clustersets.yaml
+++ b/charts/k3k/crds/k3k.io_clustersets.yaml
@@ -87,6 +87,10 @@ spec:
                 description: DefaultNodeSelector is the node selector that applies
                   to all clusters (server + agent) in the set
                 type: object
+              defaultPriorityClass:
+                description: DefaultPriorityClass is the priorityClassName applied
+                  to all pods of all clusters in the set
+                type: string
               disableNetworkPolicy:
                 description: DisableNetworkPolicy is an option that will disable the
                   creation of a default networkpolicy for cluster isolation

--- a/examples/clusterset.yaml
+++ b/examples/clusterset.yaml
@@ -8,3 +8,4 @@ metadata:
   # - "shared"
   # - "virtual"
   # podSecurityAdmissionLevel: "baseline"
+  # defaultPriorityClass: "lowpriority"

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -329,6 +329,7 @@ func (p *Provider) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 	tPod.Spec.NodeName = ""
 
 	tPod.Spec.NodeSelector = cluster.Spec.NodeSelector
+	tPod.Spec.PriorityClassName = cluster.Spec.PriorityClass
 
 	// volumes will often refer to resources in the virtual cluster, but instead need to refer to the sync'd
 	// host cluster version

--- a/pkg/apis/k3k.io/v1alpha1/set_types.go
+++ b/pkg/apis/k3k.io/v1alpha1/set_types.go
@@ -33,6 +33,9 @@ type ClusterSetSpec struct {
 	// DefaultNodeSelector is the node selector that applies to all clusters (server + agent) in the set
 	DefaultNodeSelector map[string]string `json:"defaultNodeSelector,omitempty"`
 
+	// DefaultPriorityClass is the priorityClassName applied to all pods of all clusters in the set
+	DefaultPriorityClass string `json:"defaultPriorityClass,omitempty"`
+
 	// DisableNetworkPolicy is an option that will disable the creation of a default networkpolicy for cluster isolation
 	DisableNetworkPolicy bool `json:"disableNetworkPolicy,omitempty"`
 

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -35,6 +35,10 @@ type ClusterSpec struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// PriorityClass is the priorityClassName that will be applied to all server/agent pods.
+	// In "shared" mode the priorityClassName will be applied also to the workloads.
+	PriorityClass string `json:"priorityClass,omitempty"`
+
 	// Limit is the limits that apply for the server/worker nodes.
 	Limit *ClusterLimit `json:"clusterLimit,omitempty"`
 

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -51,7 +51,8 @@ func (s *Server) podSpec(image, name string, persistent bool, affinitySelector *
 		limit = s.cluster.Spec.Limit.ServerLimit
 	}
 	podSpec := v1.PodSpec{
-		NodeSelector: s.cluster.Spec.NodeSelector,
+		NodeSelector:      s.cluster.Spec.NodeSelector,
+		PriorityClassName: s.cluster.Spec.PriorityClass,
 		Affinity: &v1.Affinity{
 			PodAntiAffinity: &v1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{

--- a/pkg/controller/clusterset/clusterset.go
+++ b/pkg/controller/clusterset/clusterset.go
@@ -88,12 +88,12 @@ func namespaceEventHandler(reconciler ClusterSetReconciler) handler.MapFunc {
 	}
 }
 
-// namespaceEventHandler will enqueue reconciling requests for all the ClusterSets in the changed namespace
+// sameNamespaceEventHandler will enqueue reconciling requests for all the ClusterSets in the changed namespace
 func sameNamespaceEventHandler(reconciler ClusterSetReconciler) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		var requests []reconcile.Request
-
 		var set v1alpha1.ClusterSetList
+
 		_ = reconciler.Client.List(ctx, &set, client.InNamespace(obj.GetNamespace()))
 		for _, clusterSet := range set.Items {
 			requests = append(requests, reconcile.Request{


### PR DESCRIPTION
This PR adds the `defaultPriorityClass` to ClusterSets and the `priorityClass` to the Cluster.

It adds a Watch to the ClusterSet controller that will trigger when a Cluster is changed. When this happens then all the ClusterSet in the namespace will be reconciled.

Tests.

Ref #121 