### PR TITLE
Fix for duplicated networking EnvVars in scheduled pods

### DIFF
--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func Test_overrideEnvVars(t *testing.T) {
+	type args struct {
+		orig []corev1.EnvVar
+		new  []corev1.EnvVar
+	}
+	tests := []struct {
+		name string
+		args args
+		want []corev1.EnvVar
+	}{
+		{
+			name: "orig and new are empty",
+			args: args{
+				orig: []v1.EnvVar{},
+				new:  []v1.EnvVar{},
+			},
+			want: []v1.EnvVar{},
+		},
+		{
+			name: "only orig is empty",
+			args: args{
+				orig: []v1.EnvVar{},
+				new:  []v1.EnvVar{{Name: "FOO", Value: "new_val"}},
+			},
+			want: []v1.EnvVar{},
+		},
+		{
+			name: "orig has a matching element",
+			args: args{
+				orig: []v1.EnvVar{{Name: "FOO", Value: "old_val"}},
+				new:  []v1.EnvVar{{Name: "FOO", Value: "new_val"}},
+			},
+			want: []v1.EnvVar{{Name: "FOO", Value: "new_val"}},
+		},
+		{
+			name: "orig have multiple elements",
+			args: args{
+				orig: []v1.EnvVar{{Name: "FOO_0", Value: "old_val_0"}, {Name: "FOO_1", Value: "old_val_1"}},
+				new:  []v1.EnvVar{{Name: "FOO_1", Value: "new_val_1"}},
+			},
+			want: []v1.EnvVar{{Name: "FOO_0", Value: "old_val_0"}, {Name: "FOO_1", Value: "new_val_1"}},
+		},
+		{
+			name: "orig and new have multiple elements and some not matching",
+			args: args{
+				orig: []v1.EnvVar{{Name: "FOO_0", Value: "old_val_0"}, {Name: "FOO_1", Value: "old_val_1"}},
+				new:  []v1.EnvVar{{Name: "FOO_1", Value: "new_val_1"}, {Name: "FOO_2", Value: "val_1"}},
+			},
+			want: []v1.EnvVar{{Name: "FOO_0", Value: "old_val_0"}, {Name: "FOO_1", Value: "new_val_1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := overrideEnvVars(tt.args.orig, tt.args.new); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("overrideEnvVars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ref:
- #204 
---

This PR fixes the duplicate environment variables, overriding the existing ones. It also add the missing `KUBERNETES_SERVICE_PORT_HTTPS` variable to the `6443`.

:warning: **Important**: this will _not_ add the variable if it was not already present. It just overwrite existing values.

Old behavior:
![image](https://github.com/user-attachments/assets/ec83f92f-8919-4066-854d-d1a841ff80ff)

New:
![image](https://github.com/user-attachments/assets/994eb6a9-3fac-41d3-8cf9-ee421eda053f)
