### PR TITLE
Fix Webhook certificate recreate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/rancher/dynamiclistener v1.27.5
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.35.0
 	github.com/urfave/cli/v2 v2.27.5
@@ -161,7 +162,6 @@ require (
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -1,28 +1,44 @@
 package agent
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	"github.com/rancher/k3k/pkg/controller"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
 	configName = "agent-config"
 )
 
-type Agent interface {
-	Name() string
-	Config() ctrlruntimeclient.Object
-	Resources() ([]ctrlruntimeclient.Object, error)
-}
-
-func New(cluster *v1alpha1.Cluster, serviceIP, sharedAgentImage, sharedAgentImagePullPolicy, token string) Agent {
-	if cluster.Spec.Mode == VirtualNodeMode {
-		return NewVirtualAgent(cluster, serviceIP, token)
-	}
-	return NewSharedAgent(cluster, serviceIP, sharedAgentImage, sharedAgentImagePullPolicy, token)
-}
-
 func configSecretName(clusterName string) string {
 	return controller.SafeConcatNameWithPrefix(clusterName, configName)
+}
+
+func (s *SharedAgent) ensureObject(ctx context.Context, obj ctrlruntimeclient.Object) error {
+	return ensureObject(ctx, s.cluster, obj, s.client, s.scheme)
+}
+
+func (v *VirtualAgent) ensureObject(ctx context.Context, obj ctrlruntimeclient.Object) error {
+	return ensureObject(ctx, v.cluster, obj, v.client, v.scheme)
+}
+
+func ensureObject(ctx context.Context, cluster *v1alpha1.Cluster, obj ctrlruntimeclient.Object, ctrlClient ctrlruntimeclient.Client, scheme *runtime.Scheme) error {
+	result, err := controllerutil.CreateOrUpdate(ctx, ctrlClient, obj, func() error {
+		fmt.Printf("call FN mut %v - %s\n", cluster, client.ObjectKeyFromObject(obj))
+
+		if err := controllerutil.SetControllerReference(cluster, obj, scheme); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	fmt.Printf("ensureObject %s - %s\n", result, client.ObjectKeyFromObject(obj))
+
+	return err
 }

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -44,7 +44,7 @@ func ensureObject(ctx context.Context, cfg *Config, obj ctrlruntimeclient.Object
 
 	if result != controllerutil.OperationResultNone {
 		key := client.ObjectKeyFromObject(obj)
-		log.Info(fmt.Sprintf("ensureObject: %T object %s was %s", obj, key, result))
+		log.Info(fmt.Sprintf("ensuring %T", obj), "key", key, "result, result")
 	}
 
 	return err

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -17,6 +17,10 @@ const (
 	configName = "agent-config"
 )
 
+type ResourceEnsurer interface {
+	EnsureResources(context.Context) error
+}
+
 type Config struct {
 	cluster *v1alpha1.Cluster
 	client  ctrlruntimeclient.Client

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -44,8 +44,7 @@ func ensureObject(ctx context.Context, cfg *Config, obj ctrlruntimeclient.Object
 
 	if result != controllerutil.OperationResultNone {
 		key := client.ObjectKeyFromObject(obj)
-		objectKind := obj.GetObjectKind().GroupVersionKind().Kind
-		log.Info(fmt.Sprintf("ensureObject: %s object %s was %s", objectKind, key, result))
+		log.Info(fmt.Sprintf("ensureObject: %T object %s was %s", obj, key, result))
 	}
 
 	return err

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -44,7 +44,8 @@ func ensureObject(ctx context.Context, cfg *Config, obj ctrlruntimeclient.Object
 
 	if result != controllerutil.OperationResultNone {
 		key := client.ObjectKeyFromObject(obj)
-		log.Info(fmt.Sprintf("ensureObject: object %s was %s", key, result))
+		objectKind := obj.GetObjectKind().GroupVersionKind().Kind
+		log.Info(fmt.Sprintf("ensureObject: %s object %s was %s", objectKind, key, result))
 	}
 
 	return err

--- a/pkg/controller/cluster/agent/agent.go
+++ b/pkg/controller/cluster/agent/agent.go
@@ -38,15 +38,12 @@ func configSecretName(clusterName string) string {
 func ensureObject(ctx context.Context, cfg *Config, obj ctrlruntimeclient.Object) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	key := client.ObjectKeyFromObject(obj)
 	result, err := controllerutil.CreateOrUpdate(ctx, cfg.client, obj, func() error {
-		if err := controllerutil.SetControllerReference(cfg.cluster, obj, cfg.scheme); err != nil {
-			return err
-		}
-		return nil
+		return controllerutil.SetControllerReference(cfg.cluster, obj, cfg.scheme)
 	})
 
 	if result != controllerutil.OperationResultNone {
+		key := client.ObjectKeyFromObject(obj)
 		log.Info(fmt.Sprintf("ensureObject: object %s was %s", key, result))
 	}
 

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -62,7 +62,7 @@ func (s *SharedAgent) EnsureResources(ctx context.Context) error {
 		s.dnsService(ctx),
 		s.webhookTLS(ctx),
 	); err != nil {
-		return fmt.Errorf("failed to ensure some kubelet resources: %w\n", err)
+		return fmt.Errorf("failed to ensure some resources: %w\n", err)
 	}
 
 	return nil

--- a/pkg/controller/cluster/agent/shared_test.go
+++ b/pkg/controller/cluster/agent/shared_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_sharedAgentData(t *testing.T) {
+	type args struct {
+		cluster     *v1alpha1.Cluster
+		serviceName string
+		ip          string
+		token       string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedData map[string]string
+	}{
+		{
+			name: "simple config",
+			args: args{
+				cluster: &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "mycluster",
+						Namespace: "ns-1",
+					},
+					Spec: v1alpha1.ClusterSpec{
+						Version: "v1.2.3",
+					},
+				},
+				ip:          "10.0.0.21",
+				serviceName: "service-name",
+				token:       "dnjklsdjnksd892389238",
+			},
+			expectedData: map[string]string{
+				"clusterName":      "mycluster",
+				"clusterNamespace": "ns-1",
+				"serverIP":         "10.0.0.21",
+				"serviceName":      "service-name",
+				"token":            "dnjklsdjnksd892389238",
+				"version":          "v1.2.3",
+			},
+		},
+		{
+			name: "version in status",
+			args: args{
+				cluster: &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "mycluster",
+						Namespace: "ns-1",
+					},
+					Spec: v1alpha1.ClusterSpec{
+						Version: "v1.2.3",
+					},
+					Status: v1alpha1.ClusterStatus{
+						HostVersion: "v1.3.3",
+					},
+				},
+				ip:          "10.0.0.21",
+				serviceName: "service-name",
+				token:       "dnjklsdjnksd892389238",
+			},
+			expectedData: map[string]string{
+				"clusterName":      "mycluster",
+				"clusterNamespace": "ns-1",
+				"serverIP":         "10.0.0.21",
+				"serviceName":      "service-name",
+				"token":            "dnjklsdjnksd892389238",
+				"version":          "v1.2.3",
+			},
+		},
+		{
+			name: "missing version in spec",
+			args: args{
+				cluster: &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "mycluster",
+						Namespace: "ns-1",
+					},
+					Status: v1alpha1.ClusterStatus{
+						HostVersion: "v1.3.3",
+					},
+				},
+				ip:          "10.0.0.21",
+				serviceName: "service-name",
+				token:       "dnjklsdjnksd892389238",
+			},
+			expectedData: map[string]string{
+				"clusterName":      "mycluster",
+				"clusterNamespace": "ns-1",
+				"serverIP":         "10.0.0.21",
+				"serviceName":      "service-name",
+				"token":            "dnjklsdjnksd892389238",
+				"version":          "v1.3.3",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := sharedAgentData(tt.args.cluster, tt.args.serviceName, tt.args.token, tt.args.ip)
+
+			data := make(map[string]string)
+			err := yaml.Unmarshal([]byte(config), data)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedData, data)
+		})
+	}
+}

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -41,7 +41,7 @@ func (v *VirtualAgent) EnsureResources(ctx context.Context) error {
 		v.config(ctx),
 		v.deployment(ctx),
 	); err != nil {
-		return fmt.Errorf("failed to ensure some kubelet resources: %w\n", err)
+		return fmt.Errorf("failed to ensure some resources: %w\n", err)
 	}
 
 	return nil

