### PR TITLE
`VirtualClusterPolicy` documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,25 @@ K3k consists of two main components:
 * **CLI:** The K3k CLI provides a command-line interface for interacting with K3k. It allows users to easily create, manage, and access virtual clusters. The CLI simplifies common tasks such as creating `Cluster` CRs, retrieving kubeconfigs for accessing virtual clusters, and performing other management operations.
 
 
+## VirtualClusterPolicy
+
+K3k introduces the VirtualClusterPolicy Custom Resource, a way to set up and apply common configurations and how your virtual clusters operate within the K3k environment.
+
+The primary goal of VCPs is to allow administrators to centrally manage and apply consistent policies. This reduces repetitive configuration, helps meet organizational standards, and enhances the security and operational consistency of virtual clusters managed by K3k.
+
+A VirtualClusterPolicy is bound to one or more Kubernetes Namespaces. Once bound, the rules defined in the VCP apply to all K3k virtual clusters that are running or get created in that Namespace. This allows for flexible policy application, meaning different Namespaces can use their own unique VCPs, while others can share a single VCP for a consistent setup.
+
+Common use cases for administrators leveraging VirtualClusterPolicy include:
+
+- Defining the operational mode (like "shared" or "virtual") for virtual clusters.
+- Setting up resource quotas and limit ranges to effectively manage how much resources virtual clusters and their workloads can use.
+- Enforcing security standards, for example, by configuring Pod Security Admission (PSA) labels for Namespaces.
+
+The K3k controller actively monitors VirtualClusterPolicy resources and the corresponding Namespace bindings. When a VCP is applied or updated, the controller ensures that the defined configurations are enforced on the relevant virtual clusters and their associated resources within the targeted Namespaces.
+
+For a deep dive into what VirtualClusterPolicy can do, along with more examples, check out the [VirtualClusterPolicy Concepts](./virtual-cluster-policy.md) page. For a full list of all the spec fields, see the [API Reference for VirtualClusterPolicy](./link-to-your-auto-generated-spec.md).
+
+
 ## Comparison and Trade-offs
 
 K3k offers two distinct modes for deploying virtual clusters: `shared` and `virtual`. Each mode has its own strengths and weaknesses, and the best choice depends on the specific needs and priorities of the user. Here's a comparison to help you make an informed decision:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ Common use cases for administrators leveraging VirtualClusterPolicy include:
 
 The K3k controller actively monitors VirtualClusterPolicy resources and the corresponding Namespace bindings. When a VCP is applied or updated, the controller ensures that the defined configurations are enforced on the relevant virtual clusters and their associated resources within the targeted Namespaces.
 
