### PR TITLE
add air-gap support

### DIFF
--- a/charts/k3k/templates/deployment.yaml
+++ b/charts/k3k/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
             value: "{{ .Values.sharedAgent.image.repository }}:{{ default .Chart.AppVersion .Values.sharedAgent.image.tag }}"
           - name: SHARED_AGENT_PULL_POLICY
             value: {{ .Values.sharedAgent.image.pullPolicy }}
+          - name: K3S_IMAGE
+            value: {{ .Values.k3sServer.image.repository }}
+          - name: K3S_IMAGE_PULL_POLICY
+            value: {{ .Values.k3sServer.image.pullPolicy }}
           ports:
           - containerPort: 8080
             name: https

--- a/charts/k3k/values.yaml
+++ b/charts/k3k/values.yaml
@@ -27,3 +27,8 @@ sharedAgent:
     repository: "rancher/k3k-kubelet"
     tag: ""
     pullPolicy: ""
+# image registry configuration related to the k3s server
+k3sServer:
+  image:
+    repository: "rancher/k3s"
+    pullPolicy: ""

--- a/howtos/airgap.md
+++ b/howtos/airgap.md
@@ -1,0 +1,83 @@
+# K3k Air Gap Installation Guide
+
+Applicable K3k modes: `virtual`, `shared`
+
+This guide describes how to deploy **K3k** in an **air-gapped environment**, including the packaging of required images, Helm chart configurations, and cluster creation using a private container registry.
+
+---
+
+## 1. Package Required Container Images
+
+### 1.1: Follow K3s Air Gap Preparation
+
+Begin with the official K3s air gap packaging instructions:  
+[K3s Air Gap Installation Docs](https://docs.k3s.io/installation/airgap)
+
+### 1.2: Include K3k-Specific Images
+
+In addition to the K3s images, make sure to include the following in your image bundle:
+
+| Image Names                 | Descriptions                                                    |
+| --------------------------- | --------------------------------------------------------------- |
+| `rancher/k3k:<tag>`         | K3k controller image (replace `<tag>` with the desired version) |
+| `rancher/k3k-kubelet:<tag>` | K3k agent image for shared mode                                 |
+| `rancher/k3s:<tag>`         | K3s server/agent image for virtual clusters                     |
+
+Load these images into your internal (air-gapped) registry.
+
+---
+
+## 2. Configure Helm Chart for Air Gap installation
+
+Update the `values.yaml` file in the K3k Helm chart with air gap settings:
+
+```yaml
+image:
+  repository: rancher/k3k
+  tag: ""            # Specify the version tag
+  pullPolicy: ""     # Optional: "IfNotPresent", "Always", etc.
+
+sharedAgent:
+  image:
+    repository: rancher/k3k-kubelet
+    tag: ""          # Specify the version tag
+    pullPolicy: ""   # Optional
+
+k3sServer:
+  image:
+    repository: rancher/k3s
+    pullPolicy: ""   # Optional
+```
+
+These values enforce the use of internal image repositories for the K3k controller, the agent and the server.
+
+**Note** : All virtual cluster will use automatically those settings. 
+
+---
+
+## 3. Enforce Registry in Virtual Clusters
+
+When creating a virtual cluster, use the `--system-default-registry` flag to ensure all system components (e.g., CoreDNS) pull from your internal registry:
+
+```bash
+k3kcli cluster create \
+  --server-args "--system-default-registry=registry.internal.domain" \
+  my-cluster
+```
+
+This flag is passed directly to the K3s server in the virtual cluster, influencing all system workload image pulls.  
+[K3s Server CLI Reference](https://docs.k3s.io/cli/server#k3s-server-cli-help)
+
+---
+
+## 4. Specify K3s Version for Virtual Clusters
+
+K3k allows specifying the K3s version used in each virtual cluster:
+
+```bash
+k3kcli cluster create \
+  --k3s-version v1.29.4+k3s1 \
+  my-cluster
+```
+
+- If omitted, the **host cluster’s K3s version** will be used by default, which might not exist if it's not part of the air gap package.

--- a/main.go
+++ b/main.go
@@ -31,6 +31,8 @@ var (
 	sharedAgentImage           string
 	sharedAgentImagePullPolicy string
 	kubeconfig                 string
+	k3SImageName               string
+	k3SImagePullPolicy         string
 	debug                      bool
 	logger                     *log.Logger
 	flags                      = []cli.Flag{
@@ -64,6 +66,19 @@ var (
 			EnvVars:     []string{"DEBUG"},
 			Usage:       "Debug level logging",
 			Destination: &debug,
+		},
+		&cli.StringFlag{
+			Name:        "k3s-image",
+			EnvVars:     []string{"K3S_IMAGE"},
+			Usage:       "K3K server image",
+			Value:       "rancher/k3k:latest",
+			Destination: &k3SImageName,
+		},
+		&cli.StringFlag{
+			Name:        "k3s-image-pull-policy",
+			EnvVars:     []string{"K3S_IMAGE_PULL_POLICY"},
+			Usage:       "K3K server image pull policy",
+			Destination: &k3SImagePullPolicy,
 		},
 	}
 )
@@ -115,7 +130,7 @@ func run(clx *cli.Context) error {
 
 	logger.Info("adding cluster controller")
 
-	if err := cluster.Add(ctx, mgr, sharedAgentImage, sharedAgentImagePullPolicy); err != nil {
+	if err := cluster.Add(ctx, mgr, sharedAgentImage, sharedAgentImagePullPolicy, k3SImageName, k3SImagePullPolicy); err != nil {
 		return fmt.Errorf("failed to add the new cluster controller: %v", err)
 	}
 

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -20,15 +20,19 @@ const (
 
 type VirtualAgent struct {
 	*Config
-	serviceIP string
-	token     string
+	serviceIP          string
+	token              string
+	k3SImageName       string
+	k3SImagePullPolicy string
 }
 
-func NewVirtualAgent(config *Config, serviceIP, token string) *VirtualAgent {
+func NewVirtualAgent(config *Config, serviceIP, token string, k3SImageName string, k3SImagePullPolicy string) *VirtualAgent {
 	return &VirtualAgent{
-		Config:    config,
-		serviceIP: serviceIP,
-		token:     token,
+		Config:             config,
+		serviceIP:          serviceIP,
+		token:              token,
+		k3SImageName:       k3SImageName,
+		k3SImagePullPolicy: k3SImagePullPolicy,
 	}
 }
 
@@ -78,7 +82,7 @@ with-node-id: true`, serviceIP, token)
 }
 
 func (v *VirtualAgent) deployment(ctx context.Context) error {
-	image := controller.K3SImage(v.cluster)
+	image := controller.K3SImage(v.cluster, v.k3SImageName)
 
 	const name = "k3k-agent"
 
@@ -175,8 +179,9 @@ func (v *VirtualAgent) podSpec(image, name string, args []string, affinitySelect
 		},
 		Containers: []v1.Container{
 			{
-				Name:  name,
-				Image: image,
+				Name:            name,
+				Image:           image,
+				ImagePullPolicy: v1.PullPolicy(v.k3SImagePullPolicy),
 				SecurityContext: &v1.SecurityContext{
 					Privileged: ptr.To(true),
 				},

--- a/pkg/controller/cluster/cluster_suite_test.go
+++ b/pkg/controller/cluster/cluster_suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	ctx, cancel = context.WithCancel(context.Background())
-	err = cluster.Add(ctx, mgr, "rancher/k3k-kubelet:latest", "")
+	err = cluster.Add(ctx, mgr, "rancher/k3k-kubelet:latest", "", "rancher/k3s", "")
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -28,18 +28,22 @@ const (
 
 // Server
 type Server struct {
-	cluster *v1alpha1.Cluster
-	client  client.Client
-	mode    string
-	token   string
+	cluster            *v1alpha1.Cluster
+	client             client.Client
+	mode               string
+	token              string
+	k3SImageName       string
+	k3SImagePullPolicy string
 }
 
-func New(cluster *v1alpha1.Cluster, client client.Client, token, mode string) *Server {
+func New(cluster *v1alpha1.Cluster, client client.Client, token, mode string, k3SImageName string, k3SImagePullPolicy string) *Server {
 	return &Server{
-		cluster: cluster,
-		client:  client,
-		token:   token,
-		mode:    mode,
+		cluster:            cluster,
+		client:             client,
+		token:              token,
+		mode:               mode,
+		k3SImageName:       k3SImageName,
+		k3SImagePullPolicy: k3SImagePullPolicy,
 	}
 }
 
@@ -109,8 +113,9 @@ func (s *Server) podSpec(image, name string, persistent bool, startupCmd string)
 		},
 		Containers: []v1.Container{
 			{
-				Name:  name,
-				Image: image,
+				Name:            name,
+				Image:           image,
+				ImagePullPolicy: v1.PullPolicy(s.k3SImagePullPolicy),
 				Env: []v1.EnvVar{
 					{
 						Name: "POD_NAME",
@@ -244,7 +249,7 @@ func (s *Server) StatefulServer(ctx context.Context) (*apps.StatefulSet, error) 
 		persistent bool
 	)
 
-	image := controller.K3SImage(s.cluster)
+	image := controller.K3SImage(s.cluster, s.k3SImageName)
 	name := controller.SafeConcatNameWithPrefix(s.cluster.Name, serverName)
 
 	replicas = *s.cluster.Spec.Servers

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	namePrefix      = "k3k"
-	k3SImageName    = "rancher/k3s"
 	AdminCommonName = "system:admin"
 )
 
@@ -27,7 +26,7 @@ var Backoff = wait.Backoff{
 // K3SImage returns the rancher/k3s image tagged with the specified Version.
 // If Version is empty it will use with the same k8s version of the host cluster,
 // stored in the Status object. It will return the untagged version as last fallback.
-func K3SImage(cluster *v1alpha1.Cluster) string {
+func K3SImage(cluster *v1alpha1.Cluster, k3SImageName string) string {
 	if cluster.Spec.Version != "" {
 		return k3SImageName + ":" + cluster.Spec.Version
 	}


### PR DESCRIPTION
Related issue: https://github.com/rancher/k3k/issues/264 

This PR add the air-gap support.
User can specify the registry of the `k3s` server (and agent) in the helm chart `values` using 

```
k3sServer:
  image:
    repository: rancher/k3s
    pullPolicy: "" 
```

When deploying a cluster the specified repository will be used. 
If not specified in the `values` it'll default to `rancher/k3s`

- Add support of `pullPolicy` for the `k3s` server pod 
- Add a `how-to` guide to explain how to use air-gap functionality 