### PR TITLE
Added test (virtual cluster creation, with pod) and small kubeconfig refactor

### DIFF
--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
@@ -98,7 +99,8 @@ func (c *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		}
 
 		// update Status HostVersion
-		cluster.Status.HostVersion = fmt.Sprintf("v%s.%s.0-k3s1", hostVersion.Major, hostVersion.Minor)
+		k8sVersion := strings.Split(hostVersion.GitVersion, "+")[0]
+		cluster.Status.HostVersion = k8sVersion + "-k3s1"
 		if err := c.Client.Status().Update(ctx, &cluster); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/cluster/cluster_test.go
+++ b/pkg/controller/cluster/cluster_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Cluster Controller", func() {
 
 				serverVersion, err := k8s.DiscoveryClient.ServerVersion()
 				Expect(err).To(Not(HaveOccurred()))
-				expectedHostVersion := fmt.Sprintf("v%s.%s.0-k3s1", serverVersion.Major, serverVersion.Minor)
+				expectedHostVersion := fmt.Sprintf("%s-k3s1", serverVersion.GitVersion)
 
 				Eventually(func() string {
 					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/utils/ptr"
 )
 
 var _ = When("a cluster is installed", func() {
@@ -32,10 +31,11 @@ var _ = When("a cluster is installed", func() {
 	})
 
 	It("will be created in shared mode", func() {
-		containerIP, err := k3sContainer.ContainerIP(context.Background())
+		ctx := context.Background()
+		containerIP, err := k3sContainer.ContainerIP(ctx)
 		Expect(err).To(Not(HaveOccurred()))
 
-		fmt.Fprintln(GinkgoWriter, "ip: "+containerIP)
+		fmt.Fprintln(GinkgoWriter, "K3s containerIP: "+containerIP)
 
 		cluster := v1alpha1.Cluster{
 			ObjectMeta: v1.ObjectMeta{
@@ -43,10 +43,6 @@ var _ = When("a cluster is installed", func() {
 				Namespace: namespace,
 			},
 			Spec: v1alpha1.ClusterSpec{
-				Mode:    v1alpha1.SharedClusterMode,
-				Servers: ptr.To[int32](1),
-				Agents:  ptr.To[int32](0),
-				Version: "v1.26.1-k3s1",
 				TLSSANs: []string{containerIP},
 				Expose: &v1alpha1.ExposeConfig{
 					NodePort: &v1alpha1.NodePortConfig{
@@ -55,66 +51,7 @@ var _ = When("a cluster is installed", func() {
 				},
 			},
 		}
-
-		err = k8sClient.Create(context.Background(), &cluster)
-		Expect(err).To(Not(HaveOccurred()))
-
-		By("checking server and kubelet readiness state")
-
-		// check that the server Pod and the Kubelet are in Ready state
-		Eventually(func() bool {
-			podList, err := k8s.CoreV1().Pods(namespace).List(context.Background(), v1.ListOptions{})
-			Expect(err).To(Not(HaveOccurred()))
-
-			serverRunning := false
-			kubeletRunning := false
-
-			for _, pod := range podList.Items {
-				imageName := pod.Spec.Containers[0].Image
-				imageName = strings.Split(imageName, ":")[0] // remove tag
-
-				switch imageName {
-				case "rancher/k3s":
-					serverRunning = pod.Status.Phase == corev1.PodRunning
-				case "rancher/k3k-kubelet":
-					kubeletRunning = pod.Status.Phase == corev1.PodRunning
-				}
-
-				if serverRunning && kubeletRunning {
-					return true
-				}
-			}
-
-			return false
-		}).
-			WithTimeout(time.Minute).
-			WithPolling(time.Second * 5).
-			Should(BeTrue())
-
-		By("Waiting for server to be ready")
-
-		var config *clientcmdapi.Config
-		Eventually(func() error {
-			vKubeconfig := kubeconfig.New()
-			vKubeconfig.AltNames = certs.AddSANs([]string{containerIP, "k3k-mycluster-kubelet"})
-			config, err = vKubeconfig.Extract(context.Background(), k8sClient, &cluster, containerIP)
-			return err
-		}).
-			WithTimeout(time.Minute * 2).
-			WithPolling(time.Second * 5).
-			Should(BeNil())
-
-		configData, err := clientcmd.Write(*config)
-		Expect(err).To(Not(HaveOccurred()))
-
-		restcfg, err := clientcmd.RESTConfigFromKubeConfig(configData)
-		Expect(err).To(Not(HaveOccurred()))
-		virtualK8sClient, err := kubernetes.NewForConfig(restcfg)
-		Expect(err).To(Not(HaveOccurred()))
-
-		serverVersion, err := virtualK8sClient.DiscoveryClient.ServerVersion()
-		Expect(err).To(Not(HaveOccurred()))
-		fmt.Fprintf(GinkgoWriter, "serverVersion: %+v\n", serverVersion)
+		virtualK8sClient := CreateCluster(containerIP, cluster)
 
 		nginxPod := &corev1.Pod{
 			ObjectMeta: v1.ObjectMeta{
@@ -128,20 +65,23 @@ var _ = When("a cluster is installed", func() {
 				}},
 			},
 		}
-		nginxPod, err = virtualK8sClient.CoreV1().Pods(nginxPod.Namespace).Create(context.Background(), nginxPod, v1.CreateOptions{})
+		nginxPod, err = virtualK8sClient.CoreV1().Pods(nginxPod.Namespace).Create(ctx, nginxPod, v1.CreateOptions{})
 		Expect(err).To(Not(HaveOccurred()))
 
 		// check that the nginx Pod is up and running in the host cluster
 		Eventually(func() bool {
 			//labelSelector := fmt.Sprintf("%s=%s", translate.ClusterNameLabel, cluster.Namespace)
-			podList, err := k8s.CoreV1().Pods(namespace).List(context.Background(), v1.ListOptions{})
+			podList, err := k8s.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{})
 			Expect(err).To(Not(HaveOccurred()))
 
 			for _, pod := range podList.Items {
 				resourceName := pod.Annotations[translate.ResourceNameAnnotation]
 				resourceNamespace := pod.Annotations[translate.ResourceNamespaceAnnotation]
 
-				fmt.Fprintf(GinkgoWriter, "pod=%s resource=%s/%s\n", pod.Name, resourceNamespace, resourceName)
+				fmt.Fprintf(GinkgoWriter,
+					"pod=%s resource=%s/%s status=%s\n",
+					pod.Name, resourceNamespace, resourceName, pod.Status.Phase,
+				)
 
 				if resourceName == nginxPod.Name && resourceNamespace == nginxPod.Namespace {
 					return pod.Status.Phase == corev1.PodRunning
@@ -155,3 +95,72 @@ var _ = When("a cluster is installed", func() {
 			Should(BeTrue())
 	})
 })
+
+func CreateCluster(hostIP string, cluster v1alpha1.Cluster) *kubernetes.Clientset {
+	GinkgoHelper()
+
+	By(fmt.Sprintf("Creating virtual cluster %s/%s", cluster.Namespace, cluster.Name))
+
+	ctx := context.Background()
+	err := k8sClient.Create(ctx, &cluster)
+	Expect(err).To(Not(HaveOccurred()))
+
+	By("Waiting for server and kubelet to be ready")
+
+	// check that the server Pod and the Kubelet are in Ready state
+	Eventually(func() bool {
+		podList, err := k8s.CoreV1().Pods(cluster.Namespace).List(ctx, v1.ListOptions{})
+		Expect(err).To(Not(HaveOccurred()))
+
+		serverRunning := false
+		kubeletRunning := false
+
+		for _, pod := range podList.Items {
+			imageName := pod.Spec.Containers[0].Image
+			imageName = strings.Split(imageName, ":")[0] // remove tag
+
+			switch imageName {
+			case "rancher/k3s":
+				serverRunning = pod.Status.Phase == corev1.PodRunning
+			case "rancher/k3k-kubelet":
+				kubeletRunning = pod.Status.Phase == corev1.PodRunning
+			}
+
+			if serverRunning && kubeletRunning {
+				return true
+			}
+		}
+
+		return false
+	}).
+		WithTimeout(time.Minute).
+		WithPolling(time.Second * 5).
+		Should(BeTrue())
+
+	By("Waiting for server to be up and running")
+
+	var config *clientcmdapi.Config
+	Eventually(func() error {
+		vKubeconfig := kubeconfig.New()
+		vKubeconfig.AltNames = certs.AddSANs([]string{hostIP, "k3k-mycluster-kubelet"})
+		config, err = vKubeconfig.Extract(ctx, k8sClient, &cluster, hostIP)
+		return err
+	}).
+		WithTimeout(time.Minute * 2).
+		WithPolling(time.Second * 5).
+		Should(BeNil())
+
+	configData, err := clientcmd.Write(*config)
+	Expect(err).To(Not(HaveOccurred()))
+
+	restcfg, err := clientcmd.RESTConfigFromKubeConfig(configData)
+	Expect(err).To(Not(HaveOccurred()))
+	virtualK8sClient, err := kubernetes.NewForConfig(restcfg)
+	Expect(err).To(Not(HaveOccurred()))
+
+	serverVersion, err := virtualK8sClient.DiscoveryClient.ServerVersion()
+	Expect(err).To(Not(HaveOccurred()))
+	fmt.Fprintf(GinkgoWriter, "serverVersion: %+v\n", serverVersion)
+
+	return virtualK8sClient
+}

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -8,9 +8,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rancher/k3k/k3k-kubelet/translate"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"github.com/rancher/k3k/pkg/controller/certs"
+	"github.com/rancher/k3k/pkg/controller/kubeconfig"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/ptr"
 )
 
@@ -26,6 +32,11 @@ var _ = When("a cluster is installed", func() {
 	})
 
 	It("will be created in shared mode", func() {
+		containerIP, err := k3sContainer.ContainerIP(context.Background())
+		Expect(err).To(Not(HaveOccurred()))
+
+		fmt.Fprintln(GinkgoWriter, "ip: "+containerIP)
+
 		cluster := v1alpha1.Cluster{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "mycluster",
@@ -36,10 +47,16 @@ var _ = When("a cluster is installed", func() {
 				Servers: ptr.To[int32](1),
 				Agents:  ptr.To[int32](0),
 				Version: "v1.26.1-k3s1",
+				TLSSANs: []string{containerIP},
+				Expose: &v1alpha1.ExposeConfig{
+					NodePort: &v1alpha1.NodePortConfig{
+						Enabled: true,
+					},
+				},
 			},
 		}
 
-		err := k8sClient.Create(context.Background(), &cluster)
+		err = k8sClient.Create(context.Background(), &cluster)
 		Expect(err).To(Not(HaveOccurred()))
 
 		By("checking server and kubelet readiness state")
@@ -74,15 +91,67 @@ var _ = When("a cluster is installed", func() {
 			WithPolling(time.Second * 5).
 			Should(BeTrue())
 
-		By("checking the existence of the bootstrap secret")
-		secretName := fmt.Sprintf("k3k-%s-bootstrap", cluster.Name)
+		By("Waiting for server to be ready")
 
+		var config *clientcmdapi.Config
 		Eventually(func() error {
-			_, err := k8s.CoreV1().Secrets(namespace).Get(context.Background(), secretName, v1.GetOptions{})
+			vKubeconfig := kubeconfig.New()
+			vKubeconfig.AltNames = certs.AddSANs([]string{containerIP, "k3k-mycluster-kubelet"})
+			config, err = vKubeconfig.Extract(context.Background(), k8sClient, &cluster, containerIP)
 			return err
 		}).
 			WithTimeout(time.Minute * 2).
 			WithPolling(time.Second * 5).
 			Should(BeNil())
+
+		configData, err := clientcmd.Write(*config)
+		Expect(err).To(Not(HaveOccurred()))
+
+		restcfg, err := clientcmd.RESTConfigFromKubeConfig(configData)
+		Expect(err).To(Not(HaveOccurred()))
+		virtualK8sClient, err := kubernetes.NewForConfig(restcfg)
+		Expect(err).To(Not(HaveOccurred()))
+
+		serverVersion, err := virtualK8sClient.DiscoveryClient.ServerVersion()
+		Expect(err).To(Not(HaveOccurred()))
+		fmt.Fprintf(GinkgoWriter, "serverVersion: %+v\n", serverVersion)
+
+		nginxPod := &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "nginx",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "nginx",
+					Image: "nginx",
+				}},
+			},
+		}
+		nginxPod, err = virtualK8sClient.CoreV1().Pods(nginxPod.Namespace).Create(context.Background(), nginxPod, v1.CreateOptions{})
+		Expect(err).To(Not(HaveOccurred()))
+
+		// check that the nginx Pod is up and running in the host cluster
+		Eventually(func() bool {
+			//labelSelector := fmt.Sprintf("%s=%s", translate.ClusterNameLabel, cluster.Namespace)
+			podList, err := k8s.CoreV1().Pods(namespace).List(context.Background(), v1.ListOptions{})
+			Expect(err).To(Not(HaveOccurred()))
+
+			for _, pod := range podList.Items {
+				resourceName := pod.Annotations[translate.ResourceNameAnnotation]
+				resourceNamespace := pod.Annotations[translate.ResourceNamespaceAnnotation]
+
+				fmt.Fprintf(GinkgoWriter, "pod=%s resource=%s/%s\n", pod.Name, resourceNamespace, resourceName)
+
+				if resourceName == nginxPod.Name && resourceNamespace == nginxPod.Namespace {
+					return pod.Status.Phase == corev1.PodRunning
+				}
+			}
+
+			return false
+		}).
+			WithTimeout(time.Minute).
+			WithPolling(time.Second * 5).
+			Should(BeTrue())
 	})
 })

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -173,7 +173,11 @@ var _ = When("k3k is installed", func() {
 
 func buildScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
+
+	err := corev1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	return scheme
 }


### PR DESCRIPTION
Ref:
- #166 
---

This PR adds a test that creates a virtual cluster, and create a Nginx pod in the virtual cluster.

It adds also a small fix to get the proper host patch version

```go
k8sVersion := strings.Split(hostVersion.GitVersion, "+")[0]
cluster.Status.HostVersion = k8sVersion + "-k3s1"
```

and a small refactor of the kubeconfig generation, moving the bootstrap GetSecret in the bootstrap package.