### PR TITLE
fix ingress creation, use the ingress host in Kubeconfig when enabled

### DIFF
--- a/pkg/controller/cluster/server/ingress.go
+++ b/pkg/controller/cluster/server/ingress.go
@@ -91,3 +91,6 @@ func configureIngressOptions(ingress *networkingv1.Ingress, ingressClassName str
 		ingress.Annotations[nginxBackendProtocolAnnotation] = "HTTPS"
 	}
 }
+func IngressName(clusterName string) string {
+	return controller.SafeConcatNameWithPrefix(clusterName, "ingress")
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -68,12 +68,10 @@ func Addresses(ctx context.Context, client ctrlruntimeclient.Client) ([]string, 
 	if err := client.List(ctx, &nodeList); err != nil {
 		return nil, err
 	}
-
-	addresses := make([]string, len(nodeList.Items))
+	addresses := []string{}
 	for _, node := range nodeList.Items {
 		addresses = append(addresses, nodeAddress(&node))
 	}
-
 	return addresses, nil
 }
 


### PR DESCRIPTION
Fix the ingress creation when using `expose.ingress`. 
The list of `addresses` where created using `addresses := make([]string, len(nodeList.Items))` which lead unintentionally to a non empty list. Therefore the resulting Ingress object has spec issue and is not applied. 

Use the `ingress` host when enabled in the generated Kubeconfig instead of the default `serviceIP`