### PR TITLE
Simplify Cluster spec

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -36,6 +36,7 @@ spec:
           metadata:
             type: object
           spec:
+            default: {}
             properties:
               addons:
                 description: Addons is a list of secrets containing raw YAML which
@@ -55,6 +56,7 @@ spec:
                   type: string
                 type: array
               agents:
+                default: 0
                 description: Agents is the number of K3s pods to run in agent (worker)
                   mode.
                 format: int32
@@ -179,6 +181,7 @@ spec:
                   type: string
                 type: array
               servers:
+                default: 1
                 description: Servers is the number of K3s pods to run in server (controlplane)
                   mode.
                 format: int32
@@ -218,11 +221,6 @@ spec:
                 description: Version is a string representing the Kubernetes version
                   to be used by the virtual nodes.
                 type: string
-            required:
-            - agents
-            - mode
-            - servers
-            - version
             type: object
           status:
             properties:

--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -228,6 +228,8 @@ spec:
                 type: string
               clusterDNS:
                 type: string
+              hostVersion:
+                type: string
               persistence:
                 properties:
                   storageClassName:
@@ -248,8 +250,6 @@ spec:
                   type: string
                 type: array
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -15,28 +15,34 @@ type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 
 	// +kubebuilder:default={}
+	// +optional
 	Spec   ClusterSpec   `json:"spec"`
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
 type ClusterSpec struct {
 	// Version is a string representing the Kubernetes version to be used by the virtual nodes.
-	Version string `json:"version,omitempty"`
+	//
+	// +optional
+	Version string `json:"version"`
 
 	// Servers is the number of K3s pods to run in server (controlplane) mode.
 	//
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:XValidation:message="cluster must have at least one server",rule="self >= 1"
-	Servers *int32 `json:"servers,omitempty"`
+	// +optional
+	Servers *int32 `json:"servers"`
 
 	// Agents is the number of K3s pods to run in agent (worker) mode.
 	//
 	// +kubebuilder:default=0
 	// +kubebuilder:validation:XValidation:message="invalid value for agents",rule="self >= 0"
-	Agents *int32 `json:"agents,omitempty"`
+	// +optional
+	Agents *int32 `json:"agents"`
 
 	// NodeSelector is the node selector that will be applied to all server/agent pods.
 	// In "shared" mode the node selector will be applied also to the workloads.
+	//
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
@@ -82,7 +88,8 @@ type ClusterSpec struct {
 	// +kubebuilder:default="shared"
 	// +kubebuilder:validation:Enum=shared;virtual
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
-	Mode ClusterMode `json:"mode,omitempty"`
+	// +optional
+	Mode ClusterMode `json:"mode"`
 
 	// Persistence contains options controlling how the etcd data of the virtual cluster is persisted. By default, no data
 	// persistence is guaranteed, so restart of a virtual cluster pod may result in data loss without this field.
@@ -157,6 +164,7 @@ type NodePortConfig struct {
 }
 
 type ClusterStatus struct {
+	HostVersion string             `json:"hostVersion,omitempty"`
 	ClusterCIDR string             `json:"clusterCIDR,omitempty"`
 	ServiceCIDR string             `json:"serviceCIDR,omitempty"`
 	ClusterDNS  string             `json:"clusterDNS,omitempty"`

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -89,7 +89,7 @@ type ClusterSpec struct {
 	// +kubebuilder:validation:Enum=shared;virtual
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
 	// +optional
-	Mode ClusterMode `json:"mode"`
+	Mode ClusterMode `json:"mode,omitempty"`
 
 	// Persistence contains options controlling how the etcd data of the virtual cluster is persisted. By default, no data
 	// persistence is guaranteed, so restart of a virtual cluster pod may result in data loss without this field.

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -14,21 +14,26 @@ type Cluster struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	metav1.TypeMeta   `json:",inline"`
 
+	// +kubebuilder:default={}
 	Spec   ClusterSpec   `json:"spec"`
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
 type ClusterSpec struct {
 	// Version is a string representing the Kubernetes version to be used by the virtual nodes.
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 
 	// Servers is the number of K3s pods to run in server (controlplane) mode.
+	//
+	// +kubebuilder:default=1
 	// +kubebuilder:validation:XValidation:message="cluster must have at least one server",rule="self >= 1"
-	Servers *int32 `json:"servers"`
+	Servers *int32 `json:"servers,omitempty"`
 
 	// Agents is the number of K3s pods to run in agent (worker) mode.
+	//
+	// +kubebuilder:default=0
 	// +kubebuilder:validation:XValidation:message="invalid value for agents",rule="self >= 0"
-	Agents *int32 `json:"agents"`
+	Agents *int32 `json:"agents,omitempty"`
 
 	// NodeSelector is the node selector that will be applied to all server/agent pods.
 	// In "shared" mode the node selector will be applied also to the workloads.
@@ -73,10 +78,11 @@ type ClusterSpec struct {
 	Addons []Addon `json:"addons,omitempty"`
 
 	// Mode is the cluster provisioning mode which can be either "shared" or "virtual". Defaults to "shared"
+	//
 	// +kubebuilder:default="shared"
 	// +kubebuilder:validation:Enum=shared;virtual
 	// +kubebuilder:validation:XValidation:message="mode is immutable",rule="self == oldSelf"
-	Mode ClusterMode `json:"mode"`
+	Mode ClusterMode `json:"mode,omitempty"`
 
 	// Persistence contains options controlling how the etcd data of the virtual cluster is persisted. By default, no data
 	// persistence is guaranteed, so restart of a virtual cluster pod may result in data loss without this field.

--- a/pkg/controller/cluster/cluster_suite_test.go
+++ b/pkg/controller/cluster/cluster_suite_test.go
@@ -1,0 +1,88 @@
+package cluster_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"github.com/rancher/k3k/pkg/controller/cluster"
+	"github.com/rancher/k3k/pkg/log"
+
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Controller Suite")
+}
+
+var (
+	testEnv   *envtest.Environment
+	k8sClient client.Client
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+var _ = BeforeSuite(func() {
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "charts", "k3k", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	scheme := buildScheme()
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	ctx, cancel = context.WithCancel(context.Background())
+	nopLogger := &log.Logger{SugaredLogger: zap.NewNop().Sugar()}
+
+	err = cluster.Add(ctx, mgr, "", nopLogger)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred(), "failed to run manager")
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func buildScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	err := corev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = appsv1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = networkingv1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	return scheme
+}

--- a/pkg/controller/cluster/cluster_test.go
+++ b/pkg/controller/cluster/cluster_test.go
@@ -1,0 +1,62 @@
+package cluster_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster Controller", func() {
+
+	Context("creating a Cluster", func() {
+
+		var (
+			namespace string
+		)
+
+		BeforeEach(func() {
+			createdNS := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{GenerateName: "ns-"}}
+			err := k8sClient.Create(context.Background(), createdNS)
+			Expect(err).To(Not(HaveOccurred()))
+			namespace = createdNS.Name
+		})
+
+		When("created with a default spec", func() {
+
+			It("should have been created with some defaults", func() {
+				cluster := &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						GenerateName: "clusterset-",
+						Namespace:    namespace,
+					},
+				}
+
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).To(Not(HaveOccurred()))
+
+				Expect(cluster.Spec.Mode).To(Equal(v1alpha1.SharedClusterMode))
+				Expect(cluster.Spec.Agents).To(Equal(ptr.To[int32](0)))
+				Expect(cluster.Spec.Servers).To(Equal(ptr.To[int32](1)))
+
+				Eventually(func() string {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
+					Expect(err).To(Not(HaveOccurred()))
+					return cluster.Spec.Version
+
+				}).
+					WithTimeout(time.Second * 30).
+					WithPolling(time.Second).
+					Should(Not(BeEmpty()))
+			})
+		})
+	})
+})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,9 +27,21 @@ var Backoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
+// K3SImage returns the rancher/k3s image tagged with the specified Version.
+// If Version is empty it will use with the same k8s version of the host cluster,
+// stored in the Status object. It will return the untagged version as last fallback.
 func K3SImage(cluster *v1alpha1.Cluster) string {
-	return k3SImageName + ":" + cluster.Spec.Version
+	if cluster.Spec.Version != "" {
+		return k3SImageName + ":" + cluster.Spec.Version
+	}
+
+	if cluster.Status.HostVersion != "" {
+		return k3SImageName + ":" + cluster.Status.HostVersion
+	}
+
+	return k3SImageName
 }
+
 func nodeAddress(node *v1.Node) string {
 	var externalIP string
 	var internalIP string


### PR DESCRIPTION
This PR removes some required parameters, adding defaults. Now it's possible to create a Cluster with an empty spec:

```yaml
apiVersion: k3k.io/v1alpha1
kind: Cluster
metadata:
  name: mycluster
  namespace: k3k-mycluster
```

**mode**: default  to `shared`
**servers**: default to `1`
**agents**: default to `0`
**version**: if not provided the version used will be the same of the host. To do so the Reconciler will use the DiscoveryClient, and it will update the Cluster **Status** subresource. A field `HostVersion` will be used, this will prevent us to overwrite the submitted spec, keeping track the original submitted resource.
