### PR TITLE
Fix and enhancements to IngressExposeConfig (`annotations`)

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -117,10 +117,6 @@ spec:
                         description: Annotations is a key value map that will enrich
                           the Ingress annotations
                         type: object
-                      hosts:
-                        items:
-                          type: string
-                        type: array
                       ingressClassName:
                         type: string
                     type: object

--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -111,6 +111,16 @@ spec:
                 properties:
                   ingress:
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a key value map that will enrich
+                          the Ingress annotations
+                        type: object
+                      hosts:
+                        items:
+                          type: string
+                        type: array
                       ingressClassName:
                         type: string
                     type: object

--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -111,8 +111,6 @@ spec:
                 properties:
                   ingress:
                     properties:
-                      enabled:
-                        type: boolean
                       ingressClassName:
                         type: string
                     type: object

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -31,12 +31,17 @@ spec:
   mode: shared
   version: v1.31.3-k3s1
   servers: 3
+  tlsSANs:
+    - my-cluster.example.com
   nodeSelector:
     disktype: ssd
   expose:
     ingress:
-      enabled: true
       ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        nginx.ingress.kubernetes.io/backend-protocol: "true"
+        nginx.ingress.kubernetes.io/ssl-redirect: "HTTPS"
   clusterCIDR: 10.42.0.0/16
   serviceCIDR: 10.43.0.0/16
   clusterDNS: 10.43.0.10
@@ -83,6 +88,8 @@ The `nodeSelector` field allows you to specify a node selector that will be appl
 The `expose` field contains options for exposing the API server of the virtual cluster. By default, the API server is only exposed as a `ClusterIP`, which is relatively secure but difficult to access from outside the cluster.
 
 You can use the `expose` field to enable exposure via `NodePort`, `LoadBalancer`, or `Ingress`.
+
+In this example we are exposing the Cluster with a Nginx ingress-controller, that has to be configured with the `--enable-ssl-passthrough` flag.
 
 
 ### `clusterCIDR`

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -165,7 +165,6 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `annotations` _object (keys:string, values:string)_ | Annotations is a key value map that will enrich the Ingress annotations |  |  |
 | `ingressClassName` _string_ |  |  |  |
-| `hosts` _string array_ |  |  |  |
 
 
 #### LoadBalancerConfig

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -163,8 +163,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ |  |  |  |
+| `annotations` _object (keys:string, values:string)_ | Annotations is a key value map that will enrich the Ingress annotations |  |  |
 | `ingressClassName` _string_ |  |  |  |
