### PR TITLE
Charts updates (removed default `k3k-system` namespace, edit of some default values)

### DIFF
--- a/charts/k3k/Chart.yaml
+++ b/charts/k3k/Chart.yaml
@@ -3,4 +3,4 @@ name: k3k
 description: A Helm chart for K3K
 type: application
 version: 0.1.5-r5
-appVersion: 0.2.0
+appVersion: v0.2.2-rc2

--- a/charts/k3k/templates/deployment.yaml
+++ b/charts/k3k/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "k3k.fullname" . }}
   labels:
     {{- include "k3k.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.image.replicaCount }}
   selector:
@@ -16,14 +16,14 @@ spec:
         {{- include "k3k.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}
           env:
           - name: CLUSTER_CIDR
             value: {{ .Values.host.clusterCIDR }}
           - name: SHARED_AGENT_IMAGE
-            value: "{{ .Values.sharedAgent.image.repository }}:{{ .Values.sharedAgent.image.tag }}"
+            value: "{{ .Values.sharedAgent.image.repository }}:{{ default .Chart.AppVersion .Values.sharedAgent.image.tag }}"
           ports:
           - containerPort: 8080
             name: https

--- a/charts/k3k/templates/namespace.yaml
+++ b/charts/k3k/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}

--- a/charts/k3k/templates/rbac.yaml
+++ b/charts/k3k/templates/rbac.yaml
@@ -11,7 +11,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "k3k.serviceAccountName" . }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/k3k/templates/service.yaml
+++ b/charts/k3k/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3k-webhook
   labels:
     {{- include "k3k.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/charts/k3k/templates/serviceaccount.yaml
+++ b/charts/k3k/templates/serviceaccount.yaml
@@ -5,5 +5,5 @@ metadata:
   name: {{ include "k3k.serviceAccountName" . }}
   labels:
     {{- include "k3k.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/k3k/values.yaml
+++ b/charts/k3k/values.yaml
@@ -1,19 +1,17 @@
 replicaCount: 1
-namespace: k3k-system
 
 image:
-  repository: rancher/k3k 
-  pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.2.1"
+  repository: rancher/k3k
+  tag: ""
+  pullPolicy: ""
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 host:
-# clusterCIDR specifies the clusterCIDR that will be added to the default networkpolicy for clustersets, if not set
-# the controller will collect the PodCIDRs of all the nodes on the system.
+  # clusterCIDR specifies the clusterCIDR that will be added to the default networkpolicy for clustersets, if not set
+  # the controller will collect the PodCIDRs of all the nodes on the system.
   clusterCIDR: ""
 
 serviceAccount:
@@ -26,5 +24,5 @@ serviceAccount:
 # configuration related to the shared agent mode in k3k
 sharedAgent:
   image:
-    repository: "rancher/k3k"
-    tag: "k3k-kubelet-dev"
+    repository: "rancher/k3k-kubelet"
+    tag: ""


### PR DESCRIPTION
With Helm we should not create the namespace where we want to deploy the resources, but it should be specified during the `helm install` command. When trying to use Helm with testcontainers (#189) I had some problem related to this.


> - https://github.com/helm/helm/issues/5153
>  
> In general, a chart should not contain a namespace nor should the templates reference a particular namespace. Instead, a namespace can be provided on helm install, which then the namespace will be created for you if it does not exist.
>
> (https://github.com/helm/helm/issues/5153#issuecomment-453243101)

or

> - https://github.com/helm/helm/issues/4456
>
>  Helm will not do cross-namespace management, and we do not recommend setting namespace: directly in a template.
>
> (https://github.com/helm/helm/issues/4456#issuecomment-412134651)

This PR changes the `{{ .Values.namespace }}` `{{ .Release.Namespace }}` accordingly.

### values.yaml

This PR also updates some default values in the `values.yaml` file, with more "production" ready values.

The `image.tag` default value is now unset. The default will be the one specified in the `Chart.yaml` file. And the `pullPolicy` is unset (`IfNotPresent` by default). The `Always` value is useful in a development context, but it still can be set programmatically, or with a custom `values.yaml` file.

```yaml
image:
  repository: rancher/k3k
  tag: ""
  pullPolicy: ""
```

The **sharedAgent** values where updated to match the new image, with the same version tag of the k3k controller by default, matching the new repository:

```yaml
sharedAgent:
  image:
    repository: "rancher/k3k-kubelet"
    tag: ""
```

## :warning:  Note

Please, be aware that now to install `k3k` you should specify the `k3k-system` namespace during the creation:

i.e.:
```
helm upgrade --install --namespace k3k-system --create-namespace k3k ./charts/k3k
```