### PR TITLE
Fix kubeconfig load from multiple configuration files

### DIFF
--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -67,7 +67,7 @@ func createAction(config *CreateConfig) cli.ActionFunc {
 			return errors.New("invalid cluster name")
 		}
 
-		restConfig, err := clientcmd.BuildConfigFromFlags("", Kubeconfig)
+		restConfig, err := loadRESTConfig()
 		if err != nil {
 			return err
 		}

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,7 +35,7 @@ func delete(clx *cli.Context) error {
 		return errors.New("invalid cluster name")
 	}
 
-	restConfig, err := clientcmd.BuildConfigFromFlags("", Kubeconfig)
+	restConfig, err := loadRESTConfig()
 	if err != nil {
 		return err
 	}

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -92,11 +92,7 @@ func NewKubeconfigCommand() *cli.Command {
 }
 
 func generate(clx *cli.Context) error {
-	var cluster v1alpha1.Cluster
-
-	ctx := context.Background()
-
-	restConfig, err := clientcmd.BuildConfigFromFlags("", Kubeconfig)
+	restConfig, err := loadRESTConfig()
 	if err != nil {
 		return err
 	}
@@ -113,6 +109,9 @@ func generate(clx *cli.Context) error {
 		Namespace: Namespace(),
 	}
 
+	var cluster v1alpha1.Cluster
+
+	ctx := context.Background()
 	if err := ctrlClient.Get(ctx, clusterKey, &cluster); err != nil {
 		return err
 	}

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -39,7 +39,7 @@ Create new cluster
 
 **--cluster-cidr**="": cluster CIDR
 
-**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config)
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
 **--kubeconfig-server**="": override the kubeconfig server host
 
@@ -67,7 +67,7 @@ Delete an existing cluster
 
 >k3kcli cluster delete [command options] NAME
 
-**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config)
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
 **--namespace**="": namespace to create the k3k cluster in
 
@@ -87,7 +87,7 @@ Generate kubeconfig for clusters
 
 **--expiration-days**="": Expiration date of the certificates used for the kubeconfig (default: 356)
 
-**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config)
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
 **--kubeconfig-server**="": override the kubeconfig server host
 


### PR DESCRIPTION
From `kubectl config -h`
```
Modify kubeconfig files using subcommands like "kubectl config set current-context my-context".

 The loading order follows these rules:

  1.  If the --kubeconfig flag is set, then only that file is loaded. The flag may only be set once and no merging takes
place.
  2.  If $KUBECONFIG environment variable is set, then it is used as a list of paths (normal path delimiting rules for
your system). These paths are merged. When a value is modified, it is modified in the file that defines the stanza. When
a value is created, it is created in the first file that exists. If no files in the chain exist, then it creates the
last file in the list.
  3.  Otherwise, ${HOME}/.kube/config is used and no merging takes place.
```

Option **2.** was not handled correctly. When the `KUBECONFIG` env var is set with a list of files it was failing:

```
export KUBECONFIG=~/.kube/config:~/.kube/config2

-> % k3kcli kubeconfig generate --name mycluster --namespace k3k-mycluster
FATA[0000] stat /home/enrico/.kube/config:/home/enrico/.kube/config2: no such file or directory
```

This is because we are using the [`clientcmd.BuildConfigFromFlags`](https://pkg.go.dev/k8s.io/client-go/tools/clientcmd#BuildConfigFromFlags) that looks for a specific file, if provided. 

The [`clientcmd.NewNonInteractiveDeferredLoadingClientConfig`](https://pkg.go.dev/k8s.io/client-go/tools/clientcmd#NewNonInteractiveDeferredLoadingClientConfig) accept some loading rules instead, so the default Kubectl behavior is applied.

I had to remove the explicit `KUBECONFIG` env var from the flags because it will be automatically handled from the loader, so we just need to check for the `--kubeconfig` flag, to explicitly set the `loadingRules.ExplicitPath`.