### PR TITLE
Add extra env for servers/agents

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -65,6 +65,119 @@ spec:
                 items:
                   type: string
                 type: array
+              agentEnvs:
+                description: AgentEnvs specifies list of environment variables to
+                  set in the agent pod.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               agents:
                 default: 0
                 description: |-
@@ -201,6 +314,119 @@ spec:
                   Example: ["--tls-san=example.com"]
                 items:
                   type: string
+                type: array
+              serverEnvs:
+                description: ServerEnvs specifies list of environment variables to
+                  set in the server pod.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
                 type: array
               serverLimit:
                 additionalProperties:

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -30,6 +30,8 @@ type CreateConfig struct {
 	agents               int
 	serverArgs           cli.StringSlice
 	agentArgs            cli.StringSlice
+	serverEnvs           cli.StringSlice
+	agentEnvs            cli.StringSlice
 	persistenceType      string
 	storageClassName     string
 	version              string
@@ -168,6 +170,8 @@ func newCluster(name, namespace string, config *CreateConfig) *v1alpha1.Cluster 
 			ServiceCIDR: config.serviceCIDR,
 			ServerArgs:  config.serverArgs.Value(),
 			AgentArgs:   config.agentArgs.Value(),
+			ServerEnvs:  env(config.serverEnvs.Value()),
+			AgentEnvs:   env(config.agentEnvs.Value()),
 			Version:     config.version,
 			Mode:        v1alpha1.ClusterMode(config.mode),
 			Persistence: v1alpha1.PersistenceConfig{
@@ -188,4 +192,19 @@ func newCluster(name, namespace string, config *CreateConfig) *v1alpha1.Cluster 
 	}
 
 	return cluster
+}
+
+func env(envSlice []string) []v1.EnvVar {
+	var envVars []v1.EnvVar
+	for _, env := range envSlice {
+		keyValue := strings.Split(env, "=")
+		if len(keyValue) != 2 {
+			logrus.Fatalf("incorrect value for environment variable %s", env)
+		}
+		envVars = append(envVars, v1.EnvVar{
+			Name:  keyValue[0],
+			Value: keyValue[1],
+		})
+	}
+	return envVars
 }

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -196,15 +196,18 @@ func newCluster(name, namespace string, config *CreateConfig) *v1alpha1.Cluster 
 
 func env(envSlice []string) []v1.EnvVar {
 	var envVars []v1.EnvVar
+
 	for _, env := range envSlice {
 		keyValue := strings.Split(env, "=")
 		if len(keyValue) != 2 {
 			logrus.Fatalf("incorrect value for environment variable %s", env)
 		}
+
 		envVars = append(envVars, v1.EnvVar{
 			Name:  keyValue[0],
 			Value: keyValue[1],
 		})
 	}
+
 	return envVars
 }

--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -70,6 +70,16 @@ func NewCreateFlags(config *CreateConfig) []cli.Flag {
 			Usage:       "agents extra arguments",
 			Destination: &config.agentArgs,
 		},
