### PR TITLE
add flag to override kubernetes server value in the generated kubeconfig

### DIFF
--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -37,18 +37,19 @@ func init() {
 }
 
 var (
-	name             string
-	token            string
-	clusterCIDR      string
-	serviceCIDR      string
-	servers          int64
-	agents           int64
-	serverArgs       cli.StringSlice
-	agentArgs        cli.StringSlice
-	persistenceType  string
-	storageClassName string
-	version          string
-	mode             string
+	name                 string
+	token                string
+	clusterCIDR          string
+	serviceCIDR          string
+	servers              int64
+	agents               int64
+	serverArgs           cli.StringSlice
+	agentArgs            cli.StringSlice
+	persistenceType      string
+	storageClassName     string
+	version              string
+	mode                 string
+	kubeconfigServerHost string
 
 	clusterCreateFlags = []cli.Flag{
 		&cli.StringFlag{
@@ -115,6 +116,12 @@ var (
 			Destination: &mode,
 			Value:       "shared",
 		},
+		&cli.StringFlag{
+			Name:        "kubeconfig-server",
+			Usage:       "override the kubeconfig server host",
+			Destination: &kubeconfigServerHost,
+			Value:       "",
+		},
 	}
 )
 
@@ -169,6 +176,9 @@ func create(clx *cli.Context) error {
 		return err
 	}
 	host := strings.Split(url.Host, ":")
+	if kubeconfigServerHost != "" {
+		host = []string{kubeconfigServerHost}
+	}
 	cluster.Spec.TLSSANs = []string{host[0]}
 
 	if err := ctrlClient.Create(ctx, cluster); err != nil {

--- a/cli/cmds/kubeconfig/kubeconfig.go
+++ b/cli/cmds/kubeconfig/kubeconfig.go
@@ -130,7 +130,10 @@ func generate(clx *cli.Context) error {
 	host := strings.Split(url.Host, ":")
 	if kubeconfigServerHost != "" {
 		host = []string{kubeconfigServerHost}
-		altNames.Set(kubeconfigServerHost)
+		err := altNames.Set(kubeconfigServerHost)
+		if err != nil {
+			return err
+		}
 	}
 
 	certAltNames := certs.AddSANs(altNames.Value())

--- a/cli/cmds/kubeconfig/kubeconfig.go
+++ b/cli/cmds/kubeconfig/kubeconfig.go
@@ -38,6 +38,7 @@ var (
 	altNames                cli.StringSlice
 	expirationDays          int64
 	configName              string
+	kubeconfigServerHost    string
 	generateKubeconfigFlags = []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
@@ -70,6 +71,12 @@ var (
 			Usage:       "Expiration date of the certificates used for the kubeconfig",
 			Destination: &expirationDays,
 			Value:       356,
+		},
+		&cli.StringFlag{
+			Name:        "kubeconfig-server",
+			Usage:       "override the kubeconfig server host",
+			Destination: &kubeconfigServerHost,
+			Value:       "",
 		},
 	}
 )
@@ -121,6 +128,10 @@ func generate(clx *cli.Context) error {
 		return err
 	}
 	host := strings.Split(url.Host, ":")
+	if kubeconfigServerHost != "" {
+		host = []string{kubeconfigServerHost}
+		altNames.Set(kubeconfigServerHost)
+	}
 
 	certAltNames := certs.AddSANs(altNames.Value())
 


### PR DESCRIPTION
When you use a host cluster in Rancher and you get the kubeconfig from Rancher, the K3K generated kubeconfig won't work. The host in `cluster.url` is wrong as it is created using the host kubeconfig which uses the Rancher domain host.

This fix add a flag `kubeconfig-server` allowing the user to override the host of `cluster.url` in the create operation and in the generate kubeconfig operation.

