### PR TITLE
Fix delete cli

### DIFF
--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -112,11 +112,6 @@ func RemoveOwnerReferenceFromSecret(ctx context.Context, name string, cl client.
 		return err
 	}
 
-	owners := secret.GetOwnerReferences()
-	if len(owners) < 1 {
-		return nil
-	}
-
 	if controllerutil.HasControllerReference(&secret) {
 		if err := controllerutil.RemoveOwnerReference(&cluster, &secret, cl.Scheme()); err != nil {
 			return err

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -117,8 +117,10 @@ func RemoveOwnerReferenceFromSecret(ctx context.Context, name string, cl client.
 		return nil
 	}
 
-	if err := controllerutil.RemoveOwnerReference(&cluster, &secret, cl.Scheme()); err != nil {
-		return err
+	if controllerutil.HasControllerReference(&secret) {
+		if err := controllerutil.RemoveOwnerReference(&cluster, &secret, cl.Scheme()); err != nil {
+			return err
+		}
 	}
 
 	return cl.Update(ctx, &secret)

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -99,6 +99,7 @@ func delete(clx *cli.Context) error {
 
 func RemoveOwnerReferenceFromSecret(ctx context.Context, name string, cl client.Client, cluster v1alpha1.Cluster) error {
 	var secret v1.Secret
+
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: cluster.Namespace,

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -108,6 +108,7 @@ func RemoveOwnerReferenceFromSecret(ctx context.Context, name string, cl client.
 			logrus.Warnf("%s secret is not found", name)
 			return nil
 		}
+
 		return err
 	}
 

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -6,19 +6,29 @@ import (
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	k3kcluster "github.com/rancher/k3k/pkg/controller/cluster"
+	"github.com/rancher/k3k/pkg/controller/cluster/agent"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+var keepData bool
 
 func NewClusterDeleteCmd() *cli.Command {
 	return &cli.Command{
-		Name:            "delete",
-		Usage:           "Delete an existing cluster",
-		UsageText:       "k3kcli cluster delete [command options] NAME",
-		Action:          delete,
-		Flags:           CommonFlags,
+		Name:      "delete",
+		Usage:     "Delete an existing cluster",
+		UsageText: "k3kcli cluster delete [command options] NAME",
+		Action:    delete,
+		Flags: append(CommonFlags, &cli.BoolFlag{
+			Name:        "keep-data",
+			Usage:       "keeps persistence volumes created for the cluster after deletion",
+			Destination: &keepData,
+		}),
 		HideHelpCommand: true,
 	}
 }
@@ -55,6 +65,54 @@ func delete(clx *cli.Context) error {
 			Namespace: Namespace(),
 		},
 	}
+	// keep bootstrap secrets and tokens if --keep-data flag is passed
+	if keepData {
+		var tokenSecret, webhookSecret v1.Secret
+		// skip removing tokenSecret
+		key := types.NamespacedName{
+			Name:      k3kcluster.TokenSecretName(cluster.Name),
+			Namespace: cluster.Namespace,
+		}
+		if err := ctrlClient.Get(ctx, key, &tokenSecret); err != nil {
+			return err
+		}
+		if err := controllerutil.RemoveOwnerReference(&cluster, &tokenSecret, ctrlClient.Scheme()); err != nil {
+			return err
+		}
+		if err := ctrlClient.Update(ctx, &tokenSecret); err != nil {
+			return err
+		}
 
-	return ctrlClient.Delete(ctx, &cluster)
+		// skip removing webhook secret
+		key = types.NamespacedName{
+			Name:      agent.WebhookSecretName(cluster.Name),
+			Namespace: cluster.Namespace,
+		}
+		if err := ctrlClient.Get(ctx, key, &webhookSecret); err != nil {
+			return err
+		}
+		if err := controllerutil.RemoveOwnerReference(&cluster, &webhookSecret, ctrlClient.Scheme()); err != nil {
+			return err
+		}
+		if err := ctrlClient.Update(ctx, &webhookSecret); err != nil {
+			return err
+		}
+
+	}
+	if err := ctrlClient.Delete(ctx, &cluster); err != nil {
+		return err
+	}
+
+	// make sure to delete pv claims for the cluster if --keep-data is not used
+	if !keepData {
+		matchingLabels := client.MatchingLabels(map[string]string{"cluster": cluster.Name, "role": "server"})
+		listOpts := client.ListOptions{Namespace: cluster.Namespace}
+		matchingLabels.ApplyToList(&listOpts)
+		deleteOpts := &client.DeleteAllOfOptions{ListOptions: listOpts}
+
+		if err := ctrlClient.DeleteAllOf(ctx, &v1.PersistentVolumeClaim{}, deleteOpts); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -76,9 +76,11 @@ func delete(clx *cli.Context) error {
 		if err := ctrlClient.Get(ctx, key, &tokenSecret); err != nil {
 			return err
 		}
+
 		if err := controllerutil.RemoveOwnerReference(&cluster, &tokenSecret, ctrlClient.Scheme()); err != nil {
 			return err
 		}
+
 		if err := ctrlClient.Update(ctx, &tokenSecret); err != nil {
 			return err
 		}
@@ -91,14 +93,16 @@ func delete(clx *cli.Context) error {
 		if err := ctrlClient.Get(ctx, key, &webhookSecret); err != nil {
 			return err
 		}
+
 		if err := controllerutil.RemoveOwnerReference(&cluster, &webhookSecret, ctrlClient.Scheme()); err != nil {
 			return err
 		}
+
 		if err := ctrlClient.Update(ctx, &webhookSecret); err != nil {
 			return err
 		}
-
 	}
+
 	if err := ctrlClient.Delete(ctx, &cluster); err != nil {
 		return err
 	}
@@ -114,5 +118,6 @@ func delete(clx *cli.Context) error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -121,7 +121,9 @@ func RemoveOwnerReferenceFromSecret(ctx context.Context, name string, cl client.
 		if err := controllerutil.RemoveOwnerReference(&cluster, &secret, cl.Scheme()); err != nil {
 			return err
 		}
+
+		return cl.Update(ctx, &secret)
 	}
 
-	return cl.Update(ctx, &secret)
+	return nil
 }

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -67,6 +67,8 @@ Delete an existing cluster
 
 >k3kcli cluster delete [command options] NAME
 
+**--keep-data**: keeps persistence volumes created for the cluster after deletion
+
 **--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
 **--namespace**="": namespace to create the k3k cluster in

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -397,6 +398,11 @@ func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
 		"host_namespace", tPod.Namespace, "host_name", tPod.Name,
 		"virtual_namespace", pod.Namespace, "virtual_name", pod.Name,
 	)
+
+	// set ownerReference to the cluster object
+	if err := controllerutil.SetControllerReference(&cluster, tPod, p.HostClient.Scheme()); err != nil {
+		return err
+	}
 
 	return p.HostClient.Create(ctx, tPod)
 }


### PR DESCRIPTION
- Adds --keep-data flag to the delete cli.
  - when this flag is used both webhook secret and token secret will not be removed.
  - when this flag is used the PVCs of the cluster will not be removed.
- Default the delete cli to remove the entire cluster.

- #164 