### PR TITLE
cli - fix bug with Kubeconfig value resolution

### DIFF
--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
 	"github.com/rancher/k3k/pkg/buildinfo"
@@ -28,7 +29,8 @@ var (
 			EnvVars:     []string{"KUBECONFIG"},
 			Usage:       "kubeconfig path",
 			Destination: &Kubeconfig,
-			Value:       "$HOME/.kube/config",
+			Value:       os.Getenv("HOME") + "/.kube/config",
+			DefaultText: "$HOME/.kube/config",
 		},
 		&cli.StringFlag{
 			Name:        "namespace",

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -39,7 +39,7 @@ Create new cluster
 
 **--cluster-cidr**="": cluster CIDR
 
-**--kubeconfig**="": kubeconfig path (default: "$HOME/.kube/config")
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config)
 
 **--kubeconfig-server**="": override the kubeconfig server host
 
@@ -67,7 +67,7 @@ Delete an existing cluster
 
 >k3kcli cluster delete [command options] NAME
 
-**--kubeconfig**="": kubeconfig path (default: "$HOME/.kube/config")
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config)
 
 **--namespace**="": namespace to create the k3k cluster in
 
@@ -87,7 +87,7 @@ Generate kubeconfig for clusters
 
 **--expiration-days**="": Expiration date of the certificates used for the kubeconfig (default: 356)
 
-**--kubeconfig**="": kubeconfig path (default: "$HOME/.kube/config")
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config)
 
 **--kubeconfig-server**="": override the kubeconfig server host
 


### PR DESCRIPTION
Fix a regression with the cli.
The location of the `kubeconfig` is not resolved anymore and lead an error when the `KUBECONFIG` variable is not defined and the `--kubeconfig` is not passed

```
-> % k3kcli kubeconfig generate --name mycluster2 --namespace k3k-mycluster2 --kubeconfig-server localhost
FATA[0000] stat $HOME/.kube/config: no such file or directory
```

This fix solve the issue by reverting the value to 
```
Value:       os.Getenv("HOME") + "/.kube/config",
```
and using `DefaultText ` to describe the value and provide a static output for the cli documentation 