--- a/pkg/controller/cluster/agent/virtual_test.go
+++ b/pkg/controller/cluster/agent/virtual_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func Test_virtualAgentData(t *testing.T) {
+	type args struct {
+		serviceIP string
+		token     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				serviceIP: "10.0.0.21",
+			},
+			want: "server: https://%s:6443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := virtualAgentData(tt.args.serviceIP, tt.args.token)
+
+			data := make(map[string]string)
+			err := yaml.Unmarshal([]byte(config), data)
+			assert.NoError(t, err)
+			fmt.Println(data)
+		})
+	}
+}

--- a/pkg/controller/cluster/agent/virtual_test.go
+++ b/pkg/controller/cluster/agent/virtual_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,16 +13,21 @@ func Test_virtualAgentData(t *testing.T) {
 		token     string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name         string
+		args         args
+		expectedData map[string]string
 	}{
 		{
-			name: "test",
+			name: "simple config",
 			args: args{
 				serviceIP: "10.0.0.21",
+				token:     "dnjklsdjnksd892389238",
 			},
-			want: "server: https://%s:6443",
+			expectedData: map[string]string{
+				"server":       "https://10.0.0.21:6443",
+				"token":        "dnjklsdjnksd892389238",
+				"with-node-id": "true",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -32,8 +36,9 @@ func Test_virtualAgentData(t *testing.T) {
 
 			data := make(map[string]string)
 			err := yaml.Unmarshal([]byte(config), data)
+
 			assert.NoError(t, err)
-			fmt.Println(data)
+			assert.Equal(t, tt.expectedData, data)
 		})
 	}
 }

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -341,7 +341,7 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 
 	if result != controllerutil.OperationResultNone {
 		key := client.ObjectKeyFromObject(serverStatefulSet)
-		log.Info(fmt.Sprintf("ensureObject: object %s was %s", key, result))
+		log.Info(fmt.Sprintf("ensureObject: serverStatefulSet %s was %s", key, result))
 	}
 
 	return err

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -341,7 +341,7 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 
 	if result != controllerutil.OperationResultNone {
 		key := client.ObjectKeyFromObject(serverStatefulSet)
-		log.Info(fmt.Sprintf("ensureObject: serverStatefulSet %s was %s", key, result))
+		log.Info("ensuring serverStatefulSet", "key", key, "result", result)
 	}
 
 	return err

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -326,20 +327,24 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 			return err
 		}
 	}
