### PR TITLE
Fix for default priorityClasses

### DIFF
--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -329,7 +329,14 @@ func (p *Provider) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 	tPod.Spec.NodeName = ""
 
 	tPod.Spec.NodeSelector = cluster.Spec.NodeSelector
-	tPod.Spec.PriorityClassName = cluster.Spec.PriorityClass
+
+	// if the priorityCluss for the virtual cluster is set then override the provided value
+	// Note: the core-dns and local-path-provisioner pod are scheduled by k3s with the
+	// 'system-cluster-critical' and 'system-node-critical' default priority classes.
+	if cluster.Spec.PriorityClass != "" {
+		tPod.Spec.PriorityClassName = cluster.Spec.PriorityClass
+		tPod.Spec.Priority = nil
+	}
 
 	// volumes will often refer to resources in the virtual cluster, but instead need to refer to the sync'd
 	// host cluster version


### PR DESCRIPTION
In some cases (i.e. when k3s is creating the `core-dns` and the `local-path-provisioner` pods) the priorityClassName and the priority are already defined. This PR fixes the issue overriding the priority only if a default is provided.

