### PR TITLE
Added ClusterSet as singleton

### DIFF
--- a/charts/k3k/crds/k3k.io_clustersets.yaml
+++ b/charts/k3k/crds/k3k.io_clustersets.yaml
@@ -14,7 +14,14 @@ spec:
     singular: clusterset
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -73,6 +80,9 @@ spec:
                 description: DisableNetworkPolicy indicates whether to disable the
                   creation of a default network policy for cluster isolation.
                 type: boolean
+              displayName:
+                description: DisplayName is the human-readable name for the set.
+                type: string
               limit:
                 description: |-
                   Limit specifies the LimitRange that will be applied to all pods within the ClusterSet
@@ -312,6 +322,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: Name must match 'default'
+          rule: self.metadata.name == "default"
     served: true
     storage: true
     subresources:

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -313,6 +313,9 @@ type ClusterList struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == \"default\"",message="Name must match 'default'"
+// +kubebuilder:printcolumn:JSONPath=".spec.displayName",name=Display Name,type=string
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 
 // ClusterSet represents a group of virtual Kubernetes clusters managed by k3k.
 // It allows defining common configurations and constraints for the clusters within the set.
@@ -333,6 +336,11 @@ type ClusterSet struct {
 
 // ClusterSetSpec defines the desired state of a ClusterSet.
 type ClusterSetSpec struct {
+
+	// DisplayName is the human-readable name for the set.
+	//
+	// +optional
+	DisplayName string `json:"displayName"`
 
 	// Quota specifies the resource limits for clusters within a clusterset.
 	//

--- a/pkg/controller/clusterset/clusterset_test.go
+++ b/pkg/controller/clusterset/clusterset_test.go
@@ -699,8 +699,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should create resourceQuota if Quota is enabled", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						Quota: &v1.ResourceQuotaSpec{
@@ -730,11 +730,12 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 				Expect(resourceQuota.Spec.Hard.Cpu().String()).To(BeEquivalentTo("800m"))
 				Expect(resourceQuota.Spec.Hard.Memory().String()).To(BeEquivalentTo("1Gi"))
 			})
+
 			It("should delete the ResourceQuota if Quota is deleted", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						Quota: &v1.ResourceQuotaSpec{
@@ -779,11 +780,12 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 					WithPolling(time.Second).
 					Should(BeTrue())
 			})
+
 			It("should create resourceQuota if Quota is enabled", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						Limit: &v1.LimitRangeSpec{

--- a/pkg/controller/clusterset/clusterset_test.go
+++ b/pkg/controller/clusterset/clusterset_test.go
@@ -39,8 +39,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should have only the 'shared' allowedModeTypes", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 				}
 
@@ -52,11 +52,39 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 				Expect(allowedModeTypes).To(ContainElement(v1alpha1.SharedClusterMode))
 			})
 
+			It("should not be able to create a cluster with a non 'default' name", func() {
+				err := k8sClient.Create(ctx, &v1alpha1.ClusterSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-name",
+						Namespace: namespace,
+					},
+				})
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should not be able to create two ClusterSets in the same namespace", func() {
+				err := k8sClient.Create(ctx, &v1alpha1.ClusterSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: namespace,
+					},
+				})
+				Expect(err).To(Not(HaveOccurred()))
+
+				err = k8sClient.Create(ctx, &v1alpha1.ClusterSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-2",
+						Namespace: namespace,
+					},
+				})
+				Expect(err).To(HaveOccurred())
+			})
+
 			It("should create a NetworkPolicy", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 				}
 
@@ -119,8 +147,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should not create a NetworkPolicy if true", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DisableNetworkPolicy: true,
@@ -148,8 +176,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should delete the NetworkPolicy if changed to false", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 				}
 
@@ -192,8 +220,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should recreate the NetworkPolicy if deleted", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 				}
 
@@ -243,8 +271,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should have the 'virtual' mode if specified", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						AllowedModeTypes: []v1alpha1.ClusterMode{
@@ -264,8 +292,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should have both modes if specified", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						AllowedModeTypes: []v1alpha1.ClusterMode{
@@ -289,8 +317,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should fail for a non-existing mode", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						AllowedModeTypes: []v1alpha1.ClusterMode{
@@ -316,8 +344,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						PodSecurityAdmissionLevel: &privileged,
@@ -419,8 +447,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						PodSecurityAdmissionLevel: &privileged,
@@ -470,8 +498,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should update it if needed", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DefaultPriorityClass: "foobar",
@@ -511,8 +539,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should update the nodeSelector", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DefaultNodeSelector: map[string]string{"label-1": "value-1"},
@@ -552,8 +580,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should update the nodeSelector if changed", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DefaultNodeSelector: map[string]string{"label-1": "value-1"},
@@ -623,8 +651,8 @@ var _ = Describe("ClusterSet Controller", Label("controller"), Label("ClusterSet
 			It("should not be update", func() {
 				clusterSet := &v1alpha1.ClusterSet{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "clusterset-",
-						Namespace:    namespace,
+						Name:      "default",
+						Namespace: namespace,
 					},
 					Spec: v1alpha1.ClusterSetSpec{
 						DefaultPriorityClass: "foobar",


### PR DESCRIPTION
This PR enforce the existence of only one ClusterSet per namespace.

To enforce this without implementing a Webhook we are enforcing the resource to have a `default` name, and also we create a ResourceQuota with a `"count/clustersets.k3k.io": "1"` in the namespace. 

To have also a human readable name a new DisplayName field (like Projects) was added. This displayName is shown in the output thanks to the `additionalPrinterColumns` property:

```
-> % kubectl get clustersets.k3k.io -A                   
NAMESPACE           NAME        DISPLAY NAME    AGE
another             default     my-clusterset   24h
k3k-my-clusterset   default     my-clusterset   77m
```