+		&cli.StringSliceFlag{
+			Name:        "server-envs",
+			Usage:       "servers extra Envs",
+			Destination: &config.serverEnvs,
+		},
+		&cli.StringSliceFlag{
+			Name:        "agent-envs",
+			Usage:       "agents extra Envs",
+			Destination: &config.agentEnvs,
+		},
 		&cli.StringFlag{
 			Name:        "version",
 			Usage:       "k3s version",

--- a/docs/cli/cli-docs.md
+++ b/docs/cli/cli-docs.md
@@ -35,6 +35,8 @@ Create new cluster
 
 **--agent-args**="": agents extra arguments
 
+**--agent-envs**="": agents extra Envs
+
 **--agents**="": number of agents (default: 0)
 
 **--cluster-cidr**="": cluster CIDR
@@ -50,6 +52,8 @@ Create new cluster
 **--persistence-type**="": persistence mode for the nodes (dynamic, ephemeral, static) (default: "dynamic")
 
 **--server-args**="": servers extra arguments
+
+**--server-envs**="": servers extra Envs
 
 **--servers**="": number of servers (default: 1)
 

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -111,6 +111,8 @@ _Appears in:_
 | `tlsSANs` _string array_ | TLSSANs specifies subject alternative names for the K3s server certificate. |  |  |
 | `serverArgs` _string array_ | ServerArgs specifies ordered key-value pairs for K3s server pods.<br />Example: ["--tls-san=example.com"] |  |  |
 | `agentArgs` _string array_ | AgentArgs specifies ordered key-value pairs for K3s agent pods.<br />Example: ["--node-name=my-agent-node"] |  |  |
+| `serverEnvs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvar-v1-core) array_ | ServerEnvs specifies list of environment variables to set in the server pod. |  |  |
+| `agentEnvs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvar-v1-core) array_ | AgentEnvs specifies list of environment variables to set in the agent pod. |  |  |
 | `addons` _[Addon](#addon) array_ | Addons specifies secrets containing raw YAML to deploy on cluster startup. |  |  |
 | `serverLimit` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcelist-v1-core)_ | ServerLimit specifies resource limits for server nodes. |  |  |
 | `workerLimit` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcelist-v1-core)_ | WorkerLimit specifies resource limits for agent nodes. |  |  |

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -137,6 +137,16 @@ type ClusterSpec struct {
 	// +optional
 	AgentArgs []string `json:"agentArgs,omitempty"`
 
+	// ServerEnvs specifies list of environment variables to set in the server pod.
+	//
+	// +optional
+	ServerEnvs []v1.EnvVar `json:"serverEnvs,omitempty"`
+
+	// AgentEnvs specifies list of environment variables to set in the agent pod.
+	//
+	// +optional
+	AgentEnvs []v1.EnvVar `json:"agentEnvs,omitempty"`
+
 	// Addons specifies secrets containing raw YAML to deploy on cluster startup.
 	//
 	// +optional

--- a/pkg/apis/k3k.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/k3k.io/v1alpha1/zz_generated.deepcopy.go
@@ -261,6 +261,20 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServerEnvs != nil {
+		in, out := &in.ServerEnvs, &out.ServerEnvs
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.AgentEnvs != nil {
+		in, out := &in.AgentEnvs, &out.AgentEnvs
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Addons != nil {
 		in, out := &in.Addons, &out.Addons
 		*out = make([]Addon, len(*in))

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -193,7 +193,7 @@ func (s *SharedAgent) podSpec() v1.PodSpec {
 					"--config",
 					sharedKubeletConfigPath,
 				},
-				Env: []v1.EnvVar{
+				Env: append([]v1.EnvVar{
 					{
 						Name: "AGENT_HOSTNAME",
 						ValueFrom: &v1.EnvVarSource{
@@ -203,7 +203,7 @@ func (s *SharedAgent) podSpec() v1.PodSpec {
 							},
 						},
 					},
-				},
+				}, s.cluster.Spec.AgentEnvs...),
 				VolumeMounts: []v1.VolumeMount{
 					{
 						Name:      "config",

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -235,5 +235,7 @@ func (v *VirtualAgent) podSpec(image, name string, args []string, affinitySelect
 		}
 	}
 
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, v.cluster.Spec.AgentEnvs...)
+
 	return podSpec
 }

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -187,6 +187,7 @@ func (v *VirtualAgent) podSpec(image, name string, args []string, affinitySelect
 				Resources: v1.ResourceRequirements{
 					Limits: limit,
 				},
+				Env: v.cluster.Spec.AgentEnvs,
 				VolumeMounts: []v1.VolumeMount{
 					{
 						Name:      "config",
@@ -234,8 +235,6 @@ func (v *VirtualAgent) podSpec(image, name string, args []string, affinitySelect
 			Limits: v.cluster.Spec.WorkerLimit,
 		}
 	}
-
-	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, v.cluster.Spec.AgentEnvs...)
 
 	return podSpec
 }

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -219,6 +219,8 @@ func (s *Server) podSpec(image, name string, persistent bool, startupCmd string)
 		}
 	}
 
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, s.cluster.Spec.ServerEnvs...)
+
 	return podSpec
 }
 


### PR DESCRIPTION
Adding extra env arguments to the cluster spec:

cluster.Spec.ServerEnvs
cluster.Spec.AgentEnvs

The extra envs also can  be passed as a cli flag:
--server-envs
--agent-envs

#305 