### PR TITLE
Added multiarch support (`arm64`)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: "Read secrets"
       uses: rancher-eio/read-vault-secrets@main
       if: github.repository_owner == 'rancher'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,29 +67,78 @@ archives:
 # REGISTRY=ghcr.io -> ghcr.io/rancher/k3k:latest:vX.Y.Z
 #
 dockers:
-  - id: k3k
-    use: docker
+  # k3k amd64
+  - use: buildx
+    goarch: amd64
     ids:
       - k3k
       - k3kcli
     dockerfile: "package/Dockerfile.k3k"
     skip_push: false
     image_templates:
-      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}:{{ .Tag }}"
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}:{{ .Tag }}-amd64"
     build_flag_templates:
       - "--build-arg=BIN_K3K=k3k"
       - "--build-arg=BIN_K3KCLI=k3kcli"
+      - "--pull"
+      - "--platform=linux/amd64"
+  
+  # k3k arm64
+  - use: buildx
+    goarch: arm64
+    ids:
+      - k3k
+      - k3kcli
+    dockerfile: "package/Dockerfile.k3k"
+    skip_push: false
+    image_templates:
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}:{{ .Tag }}-arm64"
+    build_flag_templates:
+      - "--build-arg=BIN_K3K=k3k"
+      - "--build-arg=BIN_K3KCLI=k3kcli"
+      - "--pull"
+      - "--platform=linux/arm64"
 
-  - id: k3k-kubelet
-    use: docker
+  # k3k-kubelet amd64
+  - use: buildx
+    goarch: amd64
     ids:
       - k3k-kubelet
     dockerfile: "package/Dockerfile.k3k-kubelet"
     skip_push: false
     image_templates:
-      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}-kubelet:{{ .Tag }}"
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}-kubelet:{{ .Tag }}-amd64"
     build_flag_templates:
       - "--build-arg=BIN_K3K_KUBELET=k3k-kubelet"
+      - "--pull"
+      - "--platform=linux/amd64"
+
+  # k3k-kubelet arm64
+  - use: buildx
+    goarch: arm64
+    ids:
+      - k3k-kubelet
+    dockerfile: "package/Dockerfile.k3k-kubelet"
+    skip_push: false
+    image_templates:
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}-kubelet:{{ .Tag }}-arm64"
+    build_flag_templates:
+      - "--build-arg=BIN_K3K_KUBELET=k3k-kubelet"
+      - "--pull"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  # k3k
+  - name_template: "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}:{{ .Tag }}"
+    image_templates:
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}:{{ .Tag }}-amd64"
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}:{{ .Tag }}-arm64"
+  
+  # k3k-kubelet arm64
+  - name_template: "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}-kubelet:{{ .Tag }}"
+    image_templates:
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}-kubelet:{{ .Tag }}-amd64"
+      - "{{- if .Env.REGISTRY }}{{ .Env.REGISTRY }}/{{ end }}{{ .Env.REPO }}-kubelet:{{ .Tag }}-arm64"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Ref:
- #261 
---

The binaries were built in three variants, but we were not packaging the images for the different platforms.

This PR will use buildx to build the crossplatform images, and will upload the manifest for the different architectures (`amd64` and `arm64`).

Ref: https://goreleaser.com/cookbooks/multi-platform-docker-images/

Tested creating a RC with the release draft action:

```
docker manifest inspect ghcr.io/enrichman/k3k:v0.2.2-rc4-37-g1f6ce2c                                        
```
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 952,
         "digest": "sha256:ac74c604d4350594f8bb40cb6abdce2b153d6b454be09b9429a6f3de12319dae",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 952,
         "digest": "sha256:b0cea01b23fa6e90f293d192414125ad40d1f8a1d7b0a873036cd8af6c3e7144",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```
```
docker manifest inspect ghcr.io/enrichman/k3k-kubelet:v0.2.2-rc4-37-g1f6ce2c
```
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 741,
         "digest": "sha256:99f4fc1be922875bc1b4841b3133f0b321f7f20771f5cb20b98c7364070cb9a8",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 741,
         "digest": "sha256:d5cbe169c2d681166752be6ae4d4e6e2ee7afbc1535b993b640287c8ad5d888a",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```