### PR TITLE
Fix panic for nil Expose

### DIFF
--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -106,7 +106,9 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1alp
 		nodePort := k3kService.Spec.Ports[0].NodePort
 		url = fmt.Sprintf("https://%s:%d", hostServerIP, nodePort)
 	}
-	if cluster.Spec.Expose.Ingress != nil && cluster.Spec.Expose.Ingress.Enabled {
+
+	expose := cluster.Spec.Expose
+	if expose != nil && expose.Ingress != nil && expose.Ingress.Enabled {
 		var k3kIngress networkingv1.Ingress
 		ingressKey := types.NamespacedName{
 			Name:      server.IngressName(cluster.Name),


### PR DESCRIPTION
Fixes:
- #237 
---

Creating a Cluster without any spec will cause a panic when trying to get the URL from the Service.