+
 	ServerStatefulSet, err := server.StatefulServer(ctx)
 	if err != nil {
 		return err
 	}
 
-	if err := controllerutil.SetControllerReference(cluster, ServerStatefulSet, c.Scheme); err != nil {
-		return err
-	}
+	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, ServerStatefulSet, func() error {
+		fmt.Printf("call FN mut %v - %s\n", cluster, client.ObjectKeyFromObject(ServerStatefulSet))
 
-	if err := c.ensure(ctx, ServerStatefulSet, false); err != nil {
-		return err
-	}
+		if err := controllerutil.SetControllerReference(cluster, ServerStatefulSet, c.Scheme); err != nil {
+			return err
+		}
+		return nil
+	})
 
-	return nil
+	fmt.Printf("ensureObject %s - %s\n", result, client.ObjectKeyFromObject(ServerStatefulSet))
+
+	return err
 }
 
 func (c *ClusterReconciler) bindNodeProxyClusterRole(ctx context.Context, cluster *v1alpha1.Cluster) error {
@@ -382,71 +387,6 @@ func (c *ClusterReconciler) agent(ctx context.Context, cluster *v1alpha1.Cluster
 func (c *ClusterReconciler) validate(cluster *v1alpha1.Cluster) error {
 	if cluster.Name == ClusterInvalidName {
 		return errors.New("invalid cluster name " + cluster.Name + " no action will be taken")
-	}
-	return nil
-}
-
-func (c *ClusterReconciler) ensureAll(ctx context.Context, cluster *v1alpha1.Cluster, objs []ctrlruntimeclient.Object) error {
-	for _, obj := range objs {
-		if err := controllerutil.SetControllerReference(cluster, obj, c.Scheme); err != nil {
-			return err
-		}
-		if err := c.ensure(ctx, obj, false); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *ClusterReconciler) ensure(ctx context.Context, obj ctrlruntimeclient.Object, requiresRecreate bool) error {
-	exists := true
-	existingObject := obj.DeepCopyObject().(ctrlruntimeclient.Object)
-	if err := c.Client.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, existingObject); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get Object(%T): %w", existingObject, err)
-		}
-		exists = false
-	}
-
-	if !exists {
-		// if not exists create object
-		if err := c.Client.Create(ctx, obj); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// if exists then apply udpate or recreate if necessary
-	if reflect.DeepEqual(obj.(metav1.Object), existingObject.(metav1.Object)) {
-		return nil
-	}
-
-	// 	"k8s.io/apimachinery/pkg/api/equality"
-	// equality.Semantic.DeepEqual()
-
-	existingObjName := existingObject.(metav1.Object).GetName()
-	existingObjKind := existingObject.GetObjectKind().GroupVersionKind().Kind
-
-	fmt.Printf("Exists and not equal! UPDATE %s - %s\n", existingObjName, existingObjKind)
-
-	// do not update webhook
-	if existingObjKind == "Secret" && strings.Contains(existingObjName, "webhook") {
-		fmt.Println("Skip webhook secret update")
-		return nil
-	}
-
-	if !requiresRecreate {
-		if err := c.Client.Update(ctx, obj); err != nil {
-			return err
-		}
-	} else {
-		// this handles object that needs recreation including configmaps and secrets
-		if err := c.Client.Delete(ctx, obj); err != nil {
-			return err
-		}
-		if err := c.Client.Create(ctx, obj); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -335,15 +335,12 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 		return err
 	}
 
-	key := client.ObjectKeyFromObject(serverStatefulSet)
 	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, serverStatefulSet, func() error {
-		if err := controllerutil.SetControllerReference(cluster, serverStatefulSet, c.Scheme); err != nil {
-			return err
-		}
-		return nil
+		return controllerutil.SetControllerReference(cluster, serverStatefulSet, c.Scheme)
 	})
 
 	if result != controllerutil.OperationResultNone {
+		key := client.ObjectKeyFromObject(serverStatefulSet)
 		log.Info(fmt.Sprintf("ensureObject: object %s was %s", key, result))
 	}
 

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -330,14 +330,14 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 		}
 	}
 
