### PR TITLE
Update and fix to `k3kcli` for new ClusterSet integration

### DIFF
--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -94,5 +94,10 @@ func NewCreateFlags(config *CreateConfig) []cli.Flag {
 			Usage:       "override the kubeconfig server host",
 			Destination: &config.kubeconfigServerHost,
 		},
+		&cli.StringFlag{
+			Name:        "clusterset",
+			Usage:       "The clusterset to create the cluster in",
+			Destination: &config.clusterset,
+		},
 	}
 }

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -25,7 +25,7 @@ func NewClusterDeleteCmd(appCtx *AppContext) *cli.Command {
 		Usage:     "Delete an existing cluster",
 		UsageText: "k3kcli cluster delete [command options] NAME",
 		Action:    delete(appCtx),
-		Flags: append(CommonFlags, &cli.BoolFlag{
+		Flags: WithCommonFlags(appCtx, &cli.BoolFlag{
 			Name:        "keep-data",
 			Usage:       "keeps persistence volumes created for the cluster after deletion",
 			Destination: &keepData,
@@ -48,7 +48,7 @@ func delete(appCtx *AppContext) cli.ActionFunc {
 			return errors.New("invalid cluster name")
 		}
 
-		namespace := Namespace(name)
+		namespace := appCtx.Namespace(name)
 
 		logrus.Infof("Deleting [%s] cluster in namespace [%s]", name, namespace)
 

--- a/cli/cmds/clusterset_delete.go
+++ b/cli/cmds/clusterset_delete.go
@@ -18,7 +18,7 @@ func NewClusterSetDeleteCmd(appCtx *AppContext) *cli.Command {
 		Usage:           "Delete an existing clusterset",
 		UsageText:       "k3kcli clusterset delete [command options] NAME",
 		Action:          clusterSetDeleteAction(appCtx),
-		Flags:           CommonFlags,
+		Flags:           WithCommonFlags(appCtx),
 		HideHelpCommand: true,
 	}
 }
@@ -37,20 +37,20 @@ func clusterSetDeleteAction(appCtx *AppContext) cli.ActionFunc {
 			return errors.New("invalid cluster name")
 		}
 
-		namespace := Namespace(name)
+		namespace := appCtx.Namespace(name)
 
-		logrus.Infof("Deleting clusterset [%s] in namespace [%s]", name, namespace)
+		logrus.Infof("Deleting clusterset in namespace [%s]", namespace)
 
 		clusterSet := &v1alpha1.ClusterSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
+				Name:      "default",
 				Namespace: namespace,
 			},
 		}
 
 		if err := client.Delete(ctx, clusterSet); err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Warnf("ClusterSet [%s] not found", name)
+				logrus.Warnf("ClusterSet not found in namespace [%s]", namespace)
 			} else {
 				return err
 			}

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -88,7 +88,7 @@ func NewKubeconfigGenerateCmd(appCtx *AppContext) *cli.Command {
 		Usage:           "Generate kubeconfig for clusters",
 		SkipFlagParsing: false,
 		Action:          generate(appCtx),
-		Flags:           append(CommonFlags, generateKubeconfigFlags...),
+		Flags:           WithCommonFlags(appCtx, generateKubeconfigFlags...),
 	}
 }
 
@@ -96,9 +96,10 @@ func generate(appCtx *AppContext) cli.ActionFunc {
 	return func(clx *cli.Context) error {
 		ctx := context.Background()
 		client := appCtx.Client
+
 		clusterKey := types.NamespacedName{
 			Name:      name,
-			Namespace: Namespace(name),
+			Namespace: appCtx.Namespace(name),
 		}
 
 		var cluster v1alpha1.Cluster

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -8,6 +8,8 @@ k3kcli
 
 ```
 [--debug]
+[--kubeconfig]=[value]
+[--namespace]=[value]
 ```
 
 **Usage**:
@@ -19,6 +21,10 @@ k3kcli [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 # GLOBAL OPTIONS
 
 **--debug**: Turn on debug logs
+
+**--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
+
+**--namespace**="": namespace to create the k3k cluster in
 
 
 # COMMANDS
@@ -38,6 +44,10 @@ Create new cluster
 **--agents**="": number of agents (default: 0)
 
 **--cluster-cidr**="": cluster CIDR
+
+**--clusterset**="": The clusterset to create the cluster in
+
+**--debug**: Turn on debug logs
 
 **--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
@@ -67,6 +77,8 @@ Delete an existing cluster
 
 >k3kcli cluster delete [command options] NAME
 
+**--debug**: Turn on debug logs
+
 **--keep-data**: keeps persistence volumes created for the cluster after deletion
 
 **--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
@@ -83,6 +95,10 @@ Create new clusterset
 
 >k3kcli clusterset create [command options] NAME
 
+**--debug**: Turn on debug logs
+
+**--display-name**="": The display name of the clusterset
+
 **--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
 **--mode**="": The allowed mode type of the clusterset (default: "shared")
@@ -94,6 +110,8 @@ Create new clusterset
 Delete an existing clusterset
 
 >k3kcli clusterset delete [command options] NAME
+
+**--debug**: Turn on debug logs
 
 **--kubeconfig**="": kubeconfig path (default: $HOME/.kube/config or $KUBECONFIG if set)
 
@@ -112,6 +130,8 @@ Generate kubeconfig for clusters
 **--cn**="": Common name (CN) of the generated certificates for the kubeconfig (default: "system:admin")
 
 **--config-name**="": the name of the generated kubeconfig file
+
+**--debug**: Turn on debug logs
 
 **--expiration-days**="": Expiration date of the certificates used for the kubeconfig (default: 356)
 

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -340,7 +340,7 @@ type ClusterSetSpec struct {
 	// DisplayName is the human-readable name for the set.
 	//
 	// +optional
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName,omitempty"`
 
 	// Quota specifies the resource limits for clusters within a clusterset.
 	//


### PR DESCRIPTION
The latest PRs changed the ClusterSet to have a fixed `default` name. This is a breaking change for the `k3kcli` that needed to be updated in order to always create a ClusterSet with a `default` name, and use the `name` as a DisplayName instead.

This PR adds the `--display-name` flag to the `k3kcli clusterset create` command.

It also adds the `--clusterset` flag to the `k3kcli cluster create` command, in order to create a Cluster in the same namespace of a ClusterSet. If the ClusterSet doesn't exists it will be created.

Also a small refactor to drop some global variables.