### PR TITLE
Fix the default CIDRs for both modes

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -66,7 +66,8 @@ spec:
                   rule: self >= 0
               clusterCIDR:
                 description: ClusterCIDR is the CIDR range for the pods of the cluster.
-                  Defaults to 10.42.0.0/16.
+                  Defaults to 10.42.0.0/16 in shared mode and 10.52.0.0/16 in virtual
+                  mode.
                 type: string
                 x-kubernetes-validations:
                 - message: clusterCIDR is immutable
@@ -211,7 +212,8 @@ spec:
                   rule: self >= 1
               serviceCIDR:
                 description: ServiceCIDR is the CIDR range for the services in the
-                  cluster. Defaults to 10.43.0.0/16.
+                  cluster. Defaults to 10.43.0.0/16 in shared mode and 10.53.0.0/16
+                  in virtual mode.
                 type: string
                 x-kubernetes-validations:
                 - message: serviceCIDR is immutable

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -94,14 +94,14 @@ In this example we are exposing the Cluster with a Nginx ingress-controller, tha
 
 ### `clusterCIDR`
 
-The `clusterCIDR` field specifies the CIDR range for the pods of the cluster. The default value is `10.42.0.0/16`.
+The `clusterCIDR` field specifies the CIDR range for the pods of the cluster. The default value is `10.42.0.0/16` in shared mode, and `10.52.0.0/16` in virtual mode.
 
 
 ### `serviceCIDR`
 
-The `serviceCIDR` field specifies the CIDR range for the services in the cluster. The default value is `10.43.0.0/16`.
+The `serviceCIDR` field specifies the CIDR range for the services in the cluster. The default value is `10.43.0.0/16` in shared mode, and `10.53.0.0/16` in virtual mode.
 
-**Note:** In `shared` mode, the `serviceCIDR` should match the host cluster's `serviceCIDR` to prevent conflicts.
+**Note:** In `shared` mode, the `serviceCIDR` should match the host cluster's `serviceCIDR` to prevent conflicts and in `virtual` mode both `serviceCIDR` and `clusterCIDR` should be different than the host cluster.
 
 
 ### `clusterDNS`

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -118,8 +118,8 @@ _Appears in:_
 | `priorityClass` _string_ | PriorityClass is the priorityClassName that will be applied to all server/agent pods.<br />In "shared" mode the priorityClassName will be applied also to the workloads. |  |  |
 | `clusterLimit` _[ClusterLimit](#clusterlimit)_ | Limit is the limits that apply for the server/worker nodes. |  |  |
 | `tokenSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretreference-v1-core)_ | TokenSecretRef is Secret reference used as a token join server and worker nodes to the cluster. The controller<br />assumes that the secret has a field "token" in its data, any other fields in the secret will be ignored. |  |  |
-| `clusterCIDR` _string_ | ClusterCIDR is the CIDR range for the pods of the cluster. Defaults to 10.42.0.0/16. |  |  |
-| `serviceCIDR` _string_ | ServiceCIDR is the CIDR range for the services in the cluster. Defaults to 10.43.0.0/16. |  |  |
+| `clusterCIDR` _string_ | ClusterCIDR is the CIDR range for the pods of the cluster. Defaults to 10.42.0.0/16 in shared mode and 10.52.0.0/16 in virtual mode. |  |  |
+| `serviceCIDR` _string_ | ServiceCIDR is the CIDR range for the services in the cluster. Defaults to 10.43.0.0/16 in shared mode and 10.53.0.0/16 in virtual mode. |  |  |
 | `clusterDNS` _string_ | ClusterDNS is the IP address for the coredns service. Needs to be in the range provided by ServiceCIDR or CoreDNS may not deploy.<br />Defaults to 10.43.0.10. |  |  |
 | `serverArgs` _string array_ | ServerArgs are the ordered key value pairs (e.x. "testArg", "testValue") for the K3s pods running in server mode. |  |  |
 | `agentArgs` _string array_ | AgentArgs are the ordered key value pairs (e.x. "testArg", "testValue") for the K3s pods running in agent mode. |  |  |

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -58,11 +58,11 @@ type ClusterSpec struct {
 	// +optional
 	TokenSecretRef *v1.SecretReference `json:"tokenSecretRef"`
 
-	// ClusterCIDR is the CIDR range for the pods of the cluster. Defaults to 10.42.0.0/16.
+	// ClusterCIDR is the CIDR range for the pods of the cluster. Defaults to 10.42.0.0/16 in shared mode and 10.52.0.0/16 in virtual mode.
 	// +kubebuilder:validation:XValidation:message="clusterCIDR is immutable",rule="self == oldSelf"
 	ClusterCIDR string `json:"clusterCIDR,omitempty"`
 
-	// ServiceCIDR is the CIDR range for the services in the cluster. Defaults to 10.43.0.0/16.
+	// ServiceCIDR is the CIDR range for the services in the cluster. Defaults to 10.43.0.0/16 in shared mode and 10.53.0.0/16 in virtual mode.
 	// +kubebuilder:validation:XValidation:message="serviceCIDR is immutable",rule="self == oldSelf"
 	ServiceCIDR string `json:"serviceCIDR,omitempty"`
 


### PR DESCRIPTION
#268 

This will fix the defaults of the CIDRs for both modes:

- Virtual mode: 
  - clusterCIDR: 10.52.0.0/16
  - serviceCIDR: 10.53.0.0/16
- Shared mode:
  - clusterCIDR: 10.42.0.0/16
  - serviceCIDR: 10.43.0.0/16

It will also only lookup the host's cluster CIDR in shared mode