+| `hosts` _string array_ |  |  |  |
 
 
 #### LoadBalancerConfig

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -155,7 +155,6 @@ type IngressConfig struct {
 	// +optional
 	Annotations      map[string]string `json:"annotations,omitempty"`
 	IngressClassName string            `json:"ingressClassName,omitempty"`
-	Hosts            []string          `json:"hosts,omitempty"`
 }
 
 type LoadBalancerConfig struct {

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -151,7 +151,11 @@ type ExposeConfig struct {
 }
 
 type IngressConfig struct {
-	IngressClassName string `json:"ingressClassName,omitempty"`
+	// Annotations is a key value map that will enrich the Ingress annotations
+	// +optional
+	Annotations      map[string]string `json:"annotations,omitempty"`
+	IngressClassName string            `json:"ingressClassName,omitempty"`
+	Hosts            []string          `json:"hosts,omitempty"`
 }
 
 type LoadBalancerConfig struct {

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -151,7 +151,6 @@ type ExposeConfig struct {
 }
 
 type IngressConfig struct {
-	Enabled          bool   `json:"enabled,omitempty"`
 	IngressClassName string `json:"ingressClassName,omitempty"`
 }
 

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -315,12 +315,7 @@ func (c *ClusterReconciler) ensureIngress(ctx context.Context, cluster *v1alpha1
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("ensuring cluster ingress")
 
-	addresses, err := controller.Addresses(ctx, c.Client)
-	if err != nil {
-		return err
-	}
-
-	expectedServerIngress := server.Ingress(ctx, addresses, cluster)
+	expectedServerIngress := server.Ingress(ctx, cluster)
 
 	// delete existing Ingress if Expose or IngressConfig are nil
 	if cluster.Spec.Expose == nil || cluster.Spec.Expose.Ingress == nil {
@@ -336,7 +331,10 @@ func (c *ClusterReconciler) ensureIngress(ctx context.Context, cluster *v1alpha1
 
 		currentServerIngress.Spec = expectedServerIngress.Spec
 
-		// restore the current annotations, eventually keeping the custom one
+		// copy will keep the annotations manually set by the user
+		if currentServerIngress.Annotations == nil {
+			currentServerIngress.Annotations = make(map[string]string)
+		}
 		maps.Copy(currentServerIngress.Annotations, expectedServerIngress.Annotations)
 
 		return nil

--- a/pkg/controller/cluster/server/ingress.go
+++ b/pkg/controller/cluster/server/ingress.go
@@ -7,15 +7,10 @@ import (
 	"github.com/rancher/k3k/pkg/controller"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
-	wildcardDNS = ".sslip.io"
-
-	nginxSSLPassthroughAnnotation  = "nginx.ingress.kubernetes.io/ssl-passthrough"
-	nginxBackendProtocolAnnotation = "nginx.ingress.kubernetes.io/backend-protocol"
-	nginxSSLRedirectAnnotation     = "nginx.ingress.kubernetes.io/ssl-redirect"
-
 	servicePort = 443
 	serverPort  = 6443
 	etcdPort    = 2379
@@ -25,9 +20,7 @@ func IngressName(clusterName string) string {
 	return controller.SafeConcatNameWithPrefix(clusterName, "ingress")
 }
 
-func Ingress(ctx context.Context, addresses []string, cluster *v1alpha1.Cluster) networkingv1.Ingress {
-	ingressRules := ingressRules(addresses, cluster)
-
+func Ingress(ctx context.Context, cluster *v1alpha1.Cluster) networkingv1.Ingress {
 	ingress := networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
@@ -38,62 +31,56 @@ func Ingress(ctx context.Context, addresses []string, cluster *v1alpha1.Cluster)
 			Namespace: cluster.Namespace,
 		},
 		Spec: networkingv1.IngressSpec{
-			Rules: ingressRules,
+			Rules: ingressRules(cluster),
 		},
 	}
 
-	var ingressClassName string
 	if cluster.Spec.Expose != nil && cluster.Spec.Expose.Ingress != nil {
-		ingressClassName = cluster.Spec.Expose.Ingress.IngressClassName
-	}
+		ingressConfig := cluster.Spec.Expose.Ingress
 
-	ingress.Spec.IngressClassName = &ingressClassName
-	configureIngressOptions(&ingress, ingressClassName)
+		if ingressConfig.IngressClassName != "" {
+			ingress.Spec.IngressClassName = ptr.To(ingressConfig.IngressClassName)
+		}
+
+		if ingressConfig.Annotations != nil {
+			ingress.Annotations = ingressConfig.Annotations
+		}
+	}
 
 	return ingress
 }
 
-func ingressRules(addresses []string, cluster *v1alpha1.Cluster) []networkingv1.IngressRule {
+func ingressRules(cluster *v1alpha1.Cluster) []networkingv1.IngressRule {
 	var ingressRules []networkingv1.IngressRule
-	pathTypePrefix := networkingv1.PathTypePrefix
-	for _, address := range addresses {
-		rule := networkingv1.IngressRule{
-			Host: cluster.Name + "." + address + wildcardDNS,
-			IngressRuleValue: networkingv1.IngressRuleValue{
-				HTTP: &networkingv1.HTTPIngressRuleValue{
-					Paths: []networkingv1.HTTPIngressPath{
-						{
-							Path:     "/",
-							PathType: &pathTypePrefix,
-							Backend: networkingv1.IngressBackend{
-								Service: &networkingv1.IngressServiceBackend{
-									Name: ServiceName(cluster.Name),
-									Port: networkingv1.ServiceBackendPort{
-										Number: serverPort,
-									},
-								},
-							},
-						},
-					},
+
+	if cluster.Spec.Expose == nil || cluster.Spec.Expose.Ingress == nil {
+		return ingressRules
+	}
+
+	path := networkingv1.HTTPIngressPath{
+		Path:     "/",
+		PathType: ptr.To(networkingv1.PathTypePrefix),
+		Backend: networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{
+				Name: ServiceName(cluster.Name),
+				Port: networkingv1.ServiceBackendPort{
+					Number: serverPort,
 				},
 			},
-		}
-		ingressRules = append(ingressRules, rule)
+		},
+	}
+
+	hosts := cluster.Spec.Expose.Ingress.Hosts
+	for _, host := range hosts {
+		ingressRules = append(ingressRules, networkingv1.IngressRule{
+			Host: host,
+			IngressRuleValue: networkingv1.IngressRuleValue{
+				HTTP: &networkingv1.HTTPIngressRuleValue{
+					Paths: []networkingv1.HTTPIngressPath{path},
+				},
+			},
+		})
 	}
 
 	return ingressRules
-}
-
-// configureIngressOptions will configure the ingress object by
-// adding tls passthrough capabilities and TLS needed annotations
-// it depends on the ingressclassname to configure each ingress
-// TODO: add treafik support through ingresstcproutes
-func configureIngressOptions(ingress *networkingv1.Ingress, ingressClassName string) {
-	// initial support for nginx ingress via annotations
-	if ingressClassName == "nginx" {
-		ingress.Annotations = make(map[string]string)
-		ingress.Annotations[nginxSSLPassthroughAnnotation] = "true"
-		ingress.Annotations[nginxSSLRedirectAnnotation] = "true"
-		ingress.Annotations[nginxBackendProtocolAnnotation] = "HTTPS"
-	}
 }

--- a/pkg/controller/cluster/server/ingress.go
+++ b/pkg/controller/cluster/server/ingress.go
@@ -70,7 +70,7 @@ func ingressRules(cluster *v1alpha1.Cluster) []networkingv1.IngressRule {
 		},
 	}
 
-	hosts := cluster.Spec.Expose.Ingress.Hosts
+	hosts := cluster.Spec.TLSSANs
 	for _, host := range hosts {
 		ingressRules = append(ingressRules, networkingv1.IngressRule{
 			Host: host,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,16 +1,13 @@
 package controller
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
 	"time"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -40,41 +37,6 @@ func K3SImage(cluster *v1alpha1.Cluster) string {
 	}
 
 	return k3SImageName
-}
-
-func nodeAddress(node *v1.Node) string {
-	var externalIP string
-	var internalIP string
-
-	for _, ip := range node.Status.Addresses {
-		if ip.Type == "ExternalIP" && ip.Address != "" {
-			externalIP = ip.Address
-			break
-		}
-		if ip.Type == "InternalIP" && ip.Address != "" {
-			internalIP = ip.Address
-		}
-	}
-	if externalIP != "" {
-		return externalIP
-	}
-
-	return internalIP
-}
-
-// return all the nodes external addresses, if not found then return internal addresses
-func Addresses(ctx context.Context, client ctrlruntimeclient.Client) ([]string, error) {
-	var nodeList v1.NodeList
-	if err := client.List(ctx, &nodeList); err != nil {
-		return nil, err
-	}
-
-	addresses := make([]string, len(nodeList.Items))
-	for i, node := range nodeList.Items {
-		addresses[i] = nodeAddress(&node)
-	}
-
-	return addresses, nil
 }
 
 // SafeConcatNameWithPrefix runs the SafeConcatName with extra prefix.

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -108,7 +108,7 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1alp
 	}
 
 	expose := cluster.Spec.Expose
-	if expose != nil && expose.Ingress != nil && expose.Ingress.Enabled {
+	if expose != nil && expose.Ingress != nil {
 		var k3kIngress networkingv1.Ingress
 		ingressKey := types.NamespacedName{
 			Name:      server.IngressName(cluster.Name),


### PR DESCRIPTION
Ref:
- #246
---

This PR fixes some issues with the current Ingress implementation adding some additional configurations field.

Like the NodePort expose the `enabled` field was removed (#247). The `annotations` field was added.

The `tlsSANs` field will be used as Path to add the relevant IngressRules, while the `annotations` will be applied to the Ingress. This is because those annotations are needed to enable some behaviors to the proxy, i.e. when using an Nginx ingress-controller the SSL passthrough option is needed, and the following annotations need to be used:

```yaml
spec:
  tlsSANs:
    - my-cluster.140.150.160.199.sslip.io
  expose:
    ingress:
      ingressClassName: "nginx"
      annotations:
        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
        nginx.ingress.kubernetes.io/backend-protocol: "true"
        nginx.ingress.kubernetes.io/ssl-redirect: "HTTPS"
```