-	ServerStatefulSet, err := server.StatefulServer(ctx)
+	serverStatefulSet, err := server.StatefulServer(ctx)
 	if err != nil {
 		return err
 	}
 
-	key := client.ObjectKeyFromObject(ServerStatefulSet)
-	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, ServerStatefulSet, func() error {
-		if err := controllerutil.SetControllerReference(cluster, ServerStatefulSet, c.Scheme); err != nil {
+	key := client.ObjectKeyFromObject(serverStatefulSet)
+	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, serverStatefulSet, func() error {
+		if err := controllerutil.SetControllerReference(cluster, serverStatefulSet, c.Scheme); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -373,14 +373,10 @@ func (c *ClusterReconciler) bindNodeProxyClusterRole(ctx context.Context, cluste
 	return c.Client.Update(ctx, clusterRoleBinding)
 }
 
-type ResourceEnsurer interface {
-	EnsureResources(context.Context) error
-}
-
 func (c *ClusterReconciler) ensureAgent(ctx context.Context, cluster *v1alpha1.Cluster, serviceIP, token string) error {
 	config := agent.NewConfig(cluster, c.Client, c.Scheme)
 
-	var agentEnsurer ResourceEnsurer
+	var agentEnsurer agent.ResourceEnsurer
 	if cluster.Spec.Mode == agent.VirtualNodeMode {
 		agentEnsurer = agent.NewVirtualAgent(config, serviceIP, token)
 	} else {

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -71,7 +71,7 @@ func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1al
 	})
 
 	if result != controllerutil.OperationResultNone {
-		log.Info(fmt.Sprintf("ensureObject: tokenSecret %s was %s", key, result))
+		log.Info("ensuring tokenSecret", "key", key, "result", result)
 	}
 
 	return token, err

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -67,10 +67,7 @@ func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1al
 	key = client.ObjectKeyFromObject(&tokenSecret)
 
 	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, &tokenSecret, func() error {
-		if err := controllerutil.SetControllerReference(cluster, &tokenSecret, c.Scheme); err != nil {
-			return err
-		}
-		return nil
+		return controllerutil.SetControllerReference(cluster, &tokenSecret, c.Scheme)
 	})
 
 	if result != controllerutil.OperationResultNone {

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -64,17 +64,18 @@ func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1al
 	}
 
 	tokenSecret = TokenSecretObj(token, cluster.Name, cluster.Namespace)
+	key = client.ObjectKeyFromObject(&tokenSecret)
 
 	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, &tokenSecret, func() error {
-		fmt.Printf("call FN mut %v - %s\n", cluster, client.ObjectKeyFromObject(&tokenSecret))
-
 		if err := controllerutil.SetControllerReference(cluster, &tokenSecret, c.Scheme); err != nil {
 			return err
 		}
 		return nil
 	})
 
-	fmt.Printf("ensureObject %s - %s\n", result, client.ObjectKeyFromObject(&tokenSecret))
+	if result != controllerutil.OperationResultNone {
+		log.Info(fmt.Sprintf("ensureObject: object %s was %s", key, result))
+	}
 
 	return token, err
 

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -71,7 +71,7 @@ func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1al
 	})
 
 	if result != controllerutil.OperationResultNone {
-		log.Info(fmt.Sprintf("ensureObject: object %s was %s", key, result))
+		log.Info(fmt.Sprintf("ensureObject: tokenSecret %s was %s", key, result))
 	}
 
 	return token, err


