### PR TITLE
Fix status update, updated k3s default version, updated CRDs

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -164,7 +164,7 @@ spec:
                     type: string
                   type:
                     default: ephemeral
-                    description: Type can be ephermal, static, dynamic
+                    description: Type can be ephemeral, static, dynamic
                     type: string
                 required:
                 - type
@@ -238,7 +238,7 @@ spec:
                     type: string
                   type:
                     default: ephemeral
-                    description: Type can be ephermal, static, dynamic
+                    description: Type can be ephemeral, static, dynamic
                     type: string
                 required:
                 - type

--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -107,7 +107,6 @@ var (
 			Name:        "version",
 			Usage:       "k3s version",
 			Destination: &version,
-			Value:       "v1.26.1-k3s1",
 		},
 		&cli.StringFlag{
 			Name:        "mode",

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 			Name:        "shared-agent-image",
 			EnvVars:     []string{"SHARED_AGENT_IMAGE"},
 			Usage:       "K3K Virtual Kubelet image",
-			Value:       "rancher/k3k:k3k-kubelet-dev",
+			Value:       "rancher/k3k:latest",
 			Destination: &sharedAgentImage,
 		},
 		&cli.StringFlag{

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -104,7 +104,7 @@ func (c *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	orig := cluster.DeepCopy()
 
-	reconcileErr := c.reconcileCluster(ctx, &cluster)
+	reconcilerErr := c.reconcileCluster(ctx, &cluster)
 
 	// update Status if needed
 	if !reflect.DeepEqual(orig.Status, cluster.Status) {
@@ -114,8 +114,8 @@ func (c *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	// if there was an error during the reconciliation, return
-	if reconcileErr != nil {
-		return reconcile.Result{}, reconcileErr
+	if reconcilerErr != nil {
+		return reconcile.Result{}, reconcilerErr
 	}
 
 	// update Cluster if needed

--- a/pkg/controller/cluster/cluster_suite_test.go
+++ b/pkg/controller/cluster/cluster_suite_test.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,7 +60,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())
-	err = cluster.Add(ctx, mgr, "", "")
+	err = cluster.Add(ctx, mgr, "rancher/k3k-kubelet:latest", "")
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
@@ -81,6 +82,8 @@ func buildScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
 	err := corev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = rbacv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = appsv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/cluster/cluster_test.go
+++ b/pkg/controller/cluster/cluster_test.go
@@ -56,13 +56,11 @@ var _ = Describe("Cluster Controller", func() {
 				Eventually(func() string {
 					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
 					Expect(err).To(Not(HaveOccurred()))
-
-					fmt.Println("cluster.Status.HostVersion:", cluster.Status.HostVersion)
 					return cluster.Status.HostVersion
 
 				}).
-					WithTimeout(time.Minute * 2).
-					WithPolling(time.Second * 5).
+					WithTimeout(time.Second * 30).
+					WithPolling(time.Second).
 					Should(Equal(expectedHostVersion))
 			})
 		})

--- a/pkg/controller/cluster/cluster_test.go
+++ b/pkg/controller/cluster/cluster_test.go
@@ -56,11 +56,13 @@ var _ = Describe("Cluster Controller", func() {
 				Eventually(func() string {
 					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
 					Expect(err).To(Not(HaveOccurred()))
+
+					fmt.Println("cluster.Status.HostVersion:", cluster.Status.HostVersion)
 					return cluster.Status.HostVersion
 
 				}).
-					WithTimeout(time.Second * 30).
-					WithPolling(time.Second).
+					WithTimeout(time.Minute * 2).
+					WithPolling(time.Second * 5).
 					Should(Equal(expectedHostVersion))
 			})
 		})

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -42,6 +43,7 @@ func Generate(ctx context.Context, cluster *v1alpha1.Cluster, ip, token string) 
 	}, func() error {
 		var err error
 		bootstrap, err = requestBootstrap(token, ip)
+		fmt.Println("err bootstrap", err)
 		return err
 	}); err != nil {
 		return nil, err

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -43,7 +43,7 @@ var _ = BeforeSuite(func() {
 	var err error
 	ctx := context.Background()
 
-	k3sContainer, err = k3s.Run(ctx, "rancher/k3s:v1.27.1-k3s1")
+	k3sContainer, err = k3s.Run(ctx, "rancher/k3s:v1.32.1-k3s1")
 	Expect(err).To(Not(HaveOccurred()))
 
 	kubeconfig, err := k3sContainer.GetKubeConfig(context.Background())


### PR DESCRIPTION
Few fixes including:
- removed default from `k3kcli cluster create` (default to host version)
- updated CRDs from typo description (missed add file)
- fix for missing status update

For the last bullet point we were doing the cluster update in the reconcile function, and the status in the other one. It means that the first update was not updating the status that was just reset to the original.

Now doing the updates in the same func, backing up the updated status, works.