### PR TITLE
Logs and organization cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,18 +116,18 @@ func run(clx *cli.Context) error {
 	}
 
 	logger.Info("adding etcd pod controller")
-	if err := cluster.AddPodController(ctx, mgr, logger); err != nil {
+	if err := cluster.AddPodController(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to add the new cluster controller: %v", err)
 	}
 
 	logger.Info("adding clusterset controller")
-	if err := clusterset.Add(ctx, mgr, clusterCIDR, logger); err != nil {
+	if err := clusterset.Add(ctx, mgr, clusterCIDR); err != nil {
 		return fmt.Errorf("failed to add the clusterset controller: %v", err)
 	}
 
 	if clusterCIDR == "" {
 		logger.Info("adding networkpolicy node controller")
-		if err := clusterset.AddNodeController(ctx, mgr, logger); err != nil {
+		if err := clusterset.AddNodeController(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to add the clusterset node controller: %v", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -109,8 +109,9 @@ func run(clx *cli.Context) error {
 	}
 
 	ctrlruntimelog.SetLogger(zapr.NewLogger(logger.Desugar().WithOptions(zap.AddCallerSkip(1))))
+
 	logger.Info("adding cluster controller")
-	if err := cluster.Add(ctx, mgr, sharedAgentImage, sharedAgentImagePullPolicy, logger); err != nil {
+	if err := cluster.Add(ctx, mgr, sharedAgentImage, sharedAgentImagePullPolicy); err != nil {
 		return fmt.Errorf("failed to add the new cluster controller: %v", err)
 	}
 

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -13,8 +13,6 @@ import (
 	"github.com/rancher/k3k/pkg/controller/cluster/agent"
 	"github.com/rancher/k3k/pkg/controller/cluster/server"
 	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
-	"github.com/rancher/k3k/pkg/log"
-	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,12 +49,10 @@ type ClusterReconciler struct {
 	Scheme                     *runtime.Scheme
 	SharedAgentImage           string
 	SharedAgentImagePullPolicy string
-	logger                     *log.Logger
 }
 
 // Add adds a new controller to the manager
-func Add(ctx context.Context, mgr manager.Manager, sharedAgentImage, sharedAgentImagePullPolicy string, logger *log.Logger) error {
-
+func Add(ctx context.Context, mgr manager.Manager, sharedAgentImage, sharedAgentImagePullPolicy string) error {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		return err
@@ -69,7 +65,6 @@ func Add(ctx context.Context, mgr manager.Manager, sharedAgentImage, sharedAgent
 		Scheme:                     mgr.GetScheme(),
 		SharedAgentImage:           sharedAgentImage,
 		SharedAgentImagePullPolicy: sharedAgentImagePullPolicy,
-		logger:                     logger.Named(clusterController),
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -81,78 +76,62 @@ func Add(ctx context.Context, mgr manager.Manager, sharedAgentImage, sharedAgent
 }
 
 func (c *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	var (
-		cluster v1alpha1.Cluster
-		podList v1.PodList
-	)
-	log := c.logger.With("Cluster", req.NamespacedName)
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("reconciling")
+
+	var cluster v1alpha1.Cluster
 	if err := c.Client.Get(ctx, req.NamespacedName, &cluster); err != nil {
-		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+		return reconcile.Result{}, err
 	}
+
+	// if DeletionTimestamp is not Zero -> finalize the object
+	if !cluster.DeletionTimestamp.IsZero() {
+		return c.finalizeCluster(ctx, cluster)
+	}
+
+	// add finalizers
+	if !controllerutil.AddFinalizer(&cluster, clusterFinalizerName) {
+		if err := c.Client.Update(ctx, &cluster); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	orig := cluster.DeepCopy()
+
+	reconcilerErr := c.reconcileCluster(ctx, &cluster)
+
+	// update Status if needed
+	if !reflect.DeepEqual(orig.Status, cluster.Status) {
+		if err := c.Client.Status().Update(ctx, &cluster); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, reconcilerErr
+}
+
+func (c *ClusterReconciler) reconcileCluster(ctx context.Context, cluster *v1alpha1.Cluster) error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("reconcileCluster")
 
 	// if the Version is not specified we will try to use the same Kubernetes version of the host.
 	// This version is stored in the Status object, and it will not be updated if already set.
 	if cluster.Spec.Version == "" && cluster.Status.HostVersion == "" {
 		hostVersion, err := c.DiscoveryClient.ServerVersion()
 		if err != nil {
-			return reconcile.Result{}, err
+			return err
 		}
 
 		// update Status HostVersion
 		k8sVersion := strings.Split(hostVersion.GitVersion, "+")[0]
 		cluster.Status.HostVersion = k8sVersion + "-k3s1"
-		if err := c.Client.Status().Update(ctx, &cluster); err != nil {
-			return reconcile.Result{}, err
-		}
 	}
 
-	if cluster.DeletionTimestamp.IsZero() {
-		if !controllerutil.ContainsFinalizer(&cluster, clusterFinalizerName) {
-			controllerutil.AddFinalizer(&cluster, clusterFinalizerName)
-			if err := c.Client.Update(ctx, &cluster); err != nil {
-				return reconcile.Result{}, err
-			}
-		}
-		log.Info("enqueue cluster")
-		return reconcile.Result{}, c.createCluster(ctx, &cluster, log)
-	}
-
-	// remove finalizer from the server pods and update them.
-	matchingLabels := ctrlruntimeclient.MatchingLabels(map[string]string{"role": "server"})
-	listOpts := &ctrlruntimeclient.ListOptions{Namespace: cluster.Namespace}
-	matchingLabels.ApplyToList(listOpts)
-	if err := c.Client.List(ctx, &podList, listOpts); err != nil {
-		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
-	}
-	for _, pod := range podList.Items {
-		if controllerutil.ContainsFinalizer(&pod, etcdPodFinalizerName) {
-			controllerutil.RemoveFinalizer(&pod, etcdPodFinalizerName)
-			if err := c.Client.Update(ctx, &pod); err != nil {
-				return reconcile.Result{}, err
-			}
-		}
-	}
-
-	if err := c.unbindNodeProxyClusterRole(ctx, &cluster); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if controllerutil.ContainsFinalizer(&cluster, clusterFinalizerName) {
-		// remove finalizer from the cluster and update it.
-		controllerutil.RemoveFinalizer(&cluster, clusterFinalizerName)
-		if err := c.Client.Update(ctx, &cluster); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	log.Info("deleting cluster")
-	return reconcile.Result{}, nil
-}
-
-func (c *ClusterReconciler) createCluster(ctx context.Context, cluster *v1alpha1.Cluster, log *zap.SugaredLogger) error {
 	if err := c.validate(cluster); err != nil {
-		log.Errorw("invalid change", zap.Error(err))
+		log.Error(err, "invalid change")
 		return nil
 	}
+
 	token, err := c.token(ctx, cluster)
 	if err != nil {
 		return err
@@ -340,30 +319,6 @@ func (c *ClusterReconciler) bindNodeProxyClusterRole(ctx context.Context, cluste
 		})
 	}
 
-	return c.Client.Update(ctx, clusterRoleBinding)
-}
-
-func (c *ClusterReconciler) unbindNodeProxyClusterRole(ctx context.Context, cluster *v1alpha1.Cluster) error {
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	if err := c.Client.Get(ctx, types.NamespacedName{Name: "k3k-node-proxy"}, clusterRoleBinding); err != nil {
-		return fmt.Errorf("failed to get or find k3k-node-proxy ClusterRoleBinding: %w", err)
-	}
-
-	subjectName := controller.SafeConcatNameWithPrefix(cluster.Name, agent.SharedNodeAgentName)
-
-	var cleanedSubjects []rbacv1.Subject
-	for _, subject := range clusterRoleBinding.Subjects {
-		if subject.Name != subjectName || subject.Namespace != cluster.Namespace {
-			cleanedSubjects = append(cleanedSubjects, subject)
-		}
-	}
-
-	// if no subject was removed, all good
-	if reflect.DeepEqual(clusterRoleBinding.Subjects, cleanedSubjects) {
-		return nil
-	}
-
-	clusterRoleBinding.Subjects = cleanedSubjects
 	return c.Client.Update(ctx, clusterRoleBinding)
 }
 

--- a/pkg/controller/cluster/cluster_finalize.go
+++ b/pkg/controller/cluster/cluster_finalize.go
@@ -1,0 +1,79 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"github.com/rancher/k3k/pkg/controller"
+	"github.com/rancher/k3k/pkg/controller/cluster/agent"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (c *ClusterReconciler) finalizeCluster(ctx context.Context, cluster v1alpha1.Cluster) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("finalizeCluster")
+
+	// remove finalizer from the server pods and update them.
+	matchingLabels := ctrlruntimeclient.MatchingLabels(map[string]string{"role": "server"})
+	listOpts := &ctrlruntimeclient.ListOptions{Namespace: cluster.Namespace}
+	matchingLabels.ApplyToList(listOpts)
+
+	var podList v1.PodList
+	if err := c.Client.List(ctx, &podList, listOpts); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	for _, pod := range podList.Items {
+		if controllerutil.ContainsFinalizer(&pod, etcdPodFinalizerName) {
+			controllerutil.RemoveFinalizer(&pod, etcdPodFinalizerName)
+			if err := c.Client.Update(ctx, &pod); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
+	if err := c.unbindNodeProxyClusterRole(ctx, &cluster); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if controllerutil.ContainsFinalizer(&cluster, clusterFinalizerName) {
+		// remove finalizer from the cluster and update it.
+		controllerutil.RemoveFinalizer(&cluster, clusterFinalizerName)
+		if err := c.Client.Update(ctx, &cluster); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (c *ClusterReconciler) unbindNodeProxyClusterRole(ctx context.Context, cluster *v1alpha1.Cluster) error {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	if err := c.Client.Get(ctx, types.NamespacedName{Name: "k3k-node-proxy"}, clusterRoleBinding); err != nil {
+		return fmt.Errorf("failed to get or find k3k-node-proxy ClusterRoleBinding: %w", err)
+	}
+
+	subjectName := controller.SafeConcatNameWithPrefix(cluster.Name, agent.SharedNodeAgentName)
+
+	var cleanedSubjects []rbacv1.Subject
+	for _, subject := range clusterRoleBinding.Subjects {
+		if subject.Name != subjectName || subject.Namespace != cluster.Namespace {
+			cleanedSubjects = append(cleanedSubjects, subject)
+		}
+	}
+
+	// if no subject was removed, all good
+	if reflect.DeepEqual(clusterRoleBinding.Subjects, cleanedSubjects) {
+		return nil
+	}
+
+	clusterRoleBinding.Subjects = cleanedSubjects
+	return c.Client.Update(ctx, clusterRoleBinding)
+}

--- a/pkg/controller/cluster/cluster_finalize.go
+++ b/pkg/controller/cluster/cluster_finalize.go
@@ -19,7 +19,7 @@ import (
 
 func (c *ClusterReconciler) finalizeCluster(ctx context.Context, cluster v1alpha1.Cluster) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("finalizeCluster")
+	log.Info("finalizing Cluster")
 
 	// remove finalizer from the server pods and update them.
 	matchingLabels := ctrlruntimeclient.MatchingLabels(map[string]string{"role": "server"})

--- a/pkg/controller/cluster/cluster_suite_test.go
+++ b/pkg/controller/cluster/cluster_suite_test.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/zapr"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	"github.com/rancher/k3k/pkg/controller/cluster"
-	"github.com/rancher/k3k/pkg/log"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -53,11 +53,13 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 
+	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())
-	err = cluster.Add(ctx, mgr, "", "", &log.Logger{SugaredLogger: zap.NewNop().Sugar()})
+	err = cluster.Add(ctx, mgr, "", "")
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/pkg/controller/clusterset/clusterset_suite_test.go
+++ b/pkg/controller/clusterset/clusterset_suite_test.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/zapr"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	"github.com/rancher/k3k/pkg/controller/clusterset"
-	"github.com/rancher/k3k/pkg/log"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,10 +51,10 @@ var _ = BeforeSuite(func() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 
-	ctx, cancel = context.WithCancel(context.Background())
-	nopLogger := &log.Logger{SugaredLogger: zap.NewNop().Sugar()}
+	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))
 
-	err = clusterset.Add(ctx, mgr, "", nopLogger)
+	ctx, cancel = context.WithCancel(context.Background())
+	err = clusterset.Add(ctx, mgr, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/pkg/controller/clusterset/node.go
+++ b/pkg/controller/clusterset/node.go
@@ -73,8 +73,8 @@ func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetLi
 			continue
 		}
 
-		clusterSetLog := log.WithValues("clusterset", cs.Namespace+"/"+cs.Name)
-		clusterSetLog.Info("updating NetworkPolicy for ClusterSet")
+		log = log.WithValues("clusterset", cs.Namespace+"/"+cs.Name)
+		log.Info("updating NetworkPolicy for ClusterSet")
 
 		var err error
 		setNetworkPolicy, err = netpol(ctx, "", &cs, n.Client)
@@ -82,7 +82,7 @@ func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetLi
 			return err
 		}
 
-		clusterSetLog.Info("new NetworkPolicy for clusterset")
+		log.Info("new NetworkPolicy for clusterset")
 		if err := n.Client.Update(ctx, setNetworkPolicy); err != nil {
 			return err
 		}

--- a/pkg/controller/clusterset/node.go
+++ b/pkg/controller/clusterset/node.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
-	"github.com/rancher/k3k/pkg/log"
-	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,16 +22,14 @@ type NodeReconciler struct {
 	Client      ctrlruntimeclient.Client
 	Scheme      *runtime.Scheme
 	ClusterCIDR string
-	logger      *log.Logger
 }
 
 // AddNodeController adds a new controller to the manager
-func AddNodeController(ctx context.Context, mgr manager.Manager, logger *log.Logger) error {
+func AddNodeController(ctx context.Context, mgr manager.Manager) error {
 	// initialize a new Reconciler
 	reconciler := NodeReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		logger: logger.Named(nodeController),
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -46,7 +42,11 @@ func AddNodeController(ctx context.Context, mgr manager.Manager, logger *log.Log
 }
 
 func (n *NodeReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := n.logger.With("Node", req.NamespacedName)
+	log := ctrl.LoggerFrom(ctx).WithValues("node", req.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, log) // enrich the current logger
+
+	log.Info("reconciling node")
+
 	var clusterSetList v1alpha1.ClusterSetList
 	if err := n.Client.List(ctx, &clusterSetList); err != nil {
 		return reconcile.Result{}, err
@@ -56,26 +56,33 @@ func (n *NodeReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := n.ensureNetworkPolicies(ctx, clusterSetList, log); err != nil {
+	if err := n.ensureNetworkPolicies(ctx, clusterSetList); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetList v1alpha1.ClusterSetList, log *zap.SugaredLogger) error {
+func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetList v1alpha1.ClusterSetList) error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("ensuring network policies")
+
 	var setNetworkPolicy *networkingv1.NetworkPolicy
 	for _, cs := range clusterSetList.Items {
 		if cs.Spec.DisableNetworkPolicy {
 			continue
 		}
+
+		clusterSetLog := log.WithValues("clusterset", cs.Namespace+"/"+cs.Name)
+		clusterSetLog.Info("updating NetworkPolicy for ClusterSet")
+
 		var err error
-		log.Infow("Updating NetworkPolicy for ClusterSet", "name", cs.Name, "namespace", cs.Namespace)
 		setNetworkPolicy, err = netpol(ctx, "", &cs, n.Client)
 		if err != nil {
 			return err
 		}
-		log.Debugw("New NetworkPolicy for clusterset", "name", cs.Name, "namespace", cs.Namespace)
+
+		clusterSetLog.Info("new NetworkPolicy for clusterset")
 		if err := n.Client.Update(ctx, setNetworkPolicy); err != nil {
 			return err
 		}


### PR DESCRIPTION
Trying to following some best practices from this article I tried to cleanup a bit the Reconciliation logic, trying to apply the folliwing pattern:

```go
func (m *FooController) Reconcile(..., req ctrl.Request) (ctrl.Result, error) {
    log := ctrl.LoggerFrom(ctx)
    obj := new(apiv1.Foo)
    // 1. Fetch the resource from cache: r.Client.Get(ctx, req.NamespacedName, obj)
    // 2. Finalize object if it's being deleted
    // 3. Add finalizers + r.Client.Update() if missing

    orig := foo.DeepCopy() // take a copy of the object since we'll update it below
    foo.InitializeConditions() // set all conditions to "Unknown", if missing

   // 4. Reconcile the resource and its child resources (the magic happens here).
   //    Calculate the conditions and other "status" fields along the way.
   reconcileErr := r.reconcileKind(ctx, kcp) // magic happens here!

    // 5. if (orig.Status != foo.Status): client.Status.Patch(obj)
}
```

From the snippet I've seen we can use the logger set in the controller-runtime (`ctrl.LoggerFrom(ctx)`), and I moved the finalize/cleanup in a different file (`cluster_finalize.go`).

All the logic was kept as before.

This was done to try to simplify a bit the flow before adding some fixes related to the #170.