### PR TITLE
Fix release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Check release tag
       id: release-tag
       run: |
-        CURRENT_TAG=$(git describe --tag --always)
+        CURRENT_TAG=$(git describe --tag --always --match="v[0-9]*")
 
         if git show-ref --tags ${CURRENT_TAG} --quiet; then
           echo "tag ${CURRENT_TAG} already exists";

--- a/scripts/build
+++ b/scripts/build
@@ -2,7 +2,7 @@
 
 set -e pipefail
 
-TAG=$(git describe --tag --always)
+TAG=$(git describe --tag --always --match="v[0-9]*")
 
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     TAG="${TAG}-dirty"


### PR DESCRIPTION
Since we are taggin also the charts with the `charts-` prefix, if the current latest tag is a chart one then goreleaser will complain about it not being a valid semver tag (see https://github.com/rancher/k3k/actions/runs/12906228968).

This filter will fetch only the semver tags of the repo, to retrieve just the k3k ones.