### PR TITLE
Add `clusterset` commands

### DIFF
--- a/cli/cmds/cluster.go
+++ b/cli/cmds/cluster.go
@@ -4,13 +4,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewClusterCmd() *cli.Command {
+func NewClusterCmd(appCtx *AppContext) *cli.Command {
 	return &cli.Command{
 		Name:  "cluster",
 		Usage: "cluster command",
 		Subcommands: []*cli.Command{
-			NewClusterCreateCmd(),
-			NewClusterDeleteCmd(),
+			NewClusterCreateCmd(appCtx),
+			NewClusterDeleteCmd(appCtx),
 		},
 	}
 }

--- a/cli/cmds/clusterset.go
+++ b/cli/cmds/clusterset.go
@@ -1,0 +1,15 @@
+package cmds
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+func NewClusterSetCmd(appCtx *AppContext) *cli.Command {
+	return &cli.Command{
+		Name:  "clusterset",
+		Usage: "clusterset command",
+		Subcommands: []*cli.Command{
+			NewClusterSetCreateCmd(appCtx),
+		},
+	}
+}

--- a/cli/cmds/clusterset.go
+++ b/cli/cmds/clusterset.go
@@ -10,6 +10,7 @@ func NewClusterSetCmd(appCtx *AppContext) *cli.Command {
 		Usage: "clusterset command",
 		Subcommands: []*cli.Command{
 			NewClusterSetCreateCmd(appCtx),
+			NewClusterSetDeleteCmd(appCtx),
 		},
 	}
 }

--- a/cli/cmds/clusterset_create.go
+++ b/cli/cmds/clusterset_create.go
@@ -1,0 +1,106 @@
+package cmds
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	k3kcluster "github.com/rancher/k3k/pkg/controller/cluster"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ClusterSetCreateConfig struct {
+	mode string
+}
+
+func NewClusterSetCreateCmd(appCtx *AppContext) *cli.Command {
+	config := &ClusterSetCreateConfig{}
+
+	createFlags := []cli.Flag{
+		&cli.StringFlag{
+			Name:        "mode",
+			Usage:       "The allowed mode type of the clusterset",
+			Destination: &config.mode,
+			Value:       "shared",
+			Action: func(ctx *cli.Context, value string) error {
+				switch value {
+				case string(v1alpha1.VirtualClusterMode), string(v1alpha1.SharedClusterMode):
+					return nil
+				default:
+					return errors.New(`mode should be one of "shared" or "virtual"`)
+				}
+			},
+		},
+	}
+
+	return &cli.Command{
+		Name:            "create",
+		Usage:           "Create new clusterset",
+		UsageText:       "k3kcli clusterset create [command options] NAME",
+		Action:          clusterSetCreateAction(appCtx, config),
+		Flags:           append(CommonFlags, createFlags...),
+		HideHelpCommand: true,
+	}
+}
+
+func clusterSetCreateAction(appCtx *AppContext, config *ClusterSetCreateConfig) cli.ActionFunc {
+	return func(clx *cli.Context) error {
+		ctx := context.Background()
+		client := appCtx.Client
+
+		if clx.NArg() != 1 {
+			return cli.ShowSubcommandHelp(clx)
+		}
+
+		name := clx.Args().First()
+		if name == k3kcluster.ClusterInvalidName {
+			return errors.New("invalid cluster name")
+		}
+
+		namespace := Namespace(name)
+
+		ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		if err := client.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+
+			logrus.Infof(`Creating namespace [%s]`, namespace)
+
+			if err := client.Create(ctx, ns); err != nil {
+				return err
+			}
+		}
+
+		logrus.Infof("Creating clusterset [%s] in namespace [%s]", name, namespace)
+
+		clusterSet := &v1alpha1.ClusterSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterSet",
+				APIVersion: "k3k.io/v1alpha1",
+			},
+			Spec: v1alpha1.ClusterSetSpec{
+				AllowedModeTypes: []v1alpha1.ClusterMode{v1alpha1.ClusterMode(config.mode)},
+			},
+		}
+
+		if err := client.Create(ctx, clusterSet); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logrus.Infof("ClusterSet [%s] already exists", name)
+			} else {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/cli/cmds/clusterset_delete.go
+++ b/cli/cmds/clusterset_delete.go
@@ -1,0 +1,61 @@
+package cmds
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	k3kcluster "github.com/rancher/k3k/pkg/controller/cluster"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewClusterSetDeleteCmd(appCtx *AppContext) *cli.Command {
+	return &cli.Command{
+		Name:            "delete",
+		Usage:           "Delete an existing clusterset",
+		UsageText:       "k3kcli clusterset delete [command options] NAME",
+		Action:          clusterSetDeleteAction(appCtx),
+		Flags:           CommonFlags,
+		HideHelpCommand: true,
+	}
+}
+
+func clusterSetDeleteAction(appCtx *AppContext) cli.ActionFunc {
+	return func(clx *cli.Context) error {
+		ctx := context.Background()
+		client := appCtx.Client
+
+		if clx.NArg() != 1 {
+			return cli.ShowSubcommandHelp(clx)
+		}
+
+		name := clx.Args().First()
+		if name == k3kcluster.ClusterInvalidName {
+			return errors.New("invalid cluster name")
+		}
+
+		namespace := Namespace(name)
+
+		logrus.Infof("Deleting clusterset [%s] in namespace [%s]", name, namespace)
+
+		clusterSet := &v1alpha1.ClusterSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+
+		if err := client.Delete(ctx, clusterSet); err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Warnf("ClusterSet [%s] not found", name)
+			} else {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -73,6 +73,32 @@ Delete an existing cluster
 
 **--namespace**="": namespace to create the k3k cluster in
 
+## clusterset
+
+clusterset command
+
+### create
+
+Create new clusterset
+
+>k3kcli clusterset create [command options] NAME
+
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
+
+**--mode**="": The allowed mode type of the clusterset (default: "shared")
+
+**--namespace**="": namespace to create the k3k cluster in
+
+### delete
+
+Delete an existing clusterset
+
+>k3kcli clusterset delete [command options] NAME
+
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
+
+**--namespace**="": namespace to create the k3k cluster in
+
 ## kubeconfig
 
 Manage kubeconfig for clusters


### PR DESCRIPTION
This PR add the `k3kcli clusterset create/delete` commands.

It also refactor the commands a bit to add an `AppContext` where the Client is initialized and stored for every command.