### PR TITLE
Create dedicated namespace for new clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,8 @@ lint:	## Find any linting issues in the project
 validate: build-crds docs ## Validate the project checking for any dependency or doc mismatch
 	$(GINKGO) unfocus
 	go mod tidy
-	git --no-pager diff go.mod go.sum
 	git status --porcelain
-	test -z "$(shell git status --porcelain)"
+	git --no-pager diff --exit-code
 
 .PHONY: install
 install:	## Install K3k with Helm on the targeted Kubernetes cluster

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ validate: build-crds docs ## Validate the project checking for any dependency or
 	$(GINKGO) unfocus
 	go mod tidy
 	git --no-pager diff go.mod go.sum
+	git status --porcelain
 	test -z "$(shell git status --porcelain)"
-
 
 .PHONY: install
 install:	## Install K3k with Helm on the targeted Kubernetes cluster

--- a/cli/cmds/cluster.go
+++ b/cli/cmds/cluster.go
@@ -4,7 +4,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewClusterCommand() *cli.Command {
+func NewClusterCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "cluster",
 		Usage: "cluster command",

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -47,12 +47,14 @@ func delete(clx *cli.Context) error {
 		return err
 	}
 
-	logrus.Infof("deleting [%s] cluster", name)
+	namespace := Namespace(name)
+
+	logrus.Infof("Deleting [%s] cluster in namespace [%s]", name, namespace)
 
 	cluster := v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: Namespace(),
+			Namespace: namespace,
 		},
 	}
 

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -13,10 +13,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	defaultNamespace = "default"
-)
-
 var (
 	Scheme = runtime.NewScheme()
 
@@ -71,19 +67,19 @@ func NewApp() *cli.App {
 	}
 
 	app.Commands = []*cli.Command{
-		NewClusterCommand(),
-		NewKubeconfigCommand(),
+		NewClusterCmd(),
+		NewKubeconfigCmd(),
 	}
 
 	return app
 }
 
-func Namespace() string {
-	if namespace == "" {
-		return defaultNamespace
+func Namespace(clusterName string) string {
+	if namespace != "" {
+		return namespace
 	}
 
-	return namespace
+	return "k3k-" + clusterName
 }
 
 func loadRESTConfig() (*rest.Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	k8s.io/client-go v0.29.11
 	k8s.io/component-base v0.29.11
 	k8s.io/component-helpers v0.29.11
+	k8s.io/kubectl v0.29.11
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.17.5
 )
@@ -207,7 +208,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kms v0.29.11 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	k8s.io/kubectl v0.29.11 // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect


### PR DESCRIPTION
This PR updates the cli to create a dedicated namespace for new virtual clusters, matching the UI behavior. (#312 )

New Clusters will be created in a `k3k-<CLUSTER NAME>` namespace, to isolate better its resources (easing the cleanup), and to avoid unexpected result. The user will still be able to create a cluster in a specific namespace with the `--namespace` flag.

This PR also fixes #313 adding the namespace to the generated kubeconfig file.