-For a deep dive into what VirtualClusterPolicy can do, along with more examples, check out the [VirtualClusterPolicy Concepts](./virtual-cluster-policy.md) page. For a full list of all the spec fields, see the [API Reference for VirtualClusterPolicy](./link-to-your-auto-generated-spec.md).
+For a deep dive into what VirtualClusterPolicy can do, along with more examples, check out the [VirtualClusterPolicy Concepts](./virtualclusterpolicy.md) page. For a full list of all the spec fields, see the [API Reference for VirtualClusterPolicy](./crds/crd-docs.md#virtualclusterpolicy).
 
 
 ## Comparison and Trade-offs

--- a/docs/crds/config.yaml
+++ b/docs/crds/config.yaml
@@ -1,9 +1,4 @@
 processor:
-  # RE2 regular expressions describing types that should be excluded from the generated documentation.
-  ignoreTypes:
-    - VirtualClusterPolicy
-    - VirtualClusterPolicyList
-
   # RE2 regular expressions describing type fields that should be excluded from the generated documentation.
   ignoreFields:
     - "status$"

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -243,7 +243,7 @@ _Appears in:_
 
 
 VirtualClusterPolicy allows defining common configurations and constraints
-for the clusters in a namespace activated by an annotation on that Namespace.
+for clusters within a clusterpolicy.
 
 
 
@@ -289,9 +289,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `displayName` _string_ | DisplayName is the human-readable name for the policy. |  |  |
-| `quota` _[ResourceQuotaSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcequotaspec-v1-core)_ | Quota defines the ResourceQuotaSpec to be applied to the target Namespace. |  |  |
-| `limit` _[LimitRangeSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#limitrangespec-v1-core)_ | Limit specifies the LimitRange that will be applied to all pods in the target Namespace<br />to set defaults and constraints (min/max) |  |  |
+| `quota` _[ResourceQuotaSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcequotaspec-v1-core)_ | Quota specifies the resource limits for clusters within a clusterpolicy. |  |  |
+| `limit` _[LimitRangeSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#limitrangespec-v1-core)_ | Limit specifies the LimitRange that will be applied to all pods within the VirtualClusterPolicy<br />to set defaults and constraints (min/max) |  |  |
 | `defaultNodeSelector` _object (keys:string, values:string)_ | DefaultNodeSelector specifies the node selector that applies to all clusters (server + agent) in the target Namespace. |  |  |
 | `defaultPriorityClass` _string_ | DefaultPriorityClass specifies the priorityClassName applied to all pods of all clusters in the target Namespace. |  |  |
 | `allowedModeTypes` _[ClusterMode](#clustermode) array_ | AllowedModeTypes specifies the allowed cluster provisioning modes. Defaults to [shared]. | [shared] | Enum: [shared virtual] <br />MinItems: 1 <br /> |

--- a/docs/crds/crd-docs.md
+++ b/docs/crds/crd-docs.md
@@ -10,6 +10,8 @@
 ### Resource Types
 - [Cluster](#cluster)
 - [ClusterList](#clusterlist)
+- [VirtualClusterPolicy](#virtualclusterpolicy)
+- [VirtualClusterPolicyList](#virtualclusterpolicylist)
 
 
 
@@ -80,6 +82,7 @@ _Validation:_
 
 _Appears in:_
 - [ClusterSpec](#clusterspec)
+- [VirtualClusterPolicySpec](#virtualclusterpolicyspec)
 
 
 
@@ -219,6 +222,81 @@ PersistenceMode is the storage mode of a Cluster.
 _Appears in:_
 - [PersistenceConfig](#persistenceconfig)
 
+
+
+#### PodSecurityAdmissionLevel
+
+_Underlying type:_ _string_
+
+PodSecurityAdmissionLevel is the policy level applied to the pods in the namespace.
+
+_Validation:_
+- Enum: [privileged baseline restricted]
+
+_Appears in:_
+- [VirtualClusterPolicySpec](#virtualclusterpolicyspec)
+
+
+
+#### VirtualClusterPolicy
+
+
+
+VirtualClusterPolicy allows defining common configurations and constraints
+for the clusters in a namespace activated by an annotation on that Namespace.
+
+
+
+_Appears in:_
+- [VirtualClusterPolicyList](#virtualclusterpolicylist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `k3k.io/v1alpha1` | | |
+| `kind` _string_ | `VirtualClusterPolicy` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[VirtualClusterPolicySpec](#virtualclusterpolicyspec)_ | Spec defines the desired state of the VirtualClusterPolicy. | \{  \} |  |
+
+
+#### VirtualClusterPolicyList
+
+
+
+VirtualClusterPolicyList is a list of VirtualClusterPolicy resources.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `k3k.io/v1alpha1` | | |
+| `kind` _string_ | `VirtualClusterPolicyList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[VirtualClusterPolicy](#virtualclusterpolicy) array_ |  |  |  |
+
+
+#### VirtualClusterPolicySpec
+
+
+
+VirtualClusterPolicySpec defines the desired state of a VirtualClusterPolicy.
+
+
+
+_Appears in:_
+- [VirtualClusterPolicy](#virtualclusterpolicy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `displayName` _string_ | DisplayName is the human-readable name for the policy. |  |  |
+| `quota` _[ResourceQuotaSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcequotaspec-v1-core)_ | Quota defines the ResourceQuotaSpec to be applied to the target Namespace. |  |  |
+| `limit` _[LimitRangeSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#limitrangespec-v1-core)_ | Limit specifies the LimitRange that will be applied to all pods in the target Namespace<br />to set defaults and constraints (min/max) |  |  |
+| `defaultNodeSelector` _object (keys:string, values:string)_ | DefaultNodeSelector specifies the node selector that applies to all clusters (server + agent) in the target Namespace. |  |  |
+| `defaultPriorityClass` _string_ | DefaultPriorityClass specifies the priorityClassName applied to all pods of all clusters in the target Namespace. |  |  |
+| `allowedModeTypes` _[ClusterMode](#clustermode) array_ | AllowedModeTypes specifies the allowed cluster provisioning modes. Defaults to [shared]. | [shared] | Enum: [shared virtual] <br />MinItems: 1 <br /> |
+| `disableNetworkPolicy` _boolean_ | DisableNetworkPolicy indicates whether to disable the creation of a default network policy for cluster isolation. |  |  |
+| `podSecurityAdmissionLevel` _[PodSecurityAdmissionLevel](#podsecurityadmissionlevel)_ | PodSecurityAdmissionLevel specifies the pod security admission level applied to the pods in the namespace. |  | Enum: [privileged baseline restricted] <br /> |
 
 
 

--- a/docs/virtualclusterpolicy.md
+++ b/docs/virtualclusterpolicy.md
@@ -144,6 +144,5 @@ spec:
 
 ## Further Reading
 
-* For a complete reference of all `VirtualClusterPolicy` spec fields, see the [API Reference for VirtualClusterPolicy](./link-to-your-auto-generated-spec.md).
-* For more complex scenarios and advanced use cases, refer to the [Advanced Usage](./advanced-usage.md) guide.
+* For a complete reference of all `VirtualClusterPolicy` spec fields, see the [API Reference for VirtualClusterPolicy](./crds/crd-docs.md#virtualclusterpolicy).
 * To understand how VCPs fit into the overall K3k system, see the [Architecture](./architecture.md) document.

--- a/docs/virtualclusterpolicy.md
+++ b/docs/virtualclusterpolicy.md
@@ -29,6 +29,8 @@ metadata:
 
 In this example, `my-app-namespace` will adhere to the rules defined in the `VirtualClusterPolicy` named `standard-dev-policy`. Multiple Namespaces can be bound to the same policy for uniform configuration, or different Namespaces can be bound to distinct policies.
 
+It's also important to note what happens when a Namespace's policy binding changes. If a Namespace is unbound from a VirtualClusterPolicy (by removing the policy.k3k.io/policy-name label), K3k will clean up and remove the resources (such as ResourceQuotas, LimitRanges, and managed Namespace labels) that were originally applied by that policy. Similarly, if the label is changed to bind the Namespace to a new VirtualClusterPolicy, K3k will first remove the resources associated with the old policy before applying the configurations from the new one, ensuring a clean transition.
+
 ### Default Policy Values
 
 If you create a `VirtualClusterPolicy` without specifying any `spec` fields (e.g., using `k3kcli policy create my-default-policy`), it will be created with default settings. Currently, this includes `spec.allowedModeTypes` being set to `["shared"]`.

--- a/docs/virtualclusterpolicy.md
+++ b/docs/virtualclusterpolicy.md
@@ -1,0 +1,147 @@
+# VirtualClusterPolicy
+
+The VirtualClusterPolicy Custom Resource in K3k provides a way to define and enforce consistent configurations, security settings, and resource management rules for your virtual clusters and the Namespaces they operate within.
+
+By using VCPs, administrators can centrally manage these aspects, reducing manual configuration, ensuring alignment with organizational standards, and enhancing the overall security and operational consistency of the K3k environment.
+
+## Core Concepts
+
+### What is a VirtualClusterPolicy?
+
+A `VirtualClusterPolicy` is a cluster-scoped Kubernetes Custom Resource that specifies a set of rules and configurations. These policies are then applied to K3k virtual clusters (`Cluster` resources) operating within Kubernetes Namespaces that are explicitly bound to a VCP.
+
+### Binding a Policy to a Namespace
+
+To apply a `VirtualClusterPolicy` to one or more Namespaces (and thus to all K3k `Cluster` resources within those Namespaces), you need to label the desired Namespace(s). Add the following label to your Namespace metadata:
+
+`policy.k3k.io/policy-name: <YOUR_POLICY_NAME>`
+
+**Example: Labeling a Namespace**
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-app-namespace
+  labels:
+    policy.k3k.io/policy-name: "standard-dev-policy"
+```
+
+In this example, `my-app-namespace` will adhere to the rules defined in the `VirtualClusterPolicy` named `standard-dev-policy`. Multiple Namespaces can be bound to the same policy for uniform configuration, or different Namespaces can be bound to distinct policies.
+
+### Default Policy Values
+
+If you create a `VirtualClusterPolicy` without specifying any `spec` fields (e.g., using `k3kcli policy create my-default-policy`), it will be created with default settings. Currently, this includes `spec.allowedModeTypes` being set to `["shared"]`.
+
+```yaml
+# Example of a minimal VCP (after creation with defaults)
+apiVersion: k3k.io/v1alpha1
+kind: VirtualClusterPolicy
+metadata:
+  name: my-default-policy
+spec:
+  allowedModeTypes:
+  - shared
+```
+
+## Key Capabilities & Examples
+
+A `VirtualClusterPolicy` can configure several aspects of the Namespaces it's bound to and the virtual clusters operating within them.
+
+### 1. Restricting Allowed Virtual Cluster Modes (`allowedModeTypes`)
+
+You can restrict the `mode` (e.g., "shared" or "virtual") in which K3k `Cluster` resources can be provisioned within bound Namespaces. If a `Cluster` is created in a bound Namespace with a mode not listed in `allowedModeTypes`, its creation might proceed but an error should be reported in the `Cluster` resource's status.
+
+**Example:** Allow only "shared" mode clusters.
+
+```yaml
+apiVersion: k3k.io/v1alpha1
+kind: VirtualClusterPolicy
+metadata:
+  name: shared-only-policy
+spec:
+  allowedModeTypes:
+  - shared
+```
+
+You can also specify this using the CLI: `k3kcli policy create --mode shared shared-only-policy` (or `--mode virtual`).
+
+### 2. Defining Resource Quotas (`quota`)
+
+You can define resource consumption limits for bound Namespaces by specifying a `ResourceQuota`. K3k will create a `ResourceQuota` object in each bound Namespace with the provided specifications.
+
+**Example:** Set CPU, memory, and pod limits.
+
+```yaml
+apiVersion: k3k.io/v1alpha1
+kind: VirtualClusterPolicy
+metadata:
+  name: quota-policy
+spec:
+  quota:
+    hard:
+      cpu: "10"
+      memory: "20Gi"
+      pods: "10"
+```
+
+### 3. Setting Limit Ranges (`limit`)
+
+You can define default resource requests/limits and min/max constraints for containers running in bound Namespaces by specifying a `LimitRange`. K3k will create a `LimitRange` object in each bound Namespace.
+
+**Example:** Define default CPU requests/limits and min/max CPU.
+
+```yaml
+apiVersion: k3k.io/v1alpha1
+kind: VirtualClusterPolicy
+metadata:
+  name: limit-policy
+spec:
+  limit:
+    limits:
+    - default:
+        cpu: "500m"
+      defaultRequest:
+        cpu: "500m"
+      max:
+        cpu: "1"
+      min:
+        cpu: "100m"
+      type: Container
+```
+
+### 4. Managing Network Isolation (`disableNetworkPolicy`)
+
+By default, K3k creates a `NetworkPolicy` in bound Namespaces to provide network isolation for virtual clusters (especially in shared mode). You can disable the creation of this default policy.
+
+**Example:** Disable the default NetworkPolicy.
+
+```yaml
+apiVersion: k3k.io/v1alpha1
+kind: VirtualClusterPolicy
+metadata:
+  name: no-default-netpol-policy
+spec:
+  disableNetworkPolicy: true
+```
+
+### 5. Enforcing Pod Security Admission (`podSecurityAdmissionLevel`)
+
+You can enforce Pod Security Standards (PSS) by specifying a Pod Security Admission (PSA) level. K3k will apply the corresponding PSA labels to each bound Namespace. The allowed values are `privileged`, `baseline`, `restricted`, and this will add labels like `pod-security.kubernetes.io/enforce: <level>` to the bound Namespace.
+
+**Example:** Enforce the "baseline" PSS level.
+
+```yaml
+apiVersion: k3k.io/v1alpha1
+kind: VirtualClusterPolicy
+metadata:
+  name: baseline-psa-policy
+spec:
+  podSecurityAdmissionLevel: baseline
+```
+
+## Further Reading
+
+* For a complete reference of all `VirtualClusterPolicy` spec fields, see the [API Reference for VirtualClusterPolicy](./link-to-your-auto-generated-spec.md).
+* For more complex scenarios and advanced use cases, refer to the [Advanced Usage](./advanced-usage.md) guide.
+* To understand how VCPs fit into the overall K3k system, see the [Architecture](./architecture.md) document.


### PR DESCRIPTION
Fix #363 

This PR adds the doc for VirtualClusterPolicies. It adds the autogenerated docs from the specs, and also the more general doc in its own page, and main page.