### PR TITLE
Update quickstart pre-requisite and add cli docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GINKGO_VERSION ?= v2.21.0
 ENVTEST_VERSION ?= latest
 ENVTEST_K8S_VERSION := 1.31.0
+CRD_REF_DOCS_VER ?= v0.1.0
 
 GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 CONTROLLER_GEN ?= go run sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+CRD_REF_DOCS := go run github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VER)
 
 ENVTEST ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 ENVTEST_DIR ?= $(shell pwd)/.envtest
@@ -75,8 +77,9 @@ build-crds:	## Build the CRDs specs
 		output:crd:dir=./charts/k3k/crds
 
 .PHONY: docs
-docs:	## Build the CRDs docs
-	$(MAKE) -C docs/crds
+docs:	## Build the CRDs and CLI docs
+	$(CRD_REF_DOCS) --config=./docs/crds/config.yaml --renderer=markdown --source-path=./pkg/apis/k3k.io/v1alpha1 --output-path=./docs/crds/crd-docs.md
+	@go run ./docs/cli/genclidoc.go
 
 .PHONY: lint
 lint:	## Find any linting issues in the project

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ This section provides instructions on how to install K3k and the `k3kcli`.
 ### Prerequisites
 
 * [Helm](https://helm.sh) must be installed to use the charts. Please refer to Helm's [documentation](https://helm.sh/docs) to get started.
+* An existing [RKE2](https://docs.rke2.io/install/quickstart) Kubernetes cluster (recommended).
+* A configured storage provider with a default storage class.
 
+**Note:** If you do not have a storage provider, you can configure the cluster to use ephemeral or static storage. Please consult the [k3kcli advance usage](./docs/advanced-usage.md#using-the-cli) for instructions on using these options.
 
 ### Install the K3k controller
 

--- a/cli/cmds/cluster.go
+++ b/cli/cmds/cluster.go
@@ -1,16 +1,16 @@
-package cluster
+package cmds
 
 import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewCommand() *cli.Command {
+func NewClusterCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "cluster",
 		Usage: "cluster command",
 		Subcommands: []*cli.Command{
-			NewCreateCmd(),
-			NewDeleteCmd(),
+			NewClusterCreateCmd(),
+			NewClusterDeleteCmd(),
 		},
 	}
 }

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -87,7 +87,9 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 
 		if config.token != "" {
 			logrus.Infof("Creating cluster token secret")
+
 			obj := k3kcluster.TokenSecretObj(config.token, name, Namespace())
+
 			if err := ctrlClient.Create(ctx, &obj); err != nil {
 				return err
 			}
@@ -106,10 +108,12 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
+
 		host := strings.Split(url.Host, ":")
 		if config.kubeconfigServerHost != "" {
 			host = []string{config.kubeconfigServerHost}
 		}
+
 		cluster.Spec.TLSSANs = []string{host[0]}
 
 		if err := ctrlClient.Create(ctx, cluster); err != nil {
@@ -134,6 +138,7 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 		cfg := kubeconfig.New()
 
 		var kubeconfig *clientcmdapi.Config
+
 		if err := retry.OnError(availableBackoff, apierrors.IsNotFound, func() error {
 			kubeconfig, err = cfg.Extract(ctx, ctrlClient, cluster, host[0])
 			return err
@@ -189,6 +194,7 @@ func newCluster(name, namespace string, config *CreateConfig) *v1alpha1.Cluster 
 	if config.storageClassName == "" {
 		cluster.Spec.Persistence.StorageClassName = nil
 	}
+
 	if config.token != "" {
 		cluster.Spec.TokenSecretRef = &v1.SecretReference{
 			Name:      k3kcluster.TokenSecretName(name),

--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -1,4 +1,4 @@
-package cluster
+package cmds
 
 import (
 	"errors"

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -56,5 +56,6 @@ func delete(clx *cli.Context) error {
 			Namespace: Namespace(),
 		},
 	}
+
 	return ctrlClient.Delete(ctx, &cluster)
 }

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -1,10 +1,9 @@
-package cluster
+package cmds
 
 import (
 	"context"
 	"errors"
 
-	"github.com/rancher/k3k/cli/cmds"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	k3kcluster "github.com/rancher/k3k/pkg/controller/cluster"
 	"github.com/sirupsen/logrus"
@@ -14,13 +13,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewDeleteCmd() *cli.Command {
+func NewClusterDeleteCmd() *cli.Command {
 	return &cli.Command{
 		Name:            "delete",
 		Usage:           "Delete an existing cluster",
 		UsageText:       "k3kcli cluster delete [command options] NAME",
 		Action:          delete,
-		Flags:           cmds.CommonFlags,
+		Flags:           CommonFlags,
 		HideHelpCommand: true,
 	}
 }
@@ -37,7 +36,7 @@ func delete(clx *cli.Context) error {
 		return errors.New("invalid cluster name")
 	}
 
-	restConfig, err := clientcmd.BuildConfigFromFlags("", cmds.Kubeconfig)
+	restConfig, err := clientcmd.BuildConfigFromFlags("", Kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -54,9 +53,8 @@ func delete(clx *cli.Context) error {
 	cluster := v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: cmds.Namespace(),
+			Namespace: Namespace(),
 		},
 	}
-
 	return ctrlClient.Delete(ctx, &cluster)
 }

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -93,6 +93,7 @@ func NewKubeconfigCommand() *cli.Command {
 
 func generate(clx *cli.Context) error {
 	var cluster v1alpha1.Cluster
+
 	ctx := context.Background()
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", Kubeconfig)
@@ -106,6 +107,7 @@ func generate(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	clusterKey := types.NamespacedName{
 		Name:      name,
 		Namespace: Namespace(),
@@ -119,9 +121,11 @@ func generate(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	host := strings.Split(url.Host, ":")
 	if kubeconfigServerHost != "" {
 		host = []string{kubeconfigServerHost}
+
 		if err := altNames.Set(kubeconfigServerHost); err != nil {
 			return err
 		}
@@ -144,6 +148,7 @@ func generate(clx *cli.Context) error {
 	logrus.Infof("waiting for cluster to be available..")
 
 	var kubeconfig *clientcmdapi.Config
+
 	if err := retry.OnError(controller.Backoff, apierrors.IsNotFound, func() error {
 		kubeconfig, err = cfg.Extract(ctx, ctrlClient, &cluster, host[0])
 		return err

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -61,6 +61,7 @@ func NewApp() *cli.App {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
+
 		return nil
 	}
 
@@ -81,5 +82,6 @@ func Namespace() string {
 	if namespace == "" {
 		return defaultNamespace
 	}
+
 	return namespace
 }

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -2,7 +2,6 @@ package cmds
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	"github.com/rancher/k3k/pkg/buildinfo"
@@ -29,7 +28,7 @@ var (
 			EnvVars:     []string{"KUBECONFIG"},
 			Usage:       "kubeconfig path",
 			Destination: &Kubeconfig,
-			Value:       os.Getenv("HOME") + "/.kube/config",
+			Value:       "$HOME/.kube/config",
 		},
 		&cli.StringFlag{
 			Name:        "namespace",

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,29 +1,14 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/rancher/k3k/cli/cmds"
-	"github.com/rancher/k3k/cli/cmds/cluster"
-	"github.com/rancher/k3k/cli/cmds/kubeconfig"
-	"github.com/rancher/k3k/pkg/buildinfo"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
 )
 
 func main() {
 	app := cmds.NewApp()
-	app.Version = buildinfo.Version
-	cli.VersionPrinter = func(cCtx *cli.Context) {
-		fmt.Println("k3kcli Version: " + buildinfo.Version)
-	}
-
-	app.Commands = []*cli.Command{
-		cluster.NewCommand(),
-		kubeconfig.NewCommand(),
-	}
-
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)
 	}

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -117,14 +117,12 @@ The `serverArgs` field allows you to specify additional arguments to be passed t
 
 You can check the [k3kcli documentation](./cli/cli-docs.md) for the full specs.
 
-### Examples for no storage provider:
+### No storage provider:
 
 * Ephemeral Storage:
 
     ```bash
-
     k3kcli cluster create my-cluster --persistence-type ephemeral
-
     ```
 
 *Important Notes:*

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -127,19 +127,7 @@ You can check the [k3kcli documentation](./cli/cli-docs.md) for the full specs.
 
     ```
 
-* Static Storage (Requires pre-provisioned PVs):
-
-    ```bash
-
-    k3kcli cluster create my-cluster --persistence-type static
-
-    ```
-
-    (You will need to ensure that persistent volumes that match the requirements of your k3k cluster exist before creation)
-
 *Important Notes:*
-
-* When using `--persistence-type static`, you must manually create PersistentVolumes (PVs) that match the storage requirements of your K3K cluster.
 
 * Using `--persistence-type ephemeral` will result in data loss if the nodes are restarted.
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -6,7 +6,7 @@ This document provides advanced usage information for k3k, including detailed us
 
 The `Cluster` resource provides a variety of fields for customizing the behavior of your virtual clusters. You can check the [CRD documentation](./crds/crd-docs.md) for the full specs.
 
-**Note:** Most of these customization options can also be configured using the `k3kcli` tool. Refer to the `k3kcli` documentation for more details.
+**Note:** Most of these customization options can also be configured using the `k3kcli` tool. Refer to the [k3kcli](./cli/cli-docs.md) documentation for more details.
 
 
 
@@ -112,3 +112,35 @@ The `clusterDNS` field specifies the IP address for the CoreDNS service. It need
 ### `serverArgs`
 
 The `serverArgs` field allows you to specify additional arguments to be passed to the K3s server pods.
+
+## Using the cli
+
+You can check the [k3kcli documentation](./cli/cli-docs.md) for the full specs.
+
+### Examples for no storage provider:
+
+* Ephemeral Storage:
+
+    ```bash
+
+    k3kcli cluster create my-cluster --persistence-type ephemeral
+
+    ```
+
+* Static Storage (Requires pre-provisioned PVs):
+
+    ```bash
+
+    k3kcli cluster create my-cluster --persistence-type static
+
+    ```
+
+    (You will need to ensure that persistent volumes that match the requirements of your k3k cluster exist before creation)
+
+*Important Notes:*
+
+* When using `--persistence-type static`, you must manually create PersistentVolumes (PVs) that match the storage requirements of your K3K cluster.
+
+* Using `--persistence-type ephemeral` will result in data loss if the nodes are restarted.
+
+* It is highly recommended to use `--persistence-type dynamic` with a configured storage class.

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -1,0 +1,98 @@
+# NAME
+
+k3kcli - CLI for K3K
+
+# SYNOPSIS
+
+k3kcli
+
+```
+[--debug]
+```
+
+**Usage**:
+
+```
+k3kcli [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+```
+
+# GLOBAL OPTIONS
+
+**--debug**: Turn on debug logs
+
+
+# COMMANDS
+
+## cluster
+
+cluster command
+
+### create
+
+Create new cluster
+
+>k3kcli cluster create [command options] NAME
+
+**--agent-args**="": agents extra arguments
+
+**--agents**="": number of agents (default: 0)
+
+**--cluster-cidr**="": cluster CIDR
+
+**--kubeconfig**="": kubeconfig path (default: "/home/jpgouin/.kube/config")
+
+**--kubeconfig-server**="": override the kubeconfig server host
+
+**--mode**="": k3k mode type (shared, virtual) (default: "shared")
+
+**--namespace**="": namespace to create the k3k cluster in
+
+**--persistence-type**="": persistence mode for the nodes (ephemeral, static, dynamic) (default: "dynamic")
+
+**--server-args**="": servers extra arguments
+
+**--servers**="": number of servers (default: 1)
+
+**--service-cidr**="": service CIDR
+
+**--storage-class-name**="": storage class name for dynamic persistence type
+
+**--token**="": token of the cluster
+
+**--version**="": k3s version
+
+### delete
+
+Delete an existing cluster
+
+>k3kcli cluster delete [command options] NAME
+
+**--kubeconfig**="": kubeconfig path (default: "/home/jpgouin/.kube/config")
+
+**--namespace**="": namespace to create the k3k cluster in
+
+## kubeconfig
+
+Manage kubeconfig for clusters
+
+### generate
+
+Generate kubeconfig for clusters
+
+**--altNames**="": altNames of the generated certificates for the kubeconfig
+
+**--cn**="": Common name (CN) of the generated certificates for the kubeconfig (default: "system:admin")
+
+**--config-name**="": the name of the generated kubeconfig file
+
+**--expiration-days**="": Expiration date of the certificates used for the kubeconfig (default: 356)
+
+**--kubeconfig**="": kubeconfig path (default: "/home/jpgouin/.kube/config")
+
+**--kubeconfig-server**="": override the kubeconfig server host
+
+**--name**="": cluster name
+
+**--namespace**="": namespace to create the k3k cluster in
+
+**--org**="": Organization name (ORG) of the generated certificates for the kubeconfig

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -39,7 +39,7 @@ Create new cluster
 
 **--cluster-cidr**="": cluster CIDR
 
-**--kubeconfig**="": kubeconfig path (default: "/home/jpgouin/.kube/config")
+**--kubeconfig**="": kubeconfig path (default: "$HOME/.kube/config")
 
 **--kubeconfig-server**="": override the kubeconfig server host
 
@@ -67,7 +67,7 @@ Delete an existing cluster
 
 >k3kcli cluster delete [command options] NAME
 
-**--kubeconfig**="": kubeconfig path (default: "/home/jpgouin/.kube/config")
+**--kubeconfig**="": kubeconfig path (default: "$HOME/.kube/config")
 
 **--namespace**="": namespace to create the k3k cluster in
 
@@ -87,7 +87,7 @@ Generate kubeconfig for clusters
 
 **--expiration-days**="": Expiration date of the certificates used for the kubeconfig (default: 356)
 
-**--kubeconfig**="": kubeconfig path (default: "/home/jpgouin/.kube/config")
+**--kubeconfig**="": kubeconfig path (default: "$HOME/.kube/config")
 
 **--kubeconfig-server**="": override the kubeconfig server host
 

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -47,7 +47,7 @@ Create new cluster
 
 **--namespace**="": namespace to create the k3k cluster in
 
-**--persistence-type**="": persistence mode for the nodes (ephemeral, static, dynamic) (default: "dynamic")
+**--persistence-type**="": persistence mode for the nodes (dynamic, ephemeral, static) (default: "dynamic")
 
 **--server-args**="": servers extra arguments
 

--- a/docs/cli/genclidoc.go
+++ b/docs/cli/genclidoc.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/rancher/k3k/cli/cmds"
+)
+
+func main() {
+	// Instantiate the CLI application
+	app := cmds.NewApp()
+
+	// Generate the Markdown documentation
+	md, err := app.ToMarkdown()
+	if err != nil {
+		fmt.Println("Error generating documentation:", err)
+		os.Exit(1)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	outputFile := path.Join(wd, "docs/cli/cli-docs.md")
+	err = os.WriteFile(outputFile, []byte(md), 0644)
+	if err != nil {
+		fmt.Println("Error generating documentation:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Documentation generated at " + outputFile)
+}

--- a/docs/cli/genclidoc.go
+++ b/docs/cli/genclidoc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -26,6 +27,13 @@ func main() {
 	}
 
 	outputFile := path.Join(wd, "docs/cli/cli-docs.md")
+
+	// Check if the file exists and if the content is different
+	existingContent, err := os.ReadFile(outputFile)
+	if err == nil && bytes.Equal(existingContent, []byte(md)) {
+		fmt.Println("Documentation is up to date, no changes made.")
+		return
+	}
 
 	err = os.WriteFile(outputFile, []byte(md), 0644)
 	if err != nil {

--- a/docs/cli/genclidoc.go
+++ b/docs/cli/genclidoc.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -27,13 +26,6 @@ func main() {
 	}
 
 	outputFile := path.Join(wd, "docs/cli/cli-docs.md")
-
-	// Check if the file exists and if the content is different
-	existingContent, err := os.ReadFile(outputFile)
-	if err == nil && bytes.Equal(existingContent, []byte(md)) {
-		fmt.Println("Cli Documentation is up to date, no changes made.")
-		return
-	}
 
 	err = os.WriteFile(outputFile, []byte(md), 0644)
 	if err != nil {

--- a/docs/cli/genclidoc.go
+++ b/docs/cli/genclidoc.go
@@ -26,6 +26,7 @@ func main() {
 	}
 
 	outputFile := path.Join(wd, "docs/cli/cli-docs.md")
+
 	err = os.WriteFile(outputFile, []byte(md), 0644)
 	if err != nil {
 		fmt.Println("Error generating documentation:", err)

--- a/docs/cli/genclidoc.go
+++ b/docs/cli/genclidoc.go
@@ -31,7 +31,7 @@ func main() {
 	// Check if the file exists and if the content is different
 	existingContent, err := os.ReadFile(outputFile)
 	if err == nil && bytes.Equal(existingContent, []byte(md)) {
-		fmt.Println("Documentation is up to date, no changes made.")
+		fmt.Println("Cli Documentation is up to date, no changes made.")
 		return
 	}
 

--- a/docs/crds/Makefile
+++ b/docs/crds/Makefile
@@ -1,6 +1,0 @@
-CRD_REF_DOCS_VER := v0.1.0
-CRD_REF_DOCS := go run github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VER)
-
-.PHONY: generate
-generate:
-	$(CRD_REF_DOCS) --config=config.yaml --renderer=markdown --source-path=../../pkg/apis/k3k.io/v1alpha1 --output-path=crd-docs.md


### PR DESCRIPTION
Update the pre-requisite list to include:
* a storage provider and default storage class 
* A RKE2 host (recommended) 

Add a cli documentation and provide examples to provision a cluster with `static` and `ephemeral` storage
