### PR TITLE
Fix k3s version metadata

### DIFF
--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -89,6 +89,12 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 			return err
 		}
 
+		if strings.Contains(config.version, "+") {
+			orig := config.version
+			config.version = strings.Replace(config.version, "+", "-", -1)
+			logrus.Warnf("Invalid K3s docker reference version: '%s'. Using '%s' instead", orig, config.version)
+		}
+
 		if config.token != "" {
 			logrus.Infof("Creating cluster token secret")
 			obj := k3kcluster.TokenSecretObj(config.token, name, cmds.Namespace())

--- a/cli/cmds/cluster/create_flags.go
+++ b/cli/cmds/cluster/create_flags.go
@@ -77,7 +77,7 @@ func NewCreateFlags(config *CreateConfig) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "mode",
-			Usage:       "k3k mode type",
+			Usage:       "k3k mode type (shared, virtual)",
 			Destination: &config.mode,
 			Value:       "shared",
 			Action: func(ctx *cli.Context, value string) error {


### PR DESCRIPTION
Fix:
- #220 
---

The K3s release tags don't match the Docker tags:

When the user provides the release tag, i.e `v1.29.13+k3s1`, the docker pull of the K3s image will fail:

```
couldn't parse image name "rancher/k3s:v1.29.13+k3s1": invalid reference format
```

This PR adds a fallback when the user provides a version with the metadata, trying to replace the `+` with the `-`, warning the user about this behavior:

```
-> % k3kcli cluster create --version v1.29.13+k3s1 mycluster
WARN[0000] Invalid K3s docker reference version: 'v1.29.13+k3s1'. Using 'v1.29.13-k3s1' instead 
```