### PR TITLE
[DOC] fix: Correcting incorrect procedures in advanced-usage.md

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -122,7 +122,7 @@ You can check the [k3kcli documentation](./cli/cli-docs.md) for the full specs.
 * Ephemeral Storage:
 
     ```bash
-    k3kcli cluster create my-cluster --persistence-type ephemeral
+    k3kcli cluster create --persistence-type ephemeral my-cluster
     ```
 
 *Important Notes:*


### PR DESCRIPTION
If we follow the procedure, we will get the following error:
```
k3kcli cluster create my-cluster --persistence-type ephemeral
NAME:
   k3kcli cluster create - Create new cluster

USAGE:
   k3kcli cluster create [command options] NAME

OPTIONS:
   --kubeconfig value                           kubeconfig path (default: "/home/ec2-user/.kube/config") [$KUBECONFIG]
   --namespace value                            namespace to create the k3k cluster in
   --servers value                              number of servers (default: 1)
   --agents value                               number of agents (default: 0)
   --token value                                token of the cluster
   --cluster-cidr value                         cluster CIDR
   --service-cidr value                         service CIDR
   --persistence-type value                     persistence mode for the nodes (ephemeral, static, dynamic) (default: "dynamic")
   --storage-class-name value                   storage class name for dynamic persistence type
   --server-args value [ --server-args value ]  servers extra arguments
   --agent-args value [ --agent-args value ]    agents extra arguments
   --version value                              k3s version
   --mode value                                 k3k mode type (default: "shared")
   --kubeconfig-server value                    override the kubeconfig server host
   --help, -h                                   show help
```

Corrected the command steps due to an error in the previous instructions. This change ensures that Virtual Clusters can be created successfully when using Ephemeral Storage by this command:
`k3kcli cluster create --persistence-type ephemeral my-cluster`

