### PR TITLE
Add retry for k3k-kubelet provider functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.36.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/rancher/dynamiclistener v1.27.5
 	github.com/sirupsen/logrus v1.9.3
@@ -81,6 +80,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	cv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -58,6 +60,11 @@ type Provider struct {
 	dnsIP            string
 	logger           *k3klog.Logger
 }
+
+const (
+	interval = 2 * time.Second
+	timeout  = 10 * time.Second
+)
 
 func New(hostConfig rest.Config, hostMgr, virtualMgr manager.Manager, logger *k3klog.Logger, namespace, name, serverIP, dnsIP string) (*Provider, error) {
 	coreClient, err := cv1.NewForConfig(&hostConfig)
@@ -311,8 +318,13 @@ func (p *Provider) PortForward(ctx context.Context, namespace, pod string, port 
 	return fw.ForwardPorts()
 }
 
-// CreatePod takes a Kubernetes Pod and deploys it within the provider.
+// CreatePod executes createPod with retry
 func (p *Provider) CreatePod(ctx context.Context, pod *corev1.Pod) error {
+	return p.withRetry(ctx, p.createPod, pod, interval, timeout)
+}
+
+// createPod takes a Kubernetes Pod and deploys it within the provider.
+func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
 	tPod := pod.DeepCopy()
 	p.Translater.TranslateTo(tPod)
 
@@ -362,6 +374,26 @@ func (p *Provider) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 	p.logger.Infow("Creating pod", "Host Namespace", tPod.Namespace, "Host Name", tPod.Name,
 		"Virtual Namespace", pod.Namespace, "Virtual Name", "env", pod.Name, pod.Spec.Containers[0].Env)
 	return p.HostClient.Create(ctx, tPod)
+}
+
+// withRetry retries passed function with interval and timeout
+func (p *Provider) withRetry(ctx context.Context, f func(context.Context, *v1.Pod) error, pod *v1.Pod, interval, timeout time.Duration) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			if lastErr = f(ctx, pod); lastErr != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+	if err != nil {
+		const message = "failed to create pod with provider"
+		if lastErr != nil {
+			return errors.Wrap(lastErr, message)
+		}
+		return errors.Wrap(err, message)
+	}
+	return nil
 }
 
 // transformVolumes changes the volumes to the representation in the host cluster. Will return an error
@@ -417,6 +449,7 @@ func (p *Provider) transformVolumes(ctx context.Context, podNamespace string, vo
 	return nil
 }
 
+// syncConfigmap will add the configmap object to the queue of the syncer controller to be synced to the host cluster
 func (p *Provider) syncConfigmap(ctx context.Context, podNamespace string, configMapName string, optional bool) error {
 	var configMap corev1.ConfigMap
 	nsName := types.NamespacedName{
@@ -438,6 +471,7 @@ func (p *Provider) syncConfigmap(ctx context.Context, podNamespace string, confi
 	return nil
 }
 
+// syncSecret will add the secret object to the queue of the syncer controller to be synced to the host cluster
 func (p *Provider) syncSecret(ctx context.Context, podNamespace string, secretName string, optional bool) error {
 	var secret corev1.Secret
 	nsName := types.NamespacedName{
@@ -453,13 +487,17 @@ func (p *Provider) syncSecret(ctx context.Context, podNamespace string, secretNa
 	}
 	err = p.Handler.AddResource(ctx, &secret)
 	if err != nil {
-		return fmt.Errorf("unable to add configmap to sync %s/%s: %w", nsName.Namespace, nsName.Name, err)
+		return fmt.Errorf("unable to add secret to sync %s/%s: %w", nsName.Namespace, nsName.Name, err)
 	}
 	return nil
 }
 
-// UpdatePod takes a Kubernetes Pod and updates it within the provider.
+// UpdatePod executes updatePod with retry
 func (p *Provider) UpdatePod(ctx context.Context, pod *corev1.Pod) error {
+	return p.withRetry(ctx, p.updatePod, pod, interval, timeout)
+}
+
+func (p *Provider) updatePod(ctx context.Context, pod *v1.Pod) error {
 	p.logger.Debugw("got a request for update pod")
 
 	// Once scheduled a Pod cannot update other fields than the image of the containers, initcontainers and a few others
@@ -529,10 +567,15 @@ func updateContainerImages(original, updated []v1.Container) []v1.Container {
 	return original
 }
 
-// DeletePod takes a Kubernetes Pod and deletes it from the provider. Once a pod is deleted, the provider is
+// DeletePod executes deletePod with retry
+func (p *Provider) DeletePod(ctx context.Context, pod *corev1.Pod) error {
+	return p.withRetry(ctx, p.deletePod, pod, interval, timeout)
+}
+
+// deletePod takes a Kubernetes Pod and deletes it from the provider. Once a pod is deleted, the provider is
 // expected to call the NotifyPods callback with a terminal pod status where all the containers are in a terminal
 // state, as well as the pod. DeletePod may be called multiple times for the same pod.
-func (p *Provider) DeletePod(ctx context.Context, pod *corev1.Pod) error {
+func (p *Provider) deletePod(ctx context.Context, pod *corev1.Pod) error {
 	p.logger.Infof("Got request to delete pod %s", pod.Name)
 	hostName := p.Translater.TranslateName(pod.Namespace, pod.Name)
 	err := p.CoreClient.Pods(p.ClusterNamespace).Delete(ctx, hostName, metav1.DeleteOptions{})
@@ -659,6 +702,9 @@ func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 	return retPods, nil
 }
 
+// configureNetworking will inject network information to each pod to connect them to the
+// virtual cluster api server, as well as confiugre DNS information to connect them to the
+// synced coredns on the host cluster.
 func (p *Provider) configureNetworking(podName, podNamespace string, pod *corev1.Pod) {
 	// inject networking information to the pod's environment variables
 	for i := range pod.Spec.Containers {
@@ -697,7 +743,6 @@ func (p *Provider) configureNetworking(podName, podNamespace string, pod *corev1
 			},
 		}
 	}
-
 }
 
 // getSecretsAndConfigmaps retrieves a list of all secrets/configmaps that are in use by a given pod. Useful


### PR DESCRIPTION
the PR will add a retry logic to create/update/delete implementations of k3k-kubelet to allow creation of single pods

- https://github.com/rancher/k3k/issues/168