### PR TITLE
Fix for UpdatePod

### DIFF
--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -500,8 +500,6 @@ func (p *Provider) UpdatePod(ctx context.Context, pod *corev1.Pod) error {
 	currentHostPod.Spec.ActiveDeadlineSeconds = pod.Spec.ActiveDeadlineSeconds
 	currentHostPod.Spec.Tolerations = pod.Spec.Tolerations
 
-	fmt.Println("UPDATED IMAGE currentPod", currentHostPod.Spec.Containers[0].Image)
-
 	if err := p.HostClient.Update(ctx, &currentHostPod); err != nil {
 		return fmt.Errorf("unable to update pod in the host cluster: %w", err)
 	}


### PR DESCRIPTION
The `UpdatePod` func of the virtual kubelet was failing because of a "double translation" of the pod name.

It was translating the name, and then using the GetPod the name was translated again. This was causing NotFound issues, and the pod were never updated.

```go
hostName := p.Translater.TranslateName(pod.Namespace, pod.Name)
currentPod, err := p.GetPod(ctx, p.ClusterNamespace, hostName)
```

```
'ProviderUpdateFailed' unable to get current pod for update: error when retrieving pod: Pod \"nginx-latest-default-mycluster-6e67696e782d6c61746573742b-14668\" not found"
```

Removing that part showed that the current update was not really working, because the spec of a Pod is almost immutable in all its fields.

```
type: 'Warning'
reason: 'ProviderUpdateFailed' Pod \"nginx-latest-default-mycluster-6e67696e782d6c61746573742b-86f67\" is invalid:
spec: Forbidden:
pod updates may not change fields other than
  `spec.containers[*].image`
  `spec.initContainers[*].image`
  `spec.activeDeadlineSeconds`
  `spec.tolerations` (only additions to existing tolerations)
  `spec.terminationGracePeriodSeconds` (allow it to be set to 1 if it was previously negative)
```

This PR will update only some of the fields, like the images of the Container, InitContainers, Tolerations, and ActiveDeadlineSeconds.

For the Pod in the Virtual Cluster also labels and annotations will be updated.

Note: we need to update also the Pod in the virtual cluster, otherwise any change will not be reflected. Now trying to do a `kubectl edit` or `kubectl set image pod/nginx nginx=nginx:1.9.1` will be reflected in both the virtual cluster and the host one.

```json
{
    "level": "info",
    "timestamp": "2025-01-15T15:46:47.715Z",
    "logger": "k3k-kubelet",
    "msg": "Event(v1.ObjectReference{Kind:\"Pod\", Namespace:\"default\", Name:\"nginx-latest\", UID:\"1cfa3304-bcf1-4695-ab98-323738f5f6e3\", APIVersion:\"v1\", ResourceVersion:\"13344\", FieldPath:\"\"}): type: 'Normal' reason: 'ProviderUpdateSuccess' Update pod in provider successfully"
}
```