### PR TITLE
Fixing etcd pod controller

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -23,7 +23,7 @@ RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
     cp $ENVTEST_BIN/* /usr/local/kubebuilder/bin
 
 ENV GO111MODULE on
-ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS GITHUB_TOKEN SKIP_TESTS
+ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS GITHUB_TOKEN SKIP_TESTS GIT_TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/k3k/
 ENV DAPPER_OUTPUT ./bin ./dist ./deploy ./charts
 ENV DAPPER_DOCKER_SOCKET true

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -59,7 +59,7 @@ func AddPodController(ctx context.Context, mgr manager.Manager) error {
 }
 
 func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx).WithValues("pod", req.NamespacedName)
+	log := ctrl.LoggerFrom(ctx).WithValues("statefulset", req.NamespacedName)
 	ctx = ctrl.LoggerInto(ctx, log) // enrich the current logger
 
 	s := strings.Split(req.Name, "-")
@@ -71,7 +71,7 @@ func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 	clusterName := s[1]
 	var cluster v1alpha1.Cluster
-	if err := p.Client.Get(ctx, types.NamespacedName{Name: clusterName}, &cluster); err != nil {
+	if err := p.Client.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: req.Namespace}, &cluster); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
@@ -85,7 +85,6 @@ func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 	for _, pod := range podList.Items {
-
 		if err := p.handleServerPod(ctx, cluster, &pod); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -84,6 +84,9 @@ func (p *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	if err := p.Client.List(ctx, &podList, listOpts); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
+	if len(podList.Items) == 1 {
+		return reconcile.Result{}, nil
+	}
 	for _, pod := range podList.Items {
 		if err := p.handleServerPod(ctx, cluster, &pod); err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
etcd pod controller does the following
- reconcile k3s in HA state, i.e whenever a pod is deleted and assigned a new IP, then the controller will remove the etcd member from the cluster allowing the new pod to be added to the cluster

The fix added the namespace lookup to the clutser, it was missing and that caused the controller not able to reconcile the cluster
#170 