### PR TITLE
Fix HA init server scaling

### DIFF
--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -205,6 +205,20 @@ func (s *Server) podSpec(image, name string, persistent bool, startupCmd string)
 			},
 		},
 	}
+	podSpec.Containers[0].LivenessProbe = &v1.Probe{
+		InitialDelaySeconds: 10,
+		FailureThreshold:    3,
+		PeriodSeconds:       3,
+		ProbeHandler: v1.ProbeHandler{
+			Exec: &v1.ExecAction{
+				Command: []string{
+					"sh",
+					"-c",
+					`grep -q "rejoin the cluster" /var/log/k3s.log && exit 1 || exit 0`,
+				},
+			},
+		},
+	}
 	// start the pod unprivileged in shared mode
 	if s.mode == agent.VirtualNodeMode {
 		podSpec.Containers[0].SecurityContext = &v1.SecurityContext{

--- a/pkg/controller/cluster/server/template.go
+++ b/pkg/controller/cluster/server/template.go
@@ -3,14 +3,14 @@ package server
 var singleServerTemplate string = `
 if [ -d "{{.ETCD_DIR}}" ]; then
 	# if directory exists then it means its not an initial run
-	/bin/k3s server --cluster-reset --config  {{.INIT_CONFIG}} {{.EXTRA_ARGS}}
+	/bin/k3s server --cluster-reset --config  {{.INIT_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.log
 fi
 rm -f /var/lib/rancher/k3s/server/db/reset-flag
-/bin/k3s server --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}}`
+/bin/k3s server --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.log`
 
 var HAServerTemplate string = ` 
 if [ ${POD_NAME: -1} == 0 ] && [ ! -d "{{.ETCD_DIR}}" ]; then
-	/bin/k3s server --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}}
+	/bin/k3s server --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.log
 else 
-	/bin/k3s server --config {{.SERVER_CONFIG}} {{.EXTRA_ARGS}}
+	/bin/k3s server --config {{.SERVER_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.log 
 fi`

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -165,7 +165,7 @@ var _ = When("a dynamic cluster is installed", func() {
 			Expect(len(serverPods.Items)).To(Equal(1))
 			return serverPods.Items[0].DeletionTimestamp
 		}).
-			WithTimeout(30 * time.Second).
+			WithTimeout(60 * time.Second).
 			WithPolling(time.Second * 5).
 			Should(BeNil())
 


### PR DESCRIPTION
The PR accounts for a previously deleted server from etcd cluster, it adds a liveness probe that checks for a log statement that k3s logs which indicates that the pod needs to be restarted
- #243 