### PR TITLE
Add initial support for daemonsets

### DIFF
--- a/k3k-kubelet/config.go
+++ b/k3k-kubelet/config.go
@@ -11,7 +11,7 @@ import (
 type config struct {
 	ClusterName       string `yaml:"clusterName,omitempty"`
 	ClusterNamespace  string `yaml:"clusterNamespace,omitempty"`
-	NodeName          string `yaml:"nodeName,omitempty"`
+	ServiceName       string `yaml:"serviceName,omitempty"`
 	Token             string `yaml:"token,omitempty"`
 	AgentHostname     string `yaml:"agentHostname,omitempty"`
 	HostConfigPath    string `yaml:"hostConfigPath,omitempty"`
@@ -46,8 +46,8 @@ func (c *config) unmarshalYAML(data []byte) error {
 	if c.AgentHostname == "" {
 		c.AgentHostname = conf.AgentHostname
 	}
-	if c.NodeName == "" {
-		c.NodeName = conf.NodeName
+	if c.ServiceName == "" {
+		c.ServiceName = conf.ServiceName
 	}
 	if c.Token == "" {
 		c.Token = conf.Token

--- a/k3k-kubelet/controller/webhook/pod.go
+++ b/k3k-kubelet/controller/webhook/pod.go
@@ -33,6 +33,7 @@ type webhookHandler struct {
 	client           ctrlruntimeclient.Client
 	scheme           *runtime.Scheme
 	nodeName         string
+	serviceName      string
 	clusterName      string
 	clusterNamespace string
 	logger           *log.Logger
@@ -41,11 +42,12 @@ type webhookHandler struct {
 // AddPodMutatorWebhook will add a mutator webhook to the virtual cluster to
 // modify the nodeName of the created pods with the name of the virtual kubelet node name
 // as well as remove any status fields of the downward apis env fields
-func AddPodMutatorWebhook(ctx context.Context, mgr manager.Manager, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace, nodeName string, logger *log.Logger) error {
+func AddPodMutatorWebhook(ctx context.Context, mgr manager.Manager, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace, nodeName, serviceName string, logger *log.Logger) error {
 	handler := webhookHandler{
 		client:           mgr.GetClient(),
 		scheme:           mgr.GetScheme(),
 		logger:           logger,
+		serviceName:      serviceName,
 		clusterName:      clusterName,
 		clusterNamespace: clusterNamespace,
 		nodeName:         nodeName,
@@ -107,7 +109,7 @@ func (w *webhookHandler) configuration(ctx context.Context, hostClient ctrlrunti
 	if !ok {
 		return nil, errors.New("webhook CABundle does not exist in secret")
 	}
-	webhookURL := "https://" + w.nodeName + ":" + webhookPort + webhookPath
+	webhookURL := "https://" + w.serviceName + ":" + webhookPort + webhookPath
 	return &admissionregistrationv1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "admissionregistration.k8s.io/v1",

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -127,7 +127,7 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 		return nil, errors.New("unable to create controller-runtime mgr for virtual cluster: " + err.Error())
 	}
 	logger.Info("adding pod mutator webhook")
-	if err := k3kwebhook.AddPodMutatorWebhook(ctx, virtualMgr, hostClient, c.ClusterName, c.ClusterNamespace, c.NodeName, logger); err != nil {
+	if err := k3kwebhook.AddPodMutatorWebhook(ctx, virtualMgr, hostClient, c.ClusterName, c.ClusterNamespace, c.AgentHostname, c.ServiceName, logger); err != nil {
 		return nil, errors.New("unable to add pod mutator webhook for virtual cluster: " + err.Error())
 	}
 
@@ -141,7 +141,7 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 		return nil, errors.New("failed to add pvc syncer controller: " + err.Error())
 	}
 
-	clusterIP, err := clusterIP(ctx, c.AgentHostname, c.ClusterNamespace, hostClient)
+	clusterIP, err := clusterIP(ctx, c.ServiceName, c.ClusterNamespace, hostClient)
 	if err != nil {
 		return nil, errors.New("failed to extract the clusterIP for the server service: " + err.Error())
 	}
@@ -161,7 +161,7 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 	return &kubelet{
 		virtualCluster: virtualCluster,
 
-		name:       c.NodeName,
+		name:       c.AgentHostname,
 		hostConfig: hostConfig,
 		hostClient: hostClient,
 		virtConfig: virtConfig,

--- a/k3k-kubelet/main.go
+++ b/k3k-kubelet/main.go
@@ -62,6 +62,12 @@ func main() {
 			Value:       "10250",
 		},
 		&cli.StringFlag{
+			Name:        "service-name",
+			Usage:       "The service name deployed by the k3k controller",
+			Destination: &cfg.ServiceName,
+			EnvVars:     []string{"SERVICE_NAME"},
+		},
+		&cli.StringFlag{
 			Name:        "agent-hostname",
 			Usage:       "Agent Hostname used for TLS SAN for the kubelet server",
 			Destination: &cfg.AgentHostname,


### PR DESCRIPTION
This PR adds initial support for daemonsets, it basically register a pseudo node with the same name as the node in which k3k-kubelet is deployed, this will enable the creation of daemonsets pods, this should only be an initial support for the feature, however optimally the full feature should enable having a node selector and registering the node selected in the cluster.spec.NodeSelector

- #216 