### PR TITLE
Add strict check for number of arguments in cluster `create` and `delete`

### DIFF
--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -55,12 +55,12 @@ func NewCreateCmd() *cli.Command {
 	createFlags := NewCreateFlags(createConfig)
 
 	return &cli.Command{
-		Name:      "create",
-		Usage:     "Create new cluster",
-		Action:    createAction(createConfig),
-		Flags:     append(cmds.CommonFlags, createFlags...),
-		Args:      false,
-		ArgsUsage: "NAME",
+		Name:            "create",
+		Usage:           "Create new cluster",
+		UsageText:       "k3kcli cluster create [command options] NAME",
+		Action:          createAction(createConfig),
+		Flags:           append(cmds.CommonFlags, createFlags...),
+		HideHelpCommand: true,
 	}
 }
 
@@ -68,10 +68,12 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 	return func(clx *cli.Context) error {
 		ctx := context.Background()
 
+		if clx.NArg() != 1 {
+			return cli.ShowSubcommandHelp(clx)
+		}
+
 		name := clx.Args().First()
-		if name == "" {
-			return errors.New("empty cluster name")
-		} else if name == k3kcluster.ClusterInvalidName {
+		if name == k3kcluster.ClusterInvalidName {
 			return errors.New("invalid cluster name")
 		}
 

--- a/cli/cmds/cluster/delete.go
+++ b/cli/cmds/cluster/delete.go
@@ -16,20 +16,24 @@ import (
 
 func NewDeleteCmd() *cli.Command {
 	return &cli.Command{
-		Name:   "delete",
-		Usage:  "Delete an existing cluster",
-		Action: delete,
-		Flags:  cmds.CommonFlags,
+		Name:            "delete",
+		Usage:           "Delete an existing cluster",
+		UsageText:       "k3kcli cluster delete [command options] NAME",
+		Action:          delete,
+		Flags:           cmds.CommonFlags,
+		HideHelpCommand: true,
 	}
 }
 
 func delete(clx *cli.Context) error {
 	ctx := context.Background()
 
+	if clx.NArg() != 1 {
+		return cli.ShowSubcommandHelp(clx)
+	}
+
 	name := clx.Args().First()
-	if name == "" {
-		return errors.New("empty cluster name")
-	} else if name == k3kcluster.ClusterInvalidName {
+	if name == k3kcluster.ClusterInvalidName {
 		return errors.New("invalid cluster name")
 	}
 


### PR DESCRIPTION
Any additional arguments after the first one were silently ignored.

If a user was providing some flags after the first arg (i.e. the cluster name), they were not used. The PR adds a strict validation about the number of the arguments of the `create` and `delete` command, printing the help in case of error.

```
> % k3kcli cluster delete mycluster --some-flag
NAME:
   k3kcli cluster delete - Delete an existing cluster

USAGE:
   k3kcli cluster delete [command options] NAME

OPTIONS:
   --kubeconfig value  kubeconfig path (default: "/home/enrico/.kube/config") [$KUBECONFIG]
   --namespace value   namespace to create the k3k cluster in
   --help, -h          show help
```