### PR TITLE
Added `wsl` linter, and fixed related issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,4 @@ linters:
 
   # extra
   - misspell
+  - wsl

--- a/cli/cmds/cluster/create.go
+++ b/cli/cmds/cluster/create.go
@@ -97,6 +97,7 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 
 		if config.token != "" {
 			logrus.Infof("Creating cluster token secret")
+
 			obj := k3kcluster.TokenSecretObj(config.token, name, cmds.Namespace())
 			if err := ctrlClient.Create(ctx, &obj); err != nil {
 				return err
@@ -116,10 +117,12 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
+
 		host := strings.Split(url.Host, ":")
 		if config.kubeconfigServerHost != "" {
 			host = []string{config.kubeconfigServerHost}
 		}
+
 		cluster.Spec.TLSSANs = []string{host[0]}
 
 		if err := ctrlClient.Create(ctx, cluster); err != nil {
@@ -144,6 +147,7 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 		cfg := kubeconfig.New()
 
 		var kubeconfig *clientcmdapi.Config
+
 		if err := retry.OnError(availableBackoff, apierrors.IsNotFound, func() error {
 			kubeconfig, err = cfg.Extract(ctx, ctrlClient, cluster, host[0])
 			return err
@@ -199,6 +203,7 @@ func newCluster(name, namespace string, config *CreateConfig) *v1alpha1.Cluster 
 	if config.storageClassName == "" {
 		cluster.Spec.Persistence.StorageClassName = nil
 	}
+
 	if config.token != "" {
 		cluster.Spec.TokenSecretRef = &v1.SecretReference{
 			Name:      k3kcluster.TokenSecretName(name),

--- a/cli/cmds/cluster/delete.go
+++ b/cli/cmds/cluster/delete.go
@@ -57,5 +57,6 @@ func delete(clx *cli.Context) error {
 			Namespace: cmds.Namespace(),
 		},
 	}
+
 	return ctrlClient.Delete(ctx, &cluster)
 }

--- a/cli/cmds/kubeconfig/kubeconfig.go
+++ b/cli/cmds/kubeconfig/kubeconfig.go
@@ -102,6 +102,7 @@ func NewCommand() *cli.Command {
 
 func generate(clx *cli.Context) error {
 	var cluster v1alpha1.Cluster
+
 	ctx := context.Background()
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", cmds.Kubeconfig)
@@ -115,6 +116,7 @@ func generate(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	clusterKey := types.NamespacedName{
 		Name:      name,
 		Namespace: cmds.Namespace(),
@@ -128,11 +130,12 @@ func generate(clx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	host := strings.Split(url.Host, ":")
 	if kubeconfigServerHost != "" {
 		host = []string{kubeconfigServerHost}
-		err := altNames.Set(kubeconfigServerHost)
-		if err != nil {
+
+		if err := altNames.Set(kubeconfigServerHost); err != nil {
 			return err
 		}
 	}
@@ -154,6 +157,7 @@ func generate(clx *cli.Context) error {
 	logrus.Infof("waiting for cluster to be available..")
 
 	var kubeconfig *clientcmdapi.Config
+
 	if err := retry.OnError(controller.Backoff, apierrors.IsNotFound, func() error {
 		kubeconfig, err = cfg.Extract(ctx, ctrlClient, &cluster, host[0])
 		return err

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -48,6 +48,7 @@ func NewApp() *cli.App {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
+
 		return nil
 	}
 
@@ -58,5 +59,6 @@ func Namespace() string {
 	if namespace == "" {
 		return defaultNamespace
 	}
+
 	return namespace
 }

--- a/k3k-kubelet/config.go
+++ b/k3k-kubelet/config.go
@@ -31,33 +31,43 @@ func (c *config) unmarshalYAML(data []byte) error {
 	if c.ClusterName == "" {
 		c.ClusterName = conf.ClusterName
 	}
+
 	if c.ClusterNamespace == "" {
 		c.ClusterNamespace = conf.ClusterNamespace
 	}
+
 	if c.HostConfigPath == "" {
 		c.HostConfigPath = conf.HostConfigPath
 	}
+
 	if c.VirtualConfigPath == "" {
 		c.VirtualConfigPath = conf.VirtualConfigPath
 	}
+
 	if c.KubeletPort == "" {
 		c.KubeletPort = conf.KubeletPort
 	}
+
 	if c.AgentHostname == "" {
 		c.AgentHostname = conf.AgentHostname
 	}
+
 	if c.ServiceName == "" {
 		c.ServiceName = conf.ServiceName
 	}
+
 	if c.Token == "" {
 		c.Token = conf.Token
 	}
+
 	if c.ServerIP == "" {
 		c.ServerIP = conf.ServerIP
 	}
+
 	if c.Version == "" {
 		c.Version = conf.Version
 	}
+
 	return nil
 }
 
@@ -65,12 +75,15 @@ func (c *config) validate() error {
 	if c.ClusterName == "" {
 		return errors.New("cluster name is not provided")
 	}
+
 	if c.ClusterNamespace == "" {
 		return errors.New("cluster namespace is not provided")
 	}
+
 	if c.AgentHostname == "" {
 		return errors.New("agent Hostname is not provided")
 	}
+
 	return nil
 }
 
@@ -83,5 +96,6 @@ func (c *config) parse(path string) error {
 	if err != nil {
 		return err
 	}
+
 	return c.unmarshalYAML(b)
 }

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -82,6 +82,7 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 	if err != nil {
 		return nil, err
 	}
+
 	virtConfig, err := virtRestConfig(ctx, c.VirtualConfigPath, hostClient, c.ClusterName, c.ClusterNamespace, c.Token, logger)
 	if err != nil {
 		return nil, err
@@ -110,15 +111,16 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 		return nil, errors.New("unable to create controller-runtime mgr for host cluster: " + err.Error())
 	}
 
-	virtualScheme := runtime.NewScheme()
 	// virtual client will only use core types (for now), no need to add anything other than the basics
-	err = clientgoscheme.AddToScheme(virtualScheme)
-	if err != nil {
+	virtualScheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(virtualScheme); err != nil {
 		return nil, errors.New("unable to add client go types to virtual cluster scheme: " + err.Error())
 	}
+
 	webhookServer := webhook.NewServer(webhook.Options{
 		CertDir: "/opt/rancher/k3k-webhook",
 	})
+
 	virtualMgr, err := ctrl.NewManager(virtConfig, manager.Options{
 		Scheme:                  virtualScheme,
 		WebhookServer:           webhookServer,
@@ -129,25 +131,31 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 			BindAddress: ":8084",
 		},
 	})
+
 	if err != nil {
 		return nil, errors.New("unable to create controller-runtime mgr for virtual cluster: " + err.Error())
 	}
+
 	logger.Info("adding pod mutator webhook")
+
 	if err := k3kwebhook.AddPodMutatorWebhook(ctx, virtualMgr, hostClient, c.ClusterName, c.ClusterNamespace, c.ServiceName, logger); err != nil {
 		return nil, errors.New("unable to add pod mutator webhook for virtual cluster: " + err.Error())
 	}
 
 	logger.Info("adding service syncer controller")
+
 	if err := k3kkubeletcontroller.AddServiceSyncer(ctx, virtualMgr, hostMgr, c.ClusterName, c.ClusterNamespace, k3klog.New(false)); err != nil {
 		return nil, errors.New("failed to add service syncer controller: " + err.Error())
 	}
 
 	logger.Info("adding pvc syncer controller")
+
 	if err := k3kkubeletcontroller.AddPVCSyncer(ctx, virtualMgr, hostMgr, c.ClusterName, c.ClusterNamespace, k3klog.New(false)); err != nil {
 		return nil, errors.New("failed to add pvc syncer controller: " + err.Error())
 	}
 
 	logger.Info("adding pod pvc controller")
+
 	if err := k3kkubeletcontroller.AddPodPVCController(ctx, virtualMgr, hostMgr, c.ClusterName, c.ClusterNamespace, k3klog.New(false)); err != nil {
 		return nil, errors.New("failed to add pod pvc controller: " + err.Error())
 	}
@@ -159,6 +167,7 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 
 	// get the cluster's DNS IP to be injected to pods
 	var dnsService v1.Service
+
 	dnsName := controller.SafeConcatNameWithPrefix(c.ClusterName, "kube-dns")
 	if err := hostClient.Get(ctx, types.NamespacedName{Name: dnsName, Namespace: c.ClusterNamespace}, &dnsService); err != nil {
 		return nil, errors.New("failed to get the DNS service for the cluster: " + err.Error())
@@ -188,10 +197,16 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 
 func clusterIP(ctx context.Context, serviceName, clusterNamespace string, hostClient ctrlruntimeclient.Client) (string, error) {
 	var service v1.Service
-	serviceKey := types.NamespacedName{Namespace: clusterNamespace, Name: serviceName}
+
+	serviceKey := types.NamespacedName{
+		Namespace: clusterNamespace,
+		Name:      serviceName,
+	}
+
 	if err := hostClient.Get(ctx, serviceKey, &service); err != nil {
 		return "", err
 	}
+
 	return service.Spec.ClusterIP, nil
 }
 
@@ -200,10 +215,12 @@ func (k *kubelet) registerNode(ctx context.Context, agentIP, srvPort, namespace,
 	nodeOpts := k.nodeOpts(ctx, srvPort, namespace, name, hostname, agentIP)
 
 	var err error
+
 	k.node, err = nodeutil.NewNode(k.name, providerFunc, nodeutil.WithClient(k.virtClient), nodeOpts)
 	if err != nil {
 		return errors.New("unable to start kubelet: " + err.Error())
 	}
+
 	return nil
 }
 
@@ -236,10 +253,13 @@ func (k *kubelet) start(ctx context.Context) {
 	if err := k.node.WaitReady(context.Background(), time.Minute*1); err != nil {
 		k.logger.Fatalw("node was not ready within timeout of 1 minute", zap.Error(err))
 	}
+
 	<-k.node.Done()
+
 	if err := k.node.Err(); err != nil {
 		k.logger.Fatalw("node stopped with an error", zap.Error(err))
 	}
+
 	k.logger.Info("node exited successfully")
 }
 
@@ -264,13 +284,16 @@ func (k *kubelet) nodeOpts(ctx context.Context, srvPort, namespace, name, hostna
 		if err := nodeutil.AttachProviderRoutes(mux)(c); err != nil {
 			return errors.New("unable to attach routes: " + err.Error())
 		}
+
 		c.Handler = mux
 
 		tlsConfig, err := loadTLSConfig(ctx, k.hostClient, name, namespace, k.name, hostname, k.token, agentIP)
 		if err != nil {
 			return errors.New("unable to get tls config: " + err.Error())
 		}
+
 		c.TLSConfig = tlsConfig
+
 		return nil
 	}
 }
@@ -284,8 +307,11 @@ func virtRestConfig(ctx context.Context, virtualConfigPath string, hostClient ct
 	if err := hostClient.Get(ctx, types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, &cluster); err != nil {
 		return nil, err
 	}
+
 	endpoint := server.ServiceName(cluster.Name) + "." + cluster.Namespace
+
 	var b *bootstrap.ControlRuntimeBootstrap
+
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
 		return err != nil
 	}, func() error {
@@ -296,20 +322,27 @@ func virtRestConfig(ctx context.Context, virtualConfigPath string, hostClient ct
 	}); err != nil {
 		return nil, errors.New("unable to decode bootstrap: " + err.Error())
 	}
+
 	adminCert, adminKey, err := certs.CreateClientCertKey(
-		controller.AdminCommonName, []string{user.SystemPrivilegedGroup},
-		nil, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, time.Hour*24*time.Duration(356),
+		controller.AdminCommonName,
+		[]string{user.SystemPrivilegedGroup},
+		nil, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		time.Hour*24*time.Duration(356),
 		b.ClientCA.Content,
-		b.ClientCAKey.Content)
+		b.ClientCAKey.Content,
+	)
+
 	if err != nil {
 		return nil, err
 	}
 
 	url := fmt.Sprintf("https://%s:%d", server.ServiceName(cluster.Name), server.ServerPort)
+
 	kubeconfigData, err := kubeconfigBytes(url, []byte(b.ServerCA.Content), adminCert, adminKey)
 	if err != nil {
 		return nil, err
 	}
+
 	return clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 }
 
@@ -341,10 +374,13 @@ func loadTLSConfig(ctx context.Context, hostClient ctrlruntimeclient.Client, clu
 		cluster v1alpha1.Cluster
 		b       *bootstrap.ControlRuntimeBootstrap
 	)
+
 	if err := hostClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, &cluster); err != nil {
 		return nil, err
 	}
+
 	endpoint := fmt.Sprintf("%s.%s", server.ServiceName(cluster.Name), cluster.Namespace)
+
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
 		return err != nil
 	}, func() error {
@@ -354,27 +390,34 @@ func loadTLSConfig(ctx context.Context, hostClient ctrlruntimeclient.Client, clu
 	}); err != nil {
 		return nil, errors.New("unable to decode bootstrap: " + err.Error())
 	}
+
 	ip := net.ParseIP(agentIP)
+
 	altNames := certutil.AltNames{
 		DNSNames: []string{hostname},
 		IPs:      []net.IP{ip},
 	}
+
 	cert, key, err := certs.CreateClientCertKey(nodeName, nil, &altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, 0, b.ServerCA.Content, b.ServerCAKey.Content)
 	if err != nil {
 		return nil, errors.New("unable to get cert and key: " + err.Error())
 	}
+
 	clientCert, err := tls.X509KeyPair(cert, key)
 	if err != nil {
 		return nil, errors.New("unable to get key pair: " + err.Error())
 	}
+
 	// create rootCA CertPool
 	certs, err := certutil.ParseCertsPEM([]byte(b.ServerCA.Content))
 	if err != nil {
 		return nil, errors.New("unable to create ca certs: " + err.Error())
 	}
+
 	if len(certs) < 1 {
 		return nil, errors.New("ca cert is not parsed correctly")
 	}
+
 	pool := x509.NewCertPool()
 	pool.AddCert(certs[0])
 

--- a/k3k-kubelet/main.go
+++ b/k3k-kubelet/main.go
@@ -102,9 +102,11 @@ func main() {
 	app.Before = func(clx *cli.Context) error {
 		logger = log.New(debug)
 		ctrlruntimelog.SetLogger(zapr.NewLogger(logger.Desugar().WithOptions(zap.AddCallerSkip(1))))
+
 		return nil
 	}
 	app.Action = run
+
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)
 	}
@@ -112,6 +114,7 @@ func main() {
 
 func run(clx *cli.Context) error {
 	ctx := context.Background()
+
 	if err := cfg.parse(configFile); err != nil {
 		logger.Fatalw("failed to parse config file", "path", configFile, zap.Error(err))
 	}
@@ -119,6 +122,7 @@ func run(clx *cli.Context) error {
 	if err := cfg.validate(); err != nil {
 		logger.Fatalw("failed to validate config", zap.Error(err))
 	}
+
 	k, err := newKubelet(ctx, &cfg, logger)
 	if err != nil {
 		logger.Fatalw("failed to create new virtual kubelet instance", zap.Error(err))

--- a/k3k-kubelet/provider/collectors/kubelet_resource_metrics.go
+++ b/k3k-kubelet/provider/collectors/kubelet_resource_metrics.go
@@ -107,6 +107,7 @@ func (rc *resourceMetricsCollector) DescribeWithStability(ch chan<- *compbasemet
 // custom collector in a way that only collects metrics for active containers.
 func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- compbasemetrics.Metric) {
 	var errorCount float64
+
 	defer func() {
 		ch <- compbasemetrics.NewLazyConstMetric(resourceScrapeResultDesc, compbasemetrics.GaugeValue, errorCount)
 	}()
@@ -121,6 +122,7 @@ func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- compbasemetri
 			rc.collectContainerCPUMetrics(ch, pod, container)
 			rc.collectContainerMemoryMetrics(ch, pod, container)
 		}
+
 		rc.collectPodCPUMetrics(ch, pod)
 		rc.collectPodMemoryMetrics(ch, pod)
 	}

--- a/k3k-kubelet/provider/configure.go
+++ b/k3k-kubelet/provider/configure.go
@@ -119,6 +119,7 @@ func updateNodeCapacity(coreClient typedv1.CoreV1Interface, virtualClient client
 // If some node labels are specified only the matching nodes will be considered.
 func getResourcesFromNodes(ctx context.Context, coreClient typedv1.CoreV1Interface, nodeLabels map[string]string) (v1.ResourceList, v1.ResourceList, error) {
 	listOpts := metav1.ListOptions{}
+
 	if nodeLabels != nil {
 		labelSelector := metav1.LabelSelector{MatchLabels: nodeLabels}
 		listOpts.LabelSelector = labels.Set(labelSelector.MatchLabels).String()
@@ -134,7 +135,6 @@ func getResourcesFromNodes(ctx context.Context, coreClient typedv1.CoreV1Interfa
 	virtualAvailableResources := corev1.ResourceList{}
 
 	for _, node := range nodeList.Items {
-
 		// check if the node is Ready
 		for _, condition := range node.Status.Conditions {
 			if condition.Type != corev1.NodeReady {

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -13,6 +13,7 @@ func Test_overrideEnvVars(t *testing.T) {
 		orig []corev1.EnvVar
 		new  []corev1.EnvVar
 	}
+
 	tests := []struct {
 		name string
 		args args

--- a/k3k-kubelet/provider/util.go
+++ b/k3k-kubelet/provider/util.go
@@ -17,9 +17,9 @@ func (t *translatorSizeQueue) Next() *remotecommand.TerminalSize {
 	if !ok {
 		return nil
 	}
-	newSize := remotecommand.TerminalSize{
+
+	return &remotecommand.TerminalSize{
 		Width:  size.Width,
 		Height: size.Height,
 	}
-	return &newSize
 }

--- a/k3k-kubelet/translate/host.go
+++ b/k3k-kubelet/translate/host.go
@@ -45,14 +45,17 @@ func (t *ToHostTranslator) TranslateTo(obj client.Object) {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+
 	annotations[ResourceNameAnnotation] = obj.GetName()
 	annotations[ResourceNamespaceAnnotation] = obj.GetNamespace()
 	obj.SetAnnotations(annotations)
+
 	// add a label to quickly identify objects owned by a given virtual cluster
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
+
 	labels[ClusterNameLabel] = t.ClusterName
 	obj.SetLabels(labels)
 
@@ -77,6 +80,7 @@ func (t *ToHostTranslator) TranslateFrom(obj client.Object) {
 	// In this case, we need to have some sort of fallback or error return
 	name := annotations[ResourceNameAnnotation]
 	namespace := annotations[ResourceNamespaceAnnotation]
+
 	obj.SetName(name)
 	obj.SetNamespace(namespace)
 	delete(annotations, ResourceNameAnnotation)
@@ -91,7 +95,6 @@ func (t *ToHostTranslator) TranslateFrom(obj client.Object) {
 	// resource version/UID won't match what's in the virtual cluster.
 	obj.SetResourceVersion("")
 	obj.SetUID("")
-
 }
 
 // TranslateName returns the name of the resource in the host cluster. Will not update the object with this name.
@@ -106,5 +109,6 @@ func (t *ToHostTranslator) TranslateName(namespace string, name string) string {
 	nameKey := fmt.Sprintf("%s+%s+%s", name, namespace, t.ClusterName)
 	// it's possible that the suffix will be in the name, so we use hex to make it valid for k8s
 	nameSuffix := hex.EncodeToString([]byte(nameKey))
+
 	return controller.SafeConcatName(namePrefix, nameSuffix)
 }

--- a/main.go
+++ b/main.go
@@ -82,9 +82,12 @@ func main() {
 		if err := validate(); err != nil {
 			return err
 		}
+
 		logger = log.New(debug)
+
 		return nil
 	}
+
 	if err := app.Run(os.Args); err != nil {
 		logger.Fatalw("failed to run k3k controller", zap.Error(err))
 	}
@@ -111,22 +114,26 @@ func run(clx *cli.Context) error {
 	ctrlruntimelog.SetLogger(zapr.NewLogger(logger.Desugar().WithOptions(zap.AddCallerSkip(1))))
 
 	logger.Info("adding cluster controller")
+
 	if err := cluster.Add(ctx, mgr, sharedAgentImage, sharedAgentImagePullPolicy); err != nil {
 		return fmt.Errorf("failed to add the new cluster controller: %v", err)
 	}
 
 	logger.Info("adding etcd pod controller")
+
 	if err := cluster.AddPodController(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to add the new cluster controller: %v", err)
 	}
 
 	logger.Info("adding clusterset controller")
+
 	if err := clusterset.Add(ctx, mgr, clusterCIDR); err != nil {
 		return fmt.Errorf("failed to add the clusterset controller: %v", err)
 	}
 
 	if clusterCIDR == "" {
 		logger.Info("adding networkpolicy node controller")
+
 		if err := clusterset.AddNodeController(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to add the clusterset node controller: %v", err)
 		}
@@ -147,5 +154,6 @@ func validate() error {
 			return errors.New("invalid value for shared agent image policy")
 		}
 	}
+
 	return nil
 }

--- a/pkg/apis/k3k.io/v1alpha1/register.go
+++ b/pkg/apis/k3k.io/v1alpha1/register.go
@@ -25,5 +25,6 @@ func addKnownTypes(s *runtime.Scheme) error {
 		&ClusterSetList{},
 	)
 	metav1.AddToGroupVersion(s, SchemeGroupVersion)
+
 	return nil
 }

--- a/pkg/controller/certs/certs.go
+++ b/pkg/controller/certs/certs.go
@@ -40,6 +40,7 @@ func CreateClientCertKey(commonName string, organization []string, altNames *cer
 	if altNames != nil {
 		cfg.AltNames = *altNames
 	}
+
 	cert, err := certutil.NewSignedCert(cfg, key.(crypto.Signer), caCertPEM[0], caKeyPEM.(crypto.Signer))
 	if err != nil {
 		return nil, nil, err
@@ -59,6 +60,7 @@ func generateKey() (data []byte, err error) {
 
 func AddSANs(sans []string) certutil.AltNames {
 	var altNames certutil.AltNames
+
 	for _, san := range sans {
 		ip := net.ParseIP(san)
 		if ip == nil {
@@ -67,5 +69,6 @@ func AddSANs(sans []string) certutil.AltNames {
 			altNames.IPs = append(altNames.IPs, ip)
 		}
 	}
+
 	return altNames
 }

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -96,6 +96,7 @@ func sharedAgentData(cluster *v1alpha1.Cluster, serviceName, token, ip string) s
 	if cluster.Spec.Version == "" {
 		version = cluster.Status.HostVersion
 	}
+
 	return fmt.Sprintf(`clusterName: %s
 clusterNamespace: %s
 serverIP: %s
@@ -139,7 +140,6 @@ func (s *SharedAgent) daemonset(ctx context.Context) error {
 }
 
 func (s *SharedAgent) podSpec() v1.PodSpec {
-	var limit v1.ResourceList
 	return v1.PodSpec{
 		ServiceAccountName: s.Name(),
 		NodeSelector:       s.cluster.Spec.NodeSelector,
@@ -187,7 +187,7 @@ func (s *SharedAgent) podSpec() v1.PodSpec {
 				Image:           s.image,
 				ImagePullPolicy: v1.PullPolicy(s.imagePullPolicy),
 				Resources: v1.ResourceRequirements{
-					Limits: limit,
+					Limits: v1.ResourceList{},
 				},
 				Args: []string{
 					"--config",
@@ -406,6 +406,7 @@ func (s *SharedAgent) webhookTLS(ctx context.Context) error {
 		}
 
 		altNames := []string{s.Name(), s.cluster.Name}
+
 		webhookCert, webhookKey, err := newWebhookCerts(s.Name(), altNames, caPrivateKeyPEM, caCertPEM)
 		if err != nil {
 			return err

--- a/pkg/controller/cluster/agent/shared_test.go
+++ b/pkg/controller/cluster/agent/shared_test.go
@@ -16,6 +16,7 @@ func Test_sharedAgentData(t *testing.T) {
 		ip          string
 		token       string
 	}
+
 	tests := []struct {
 		name         string
 		args         args
@@ -100,6 +101,7 @@ func Test_sharedAgentData(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := sharedAgentData(tt.args.cluster, tt.args.serviceName, tt.args.token, tt.args.ip)

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -81,6 +81,7 @@ func (v *VirtualAgent) deployment(ctx context.Context) error {
 	image := controller.K3SImage(v.cluster)
 
 	const name = "k3k-agent"
+
 	selector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"cluster": v.cluster.Name,
@@ -116,7 +117,9 @@ func (v *VirtualAgent) deployment(ctx context.Context) error {
 
 func (v *VirtualAgent) podSpec(image, name string, args []string, affinitySelector *metav1.LabelSelector) v1.PodSpec {
 	var limit v1.ResourceList
+
 	args = append([]string{"agent", "--config", "/opt/rancher/k3s/config.yaml"}, args...)
+
 	podSpec := v1.PodSpec{
 		Volumes: []v1.Volume{
 			{

--- a/pkg/controller/cluster/agent/virtual_test.go
+++ b/pkg/controller/cluster/agent/virtual_test.go
@@ -12,6 +12,7 @@ func Test_virtualAgentData(t *testing.T) {
 		serviceIP string
 		token     string
 	}
+
 	tests := []struct {
 		name         string
 		args         args
@@ -30,6 +31,7 @@ func Test_virtualAgentData(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := virtualAgentData(tt.args.serviceIP, tt.args.token)

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -184,9 +184,12 @@ func (c *ClusterReconciler) reconcileCluster(ctx context.Context, cluster *v1alp
 		// in shared mode try to lookup the serviceCIDR
 		if cluster.Spec.Mode == v1alpha1.SharedClusterMode {
 			log.Info("looking up Service CIDR for shared mode")
+
 			cluster.Status.ServiceCIDR, err = c.lookupServiceCIDR(ctx)
+
 			if err != nil {
 				log.Error(err, "error while looking up Cluster Service CIDR")
+
 				cluster.Status.ServiceCIDR = defaultSharedServiceCIDR
 			}
 		}
@@ -194,6 +197,7 @@ func (c *ClusterReconciler) reconcileCluster(ctx context.Context, cluster *v1alp
 		// in virtual mode assign a default serviceCIDR
 		if cluster.Spec.Mode == v1alpha1.VirtualClusterMode {
 			log.Info("assign default service CIDR for virtual mode")
+
 			cluster.Status.ServiceCIDR = defaultVirtualServiceCIDR
 		}
 	}
@@ -202,6 +206,7 @@ func (c *ClusterReconciler) reconcileCluster(ctx context.Context, cluster *v1alp
 	if err != nil {
 		return err
 	}
+
 	serviceIP := service.Spec.ClusterIP
 
 	if err := c.createClusterConfigs(ctx, cluster, s, serviceIP); err != nil {
@@ -252,8 +257,10 @@ func (c *ClusterReconciler) ensureBootstrapSecret(ctx context.Context, cluster *
 		bootstrapSecret.Data = map[string][]byte{
 			"bootstrap": bootstrapData,
 		}
+
 		return nil
 	})
+
 	return err
 }
 
@@ -279,9 +286,11 @@ func (c *ClusterReconciler) createClusterConfigs(ctx context.Context, cluster *v
 	if err != nil {
 		return err
 	}
+
 	if err := controllerutil.SetControllerReference(cluster, serverConfig, c.Scheme); err != nil {
 		return err
 	}
+
 	if err := c.Client.Create(ctx, serverConfig); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return err
@@ -304,8 +313,10 @@ func (c *ClusterReconciler) ensureClusterService(ctx context.Context, cluster *v
 		}
 
 		currentService.Spec = expectedService.Spec
+
 		return nil
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -341,6 +352,7 @@ func (c *ClusterReconciler) ensureIngress(ctx context.Context, cluster *v1alpha1
 
 		return nil
 	})
+
 	if err != nil {
 		return err
 	}
@@ -361,6 +373,7 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 	if err := controllerutil.SetControllerReference(cluster, serverStatefulService, c.Scheme); err != nil {
 		return err
 	}
+
 	if err := c.Client.Create(ctx, serverStatefulService); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return err
@@ -371,12 +384,15 @@ func (c *ClusterReconciler) server(ctx context.Context, cluster *v1alpha1.Cluste
 	if err != nil {
 		return err
 	}
+
 	currentServerStatefulSet := expectedServerStatefulSet.DeepCopy()
 	result, err := controllerutil.CreateOrUpdate(ctx, c.Client, currentServerStatefulSet, func() error {
 		if err := controllerutil.SetControllerReference(cluster, currentServerStatefulSet, c.Scheme); err != nil {
 			return err
 		}
+
 		currentServerStatefulSet.Spec = expectedServerStatefulSet.Spec
+
 		return nil
 	})
 
@@ -397,6 +413,7 @@ func (c *ClusterReconciler) bindNodeProxyClusterRole(ctx context.Context, cluste
 	subjectName := controller.SafeConcatNameWithPrefix(cluster.Name, agent.SharedNodeAgentName)
 
 	found := false
+
 	for _, subject := range clusterRoleBinding.Subjects {
 		if subject.Name == subjectName && subject.Namespace == cluster.Namespace {
 			found = true
@@ -431,6 +448,7 @@ func (c *ClusterReconciler) validate(cluster *v1alpha1.Cluster) error {
 	if cluster.Name == ClusterInvalidName {
 		return errors.New("invalid cluster name " + cluster.Name + " no action will be taken")
 	}
+
 	return nil
 }
 
@@ -462,6 +480,7 @@ func (c *ClusterReconciler) lookupServiceCIDR(ctx context.Context) (string, erro
 			if err != nil {
 				return "", err
 			}
+
 			return serviceCIDRAddr.String(), nil
 		}
 	}
@@ -499,11 +518,13 @@ func (c *ClusterReconciler) lookupServiceCIDR(ctx context.Context) (string, erro
 					log.Error(err, "serviceCIDR is not valid")
 					break
 				}
+
 				return serviceCIDRAddr.String(), nil
 			}
 		}
 	}
 
 	log.Info("cannot find serviceCIDR from lookup")
+
 	return "", nil
 }

--- a/pkg/controller/cluster/cluster_finalize.go
+++ b/pkg/controller/cluster/cluster_finalize.go
@@ -34,6 +34,7 @@ func (c *ClusterReconciler) finalizeCluster(ctx context.Context, cluster v1alpha
 	for _, pod := range podList.Items {
 		if controllerutil.ContainsFinalizer(&pod, etcdPodFinalizerName) {
 			controllerutil.RemoveFinalizer(&pod, etcdPodFinalizerName)
+
 			if err := c.Client.Update(ctx, &pod); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -47,10 +48,12 @@ func (c *ClusterReconciler) finalizeCluster(ctx context.Context, cluster v1alpha
 	if controllerutil.ContainsFinalizer(&cluster, clusterFinalizerName) {
 		// remove finalizer from the cluster and update it.
 		controllerutil.RemoveFinalizer(&cluster, clusterFinalizerName)
+
 		if err := c.Client.Update(ctx, &cluster); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -63,6 +66,7 @@ func (c *ClusterReconciler) unbindNodeProxyClusterRole(ctx context.Context, clus
 	subjectName := controller.SafeConcatNameWithPrefix(cluster.Name, agent.SharedNodeAgentName)
 
 	var cleanedSubjects []rbacv1.Subject
+
 	for _, subject := range clusterRoleBinding.Subjects {
 		if subject.Name != subjectName || subject.Namespace != cluster.Namespace {
 			cleanedSubjects = append(cleanedSubjects, subject)
@@ -75,5 +79,6 @@ func (c *ClusterReconciler) unbindNodeProxyClusterRole(ctx context.Context, clus
 	}
 
 	clusterRoleBinding.Subjects = cleanedSubjects
+
 	return c.Client.Update(ctx, clusterRoleBinding)
 }

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -45,7 +45,6 @@ func GenerateBootstrapData(ctx context.Context, cluster *v1alpha1.Cluster, ip, t
 	}
 
 	return json.Marshal(bootstrap)
-
 }
 
 func requestBootstrap(token, serverIP string) (*ControlRuntimeBootstrap, error) {
@@ -64,6 +63,7 @@ func requestBootstrap(token, serverIP string) (*ControlRuntimeBootstrap, error) 
 	if err != nil {
 		return nil, err
 	}
+
 	req.Header.Add("Authorization", "Basic "+basicAuth("server", token))
 
 	resp, err := client.Do(req)
@@ -91,6 +91,7 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	if err != nil {
 		return err
 	}
+
 	bootstrap.ClientCA.Content = string(decoded)
 
 	//client-ca-key
@@ -98,6 +99,7 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	if err != nil {
 		return err
 	}
+
 	bootstrap.ClientCAKey.Content = string(decoded)
 
 	//server-ca
@@ -105,6 +107,7 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	if err != nil {
 		return err
 	}
+
 	bootstrap.ServerCA.Content = string(decoded)
 
 	//server-ca-key
@@ -112,6 +115,7 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	if err != nil {
 		return err
 	}
+
 	bootstrap.ServerCAKey.Content = string(decoded)
 
 	//etcd-ca
@@ -119,6 +123,7 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	if err != nil {
 		return err
 	}
+
 	bootstrap.ETCDServerCA.Content = string(decoded)
 
 	//etcd-ca-key
@@ -126,6 +131,7 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	if err != nil {
 		return err
 	}
+
 	bootstrap.ETCDServerCAKey.Content = string(decoded)
 
 	return nil
@@ -162,5 +168,6 @@ func GetFromSecret(ctx context.Context, client client.Client, cluster *v1alpha1.
 
 	var bootstrap ControlRuntimeBootstrap
 	err := json.Unmarshal(bootstrapData, &bootstrap)
+
 	return &bootstrap, err
 }

--- a/pkg/controller/cluster/server/config.go
+++ b/pkg/controller/cluster/server/config.go
@@ -22,6 +22,7 @@ func (s *Server) Config(init bool, serviceIP string) (*v1.Secret, error) {
 	if init {
 		config = initConfigData(s.cluster, s.token)
 	}
+
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -52,21 +53,26 @@ func serverOptions(cluster *v1alpha1.Cluster, token string) string {
 	if token != "" {
 		opts = "token: " + token + "\n"
 	}
+
 	if cluster.Status.ClusterCIDR != "" {
 		opts = opts + "cluster-cidr: " + cluster.Status.ClusterCIDR + "\n"
 	}
+
 	if cluster.Status.ServiceCIDR != "" {
 		opts = opts + "service-cidr: " + cluster.Status.ServiceCIDR + "\n"
 	}
+
 	if cluster.Spec.ClusterDNS != "" {
 		opts = opts + "cluster-dns: " + cluster.Spec.ClusterDNS + "\n"
 	}
+
 	if len(cluster.Status.TLSSANs) > 0 {
 		opts = opts + "tls-san:\n"
 		for _, addr := range cluster.Status.TLSSANs {
 			opts = opts + "- " + addr + "\n"
 		}
 	}
+
 	if cluster.Spec.Mode != agent.VirtualNodeMode {
 		opts = opts + "disable-agent: true\negress-selector-mode: disabled\ndisable:\n- servicelb\n- traefik\n- metrics-server\n- local-storage"
 	}
@@ -79,5 +85,6 @@ func configSecretName(clusterName string, init bool) string {
 	if !init {
 		return controller.SafeConcatNameWithPrefix(clusterName, configName)
 	}
+
 	return controller.SafeConcatNameWithPrefix(clusterName, initConfigName)
 }

--- a/pkg/controller/cluster/server/service.go
+++ b/pkg/controller/cluster/server/service.go
@@ -54,9 +54,11 @@ func Service(cluster *v1alpha1.Cluster) *v1.Service {
 			if nodePortConfig.ServerPort != nil {
 				k3sServerPort.NodePort = *nodePortConfig.ServerPort
 			}
+
 			if nodePortConfig.ServicePort != nil {
 				k3sServicePort.NodePort = *nodePortConfig.ServicePort
 			}
+
 			if nodePortConfig.ETCDPort != nil {
 				etcdPort.NodePort = *nodePortConfig.ETCDPort
 			}

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -26,13 +26,17 @@ func (c *ClusterReconciler) token(ctx context.Context, cluster *v1alpha1.Cluster
 		Name:      cluster.Spec.TokenSecretRef.Name,
 		Namespace: cluster.Spec.TokenSecretRef.Namespace,
 	}
+
 	var tokenSecret v1.Secret
+
 	if err := c.Client.Get(ctx, nn, &tokenSecret); err != nil {
 		return "", err
 	}
+
 	if _, ok := tokenSecret.Data["token"]; !ok {
 		return "", fmt.Errorf("no token field in secret %s/%s", nn.Namespace, nn.Name)
 	}
+
 	return string(tokenSecret.Data["token"]), nil
 }
 
@@ -75,15 +79,16 @@ func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1al
 	}
 
 	return token, err
-
 }
 
 func random(size int) (string, error) {
 	token := make([]byte, size)
+
 	_, err := rand.Read(token)
 	if err != nil {
 		return "", err
 	}
+
 	return hex.EncodeToString(token), err
 }
 

--- a/pkg/controller/clusterset/clusterset.go
+++ b/pkg/controller/clusterset/clusterset.go
@@ -67,10 +67,13 @@ func Add(ctx context.Context, mgr manager.Manager, clusterCIDR string) error {
 // namespaceEventHandler will enqueue reconciling requests for all the ClusterSets in the changed namespace
 func namespaceEventHandler(reconciler ClusterSetReconciler) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		var requests []reconcile.Request
-		var set v1alpha1.ClusterSetList
+		var (
+			requests []reconcile.Request
+			set      v1alpha1.ClusterSetList
+		)
 
 		_ = reconciler.Client.List(ctx, &set, client.InNamespace(obj.GetName()))
+
 		for _, clusterSet := range set.Items {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -87,10 +90,13 @@ func namespaceEventHandler(reconciler ClusterSetReconciler) handler.MapFunc {
 // sameNamespaceEventHandler will enqueue reconciling requests for all the ClusterSets in the changed namespace
 func sameNamespaceEventHandler(reconciler ClusterSetReconciler) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		var requests []reconcile.Request
-		var set v1alpha1.ClusterSetList
+		var (
+			requests []reconcile.Request
+			set      v1alpha1.ClusterSetList
+		)
 
 		_ = reconciler.Client.List(ctx, &set, client.InNamespace(obj.GetNamespace()))
+
 		for _, clusterSet := range set.Items {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -199,6 +205,7 @@ func netpol(ctx context.Context, clusterCIDR string, clusterSet *v1alpha1.Cluste
 		if err := client.List(ctx, &nodeList); err != nil {
 			return nil, err
 		}
+
 		for _, node := range nodeList.Items {
 			cidrList = append(cidrList, node.Spec.PodCIDRs...)
 		}
@@ -261,6 +268,7 @@ func (c *ClusterSetReconciler) reconcileNamespacePodSecurityLabels(ctx context.C
 	log.Info("reconciling Namespace")
 
 	var ns v1.Namespace
+
 	key := types.NamespacedName{Name: clusterSet.Namespace}
 	if err := c.Client.Get(ctx, key, &ns); err != nil {
 		return err
@@ -295,8 +303,10 @@ func (c *ClusterSetReconciler) reconcileNamespacePodSecurityLabels(ctx context.C
 		log.V(1).Info("labels changed, updating namespace")
 
 		ns.Labels = newLabels
+
 		return c.Client.Update(ctx, &ns)
 	}
+
 	return nil
 }
 

--- a/pkg/controller/clusterset/node.go
+++ b/pkg/controller/clusterset/node.go
@@ -68,6 +68,7 @@ func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetLi
 	log.Info("ensuring network policies")
 
 	var setNetworkPolicy *networkingv1.NetworkPolicy
+
 	for _, cs := range clusterSetList.Items {
 		if cs.Spec.DisableNetworkPolicy {
 			continue
@@ -78,14 +79,17 @@ func (n *NodeReconciler) ensureNetworkPolicies(ctx context.Context, clusterSetLi
 
 		var err error
 		setNetworkPolicy, err = netpol(ctx, "", &cs, n.Client)
+
 		if err != nil {
 			return err
 		}
 
 		log.Info("new NetworkPolicy for clusterset")
+
 		if err := n.Client.Update(ctx, setNetworkPolicy); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -51,7 +51,9 @@ func SafeConcatName(name ...string) string {
 	if len(fullPath) < 64 {
 		return fullPath
 	}
+
 	digest := sha256.Sum256([]byte(fullPath))
+
 	// since we cut the string in the middle, the last char may not be compatible with what is expected in k8s
 	// we are checking and if necessary removing the last char
 	c := fullPath[56]

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -40,6 +40,7 @@ func (k *KubeConfig) Extract(ctx context.Context, client client.Client, cluster 
 	if err != nil {
 		return nil, err
 	}
+
 	serverCACert := []byte(bootstrapData.ServerCA.Content)
 
 	adminCert, adminKey, err := certs.CreateClientCertKey(
@@ -110,6 +111,7 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1alp
 	expose := cluster.Spec.Expose
 	if expose != nil && expose.Ingress != nil {
 		var k3kIngress networkingv1.Ingress
+
 		ingressKey := types.NamespacedName{
 			Name:      server.IngressName(cluster.Name),
 			Namespace: cluster.Namespace,
@@ -118,6 +120,7 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1alp
 		if err := client.Get(ctx, ingressKey, &k3kIngress); err != nil {
 			return "", err
 		}
+
 		url = fmt.Sprintf("https://%s", k3kIngress.Spec.Rules[0].Host)
 	}
 

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -55,17 +55,19 @@ func NewVirtualCluster(cluster v1alpha1.Cluster) {
 		WithTimeout(time.Minute * 2).
 		WithPolling(time.Second * 5).
 		Should(BeTrue())
-
 }
 
 // NewVirtualK8sClient returns a Kubernetes ClientSet for the virtual cluster
 func NewVirtualK8sClient(cluster v1alpha1.Cluster) *kubernetes.Clientset {
 	GinkgoHelper()
 
-	var err error
+	var (
+		err    error
+		config *clientcmdapi.Config
+	)
+
 	ctx := context.Background()
 
-	var config *clientcmdapi.Config
 	Eventually(func() error {
 		vKubeconfig := kubeconfig.New()
 		kubeletAltName := fmt.Sprintf("k3k-%s-kubelet", cluster.Name)

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -161,8 +161,10 @@ func buildScheme() *runtime.Scheme {
 }
 
 func writeK3kLogs() {
-	var err error
-	var podList v1.PodList
+	var (
+		err     error
+		podList v1.PodList
+	)
 
 	ctx := context.Background()
 	err = k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: "k3k-system"})
@@ -176,11 +178,14 @@ func writeK3kLogs() {
 }
 
 func writeLogs(filename string, logs io.ReadCloser) {
+	defer logs.Close()
+
 	logsStr, err := io.ReadAll(logs)
 	Expect(err).To(Not(HaveOccurred()))
-	defer logs.Close()
+
 	tempfile := path.Join(os.TempDir(), filename)
 	err = os.WriteFile(tempfile, []byte(logsStr), 0644)
 	Expect(err).To(Not(HaveOccurred()))
+
 	fmt.Fprintln(GinkgoWriter, "logs written to: "+filename)
 }


### PR DESCRIPTION
This PR adds the [`wsl`](https://github.com/bombsimon/wsl) linter.

This linter should improve readability enforcing whitespacing and some general rules, like grouping vars in some cases, or newlines before or after some blocks.

i.e:
```go
var nodeStats statsv1alpha1.NodeStats
var allPodsStats []statsv1alpha1.PodStats
```
```go
var (
	nodeStats    statsv1alpha1.NodeStats
	allPodsStats []statsv1alpha1.PodStats
)
```