### PR DESCRIPTION
Ref:
- #170 
---

## Description

The webhook certificate was created more than once, this was causing some issues related to it not being aligned between the different resources. This was because the reconciliation of the object was done in a generic function of the Controller (the `(c *ClusterReconciler) ensure(...)`), that was not aware of the specific resource. And since the webhook certificate is created with a time.Now() validity then it was always considered different from the previous one.

To solve this I moved the resource reconciliation responsibility to the agents. In this way it's possible to "customize" the reconciliation, and in the case of the Webhook certs we are checking for their exisistance, and eventually create them, without updating them. In the future we could check for the validity, but this was out of scope, at the moment.

## Changes

Now the `ClusterReconciler` will create the Virtual or Shared agent with a `Config`, that will be used to perform the CreateOrUpdate of the resources. The Agents implement the `ResourceEnsurer` interface.

```go
type ResourceEnsurer interface {
	EnsureResources(context.Context) error
}

func (c *ClusterReconciler) ensureAgent(ctx context.Context, cluster *v1alpha1.Cluster, serviceIP, token string) error {
	config := agent.NewConfig(cluster, c.Client, c.Scheme)

	var agentEnsurer ResourceEnsurer
	if cluster.Spec.Mode == agent.VirtualNodeMode {
		agentEnsurer = agent.NewVirtualAgent(config, serviceIP, token)
	} else {
		agentEnsurer = agent.NewSharedAgent(config, serviceIP, c.SharedAgentImage, c.SharedAgentImagePullPolicy, token)
	}

	return agentEnsurer.EnsureResources(ctx)
}
```

The `EnsureResources(ctx)` of each agent will call every resource func, that will know how to "ensure" every resource. Generally they will call the `ensureObject(ctx context.Context, obj ctrlruntimeclient.Object)`

```
func (v *VirtualAgent) ensureObject(ctx context.Context, obj ctrlruntimeclient.Object) error {
	return ensureObject(ctx, v.Config, obj)
}
```

but when needed it's now possible to do a different update logic.