### PR TITLE
fix ingress creation, use the ingress host in Kubeconfig when enabled

### DIFF
--- a/pkg/controller/cluster/server/ingress.go
+++ b/pkg/controller/cluster/server/ingress.go
@@ -91,3 +91,6 @@ func configureIngressOptions(ingress *networkingv1.Ingress, ingressClassName str
 		ingress.Annotations[nginxBackendProtocolAnnotation] = "HTTPS"
 	}
 }
+func IngressName(clusterName string) string {
+	return controller.SafeConcatNameWithPrefix(clusterName, "ingress")
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -70,8 +70,8 @@ func Addresses(ctx context.Context, client ctrlruntimeclient.Client) ([]string, 
 	}
 
 	addresses := make([]string, len(nodeList.Items))
-	for _, node := range nodeList.Items {
-		addresses = append(addresses, nodeAddress(&node))
+	for i, node := range nodeList.Items {
+		addresses[i] = nodeAddress(&node)
 	}
 
 	return addresses, nil

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -106,7 +106,7 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1alp
 		nodePort := k3kService.Spec.Ports[0].NodePort
 		url = fmt.Sprintf("https://%s:%d", hostServerIP, nodePort)
 	}
-	if cluster.Spec.Expose.Ingress.Enabled {
+	if cluster.Spec.Expose.Ingress != nil && cluster.Spec.Expose.Ingress.Enabled {
 		var k3kIngress networkingv1.Ingress
 		ingressKey := types.NamespacedName{
 			Name:      server.IngressName(cluster.Name),

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -54,7 +54,7 @@ func (k *KubeConfig) Extract(ctx context.Context, client client.Client, cluster 
 	if err != nil {
 		return nil, err
 	}
-  
+
 	url, err := getURLFromService(ctx, client, cluster, hostServerIP)
 	if err != nil {
 		return nil, err
@@ -106,9 +106,9 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1alp
 		nodePort := k3kService.Spec.Ports[0].NodePort
 		url = fmt.Sprintf("https://%s:%d", hostServerIP, nodePort)
 	}
-  if cluster.Spec.Expose.Ingress.Enabled {
+	if cluster.Spec.Expose.Ingress.Enabled {
 		var k3kIngress networkingv1.Ingress
-		ingressKey = types.NamespacedName{
+		ingressKey := types.NamespacedName{
 			Name:      server.IngressName(cluster.Name),
 			Namespace: cluster.Namespace,
 		}

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/k3k/pkg/controller/cluster/server"
 	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -72,6 +73,18 @@ func (k *KubeConfig) Extract(ctx context.Context, client client.Client, cluster 
 	if k3kService.Spec.Type == v1.ServiceTypeNodePort {
 		nodePort := k3kService.Spec.Ports[0].NodePort
 		url = fmt.Sprintf("https://%s:%d", hostServerIP, nodePort)
+	}
+	if cluster.Spec.Expose.Ingress.Enabled {
+		var k3kIngress networkingv1.Ingress
+		nn = types.NamespacedName{
+			Name:      server.IngressName(cluster.Name),
+			Namespace: cluster.Namespace,
+		}
+
+		if err := client.Get(ctx, nn, &k3kIngress); err != nil {
+			return nil, err
+		}
+		url = fmt.Sprintf("https://%s", k3kIngress.Spec.Rules[0].Host)
 	}
 	kubeconfigData, err := kubeconfig(url, []byte(bootstrap.ServerCA.Content), adminCert, adminKey)
 	if err != nil {


### PR DESCRIPTION
The `ingress.spec.rules.host` was badly formed when using a cluster with  `expose.ingress`. 
This was due to `nodeAddress` not being properly added to the `addresses` list. 

Also added the use of the `ingress` host when generating the kubeconfig over the default `service.ClusterIP`

This is a quick fix to have the feature working again. We should consider improving the UX for the ingress exposition. 