### PR TITLE
Added Ports to NodePortConfig and expose fixes

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -125,10 +125,24 @@ spec:
                     type: object
                   nodePort:
                     properties:
-                      enabled:
-                        type: boolean
-                    required:
-                    - enabled
+                      etcdPort:
+                        description: |-
+                          ETCDPort is the port on each node on which the ETCD service is exposed when type is NodePort.
+                          If not specified, a port will be allocated (default: 30000-32767)
+                        format: int32
+                        type: integer
+                      serverPort:
+                        description: |-
+                          ServerPort is the port on each node on which the K3s server service is exposed when type is NodePort.
+                          If not specified, a port will be allocated (default: 30000-32767)
+                        format: int32
+                        type: integer
+                      servicePort:
+                        description: |-
+                          ServicePort is the port on each node on which the K3s service is exposed when type is NodePort.
+                          If not specified, a port will be allocated (default: 30000-32767)
+                        format: int32
+                        type: integer
                     type: object
                 type: object
               mode:

--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -100,9 +100,7 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 		cluster := newCluster(name, cmds.Namespace(), config)
 
 		cluster.Spec.Expose = &v1alpha1.ExposeConfig{
-			NodePort: &v1alpha1.NodePortConfig{
-				Enabled: true,
-			},
+			NodePort: &v1alpha1.NodePortConfig{},
 		}
 
 		// add Host IP address as an extra TLS-SAN to expose the k3k cluster

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -196,7 +196,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ |  |  |  |
+| `serverPort` _integer_ | ServerPort is the port on each node on which the K3s server service is exposed when type is NodePort.<br />If not specified, a port will be allocated (default: 30000-32767) |  |  |
+| `servicePort` _integer_ | ServicePort is the port on each node on which the K3s service is exposed when type is NodePort.<br />If not specified, a port will be allocated (default: 30000-32767) |  |  |
+| `etcdPort` _integer_ | ETCDPort is the port on each node on which the ETCD service is exposed when type is NodePort.<br />If not specified, a port will be allocated (default: 30000-32767) |  |  |
 
 
 #### PersistenceConfig

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -160,7 +160,18 @@ type LoadBalancerConfig struct {
 }
 
 type NodePortConfig struct {
-	Enabled bool `json:"enabled"`
+	// ServerPort is the port on each node on which the K3s server service is exposed when type is NodePort.
+	// If not specified, a port will be allocated (default: 30000-32767)
+	// +optional
+	ServerPort *int32 `json:"serverPort,omitempty"`
+	// ServicePort is the port on each node on which the K3s service is exposed when type is NodePort.
+	// If not specified, a port will be allocated (default: 30000-32767)
+	// +optional
+	ServicePort *int32 `json:"servicePort,omitempty"`
+	// ETCDPort is the port on each node on which the ETCD service is exposed when type is NodePort.
+	// If not specified, a port will be allocated (default: 30000-32767)
+	// +optional
+	ETCDPort *int32 `json:"etcdPort,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/controller/cluster/server/service.go
+++ b/pkg/controller/cluster/server/service.go
@@ -8,51 +8,69 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (s *Server) Service(cluster *v1alpha1.Cluster) *v1.Service {
-	serviceType := v1.ServiceTypeClusterIP
-	if cluster.Spec.Expose != nil {
-		if cluster.Spec.Expose.NodePort != nil {
-			if cluster.Spec.Expose.NodePort.Enabled {
-				serviceType = v1.ServiceTypeNodePort
-			}
-		}
-	}
-
-	return &v1.Service{
+func Service(cluster *v1alpha1.Cluster) *v1.Service {
+	service := &v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName(s.cluster.Name),
+			Name:      ServiceName(cluster.Name),
 			Namespace: cluster.Namespace,
 		},
 		Spec: v1.ServiceSpec{
-			Type: serviceType,
+			Type: v1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				"cluster": cluster.Name,
 				"role":    "server",
 			},
-			Ports: []v1.ServicePort{
-				{
-					Name:     "k3s-server-port",
-					Protocol: v1.ProtocolTCP,
-					Port:     serverPort,
-				},
-				{
-					Name:       "k3s-service-port",
-					Protocol:   v1.ProtocolTCP,
-					Port:       servicePort,
-					TargetPort: intstr.FromInt(serverPort),
-				},
-				{
-					Name:     "k3s-etcd-port",
-					Protocol: v1.ProtocolTCP,
-					Port:     etcdPort,
-				},
-			},
 		},
 	}
+
+	k3sServerPort := v1.ServicePort{
+		Name:     "k3s-server-port",
+		Protocol: v1.ProtocolTCP,
+		Port:     serverPort,
+	}
+
+	k3sServicePort := v1.ServicePort{
+		Name:       "k3s-service-port",
+		Protocol:   v1.ProtocolTCP,
+		Port:       servicePort,
+		TargetPort: intstr.FromInt(serverPort),
+	}
+
+	etcdPort := v1.ServicePort{
+		Name:     "k3s-etcd-port",
+		Protocol: v1.ProtocolTCP,
+		Port:     etcdPort,
+	}
+
+	if cluster.Spec.Expose != nil {
+		nodePortConfig := cluster.Spec.Expose.NodePort
+		if nodePortConfig != nil {
+			service.Spec.Type = v1.ServiceTypeNodePort
+
+			if nodePortConfig.ServerPort != nil {
+				k3sServerPort.NodePort = *nodePortConfig.ServerPort
+			}
+			if nodePortConfig.ServicePort != nil {
+				k3sServicePort.NodePort = *nodePortConfig.ServicePort
+			}
+			if nodePortConfig.ETCDPort != nil {
+				etcdPort.NodePort = *nodePortConfig.ETCDPort
+			}
+		}
+	}
+
+	service.Spec.Ports = append(
+		service.Spec.Ports,
+		k3sServicePort,
+		etcdPort,
+		k3sServerPort,
+	)
+
+	return service
 }
 
 func (s *Server) StatefulServerService() *v1.Service {

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -64,9 +64,7 @@ var _ = When("a cluster is installed", func() {
 			Spec: v1alpha1.ClusterSpec{
 				TLSSANs: []string{hostIP},
 				Expose: &v1alpha1.ExposeConfig{
-					NodePort: &v1alpha1.NodePortConfig{
-						Enabled: true,
-					},
+					NodePort: &v1alpha1.NodePortConfig{},
 				},
 			},
 		}
@@ -130,9 +128,7 @@ var _ = When("a cluster is installed", func() {
 			Spec: v1alpha1.ClusterSpec{
 				TLSSANs: []string{hostIP},
 				Expose: &v1alpha1.ExposeConfig{
-					NodePort: &v1alpha1.NodePortConfig{
-						Enabled: true,
-					},
+					NodePort: &v1alpha1.NodePortConfig{},
 				},
 			},
 		}
@@ -154,7 +150,6 @@ var _ = When("a cluster is installed", func() {
 		serverPod := serverPods.Items[0]
 
 		fmt.Fprintf(GinkgoWriter, "deleting pod %s/%s\n", serverPod.Namespace, serverPod.Name)
-		// GracePeriodSeconds: ptr.To[int64](0)
 		err = k8s.CoreV1().Pods(namespace).Delete(ctx, serverPod.Name, v1.DeleteOptions{})
 		Expect(err).To(Not(HaveOccurred()))
 


### PR DESCRIPTION
Fix:
- #246
---

This PR fixes the reconciliation issue with the `expose` (see #246).

It also removes the `enabled` field, to simplify the spec, and adds the ports that can be set on the NodePort.

See also https://github.com/enrichman/k3k/blob/expose-fixes/docs/crds/crd-docs.md#nodeportconfig