### PR TITLE
Add PriorityClass reconciler (virtual cluster -> host)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ test-unit:	## Run the unit tests (skips the e2e)
 test-controller:	## Run the controller tests (pkg/controller)
 	$(GINKGO) -v -r pkg/controller
 
+.PHONY: test-kubelet-controller
+test-kubelet-controller:	## Run the controller tests (pkg/controller)
+	$(GINKGO) -v -r k3k-kubelet/controller
+
 .PHONY: test-e2e
 test-e2e:	## Run the e2e tests
 	$(GINKGO) -v -r tests

--- a/charts/k3k/templates/rbac.yaml
+++ b/charts/k3k/templates/rbac.yaml
@@ -16,7 +16,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "k3k.fullname" . }}-node-proxy
+  name: k3k-node-proxy
 rules:
 - apiGroups:
   - ""
@@ -30,8 +30,29 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "k3k.fullname" . }}-node-proxy
+  name: k3k-node-proxy
 roleRef:
   kind: ClusterRole
-  name: {{ include "k3k.fullname" . }}-node-proxy
+  name: k3k-node-proxy
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k3k-priorityclass
+rules:
+- apiGroups:
+  - "scheduling.k8s.io"
+  resources:
+  - "priorityclasses"
+  verbs:
+  - "*"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k3k-priorityclass
+roleRef:
+  kind: ClusterRole
+  name: k3k-priorityclass
   apiGroup: rbac.authorization.k8s.io

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,7 @@ To see all the available Make commands you can run `make help`, i.e:
   test                           Run all the tests
   test-unit                      Run the unit tests (skips the e2e)
   test-controller                Run the controller tests (pkg/controller)
+  test-kubelet-controller        Run the controller tests (pkg/controller)
   test-e2e                       Run the e2e tests
   generate                       Generate the CRDs specs
   docs                           Build the CRDs and CLI docs

--- a/k3k-kubelet/controller/controller_suite_test.go
+++ b/k3k-kubelet/controller/controller_suite_test.go
@@ -1,0 +1,169 @@
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Controller Suite")
+}
+
+type TestEnv struct {
+	*envtest.Environment
+	k8s       *kubernetes.Clientset
+	k8sClient client.Client
+}
+
+var (
+	hostTestEnv *TestEnv
+	hostManager ctrl.Manager
+	virtTestEnv *TestEnv
+	virtManager ctrl.Manager
+)
+
+var _ = BeforeSuite(func() {
+	hostTestEnv = NewTestEnv()
+	By("HOST testEnv running at :" + hostTestEnv.ControlPlane.APIServer.Port)
+
+	virtTestEnv = NewTestEnv()
+	By("VIRT testEnv running at :" + virtTestEnv.ControlPlane.APIServer.Port)
+
+	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))
+	ctrl.SetupSignalHandler()
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+
+	err := hostTestEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+
+	err = virtTestEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+
+	tmpKubebuilderDir := path.Join(os.TempDir(), "kubebuilder")
+	err = os.RemoveAll(tmpKubebuilderDir)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func NewTestEnv() *TestEnv {
+	GinkgoHelper()
+
+	binaryAssetsDirectory := os.Getenv("KUBEBUILDER_ASSETS")
+	if binaryAssetsDirectory == "" {
+		binaryAssetsDirectory = "/usr/local/kubebuilder/bin"
+	}
+
+	tmpKubebuilderDir := path.Join(os.TempDir(), "kubebuilder")
+
+	if err := os.Mkdir(tmpKubebuilderDir, 0755); !errors.Is(err, os.ErrExist) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	tempDir, err := os.MkdirTemp(tmpKubebuilderDir, "envtest-*")
+	Expect(err).NotTo(HaveOccurred())
+
+	err = os.CopyFS(tempDir, os.DirFS(binaryAssetsDirectory))
+	Expect(err).NotTo(HaveOccurred())
+
+	By("bootstrapping test environment")
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "charts", "k3k", "crds")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: tempDir,
+		Scheme:                buildScheme(),
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	k8s, err := kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: testEnv.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	return &TestEnv{
+		Environment: testEnv,
+		k8s:         k8s,
+		k8sClient:   k8sClient,
+	}
+}
+
+func buildScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	err := clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	return scheme
+}
+
+var _ = Describe("Kubelet Controller", func() {
+
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		var err error
+		ctx, cancel = context.WithCancel(context.Background())
+
+		hostManager, err = ctrl.NewManager(hostTestEnv.Config, ctrl.Options{
+			// disable the metrics server
+			Metrics: metricsserver.Options{BindAddress: "0"},
+			Scheme:  hostTestEnv.Scheme,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		virtManager, err = ctrl.NewManager(virtTestEnv.Config, ctrl.Options{
+			// disable the metrics server
+			Metrics: metricsserver.Options{BindAddress: "0"},
+			Scheme:  virtTestEnv.Scheme,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		go func() {
+			defer GinkgoRecover()
+			err := hostManager.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to run host manager")
+		}()
+
+		go func() {
+			defer GinkgoRecover()
+			err := virtManager.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to run virt manager")
+		}()
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("PriorityClass", PriorityClassTests)
+})

--- a/k3k-kubelet/controller/priority_class_test.go
+++ b/k3k-kubelet/controller/priority_class_test.go
@@ -1,0 +1,169 @@
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rancher/k3k/k3k-kubelet/controller"
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var PriorityClassTests = func() {
+
+	var (
+		namespace string
+		cluster   v1alpha1.Cluster
+	)
+
+	BeforeEach(func() {
+		ctx := context.Background()
+
+		ns := v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
+		}
+		err := hostTestEnv.k8sClient.Create(ctx, &ns)
+		Expect(err).NotTo(HaveOccurred())
+
+		namespace = ns.Name
+
+		cluster = v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cluster-",
+				Namespace:    namespace,
+			},
+		}
+		err = hostTestEnv.k8sClient.Create(ctx, &cluster)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = controller.AddPriorityClassReconciler(ctx, virtManager, hostManager, cluster.Name, cluster.Namespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("creates a priorityClass on the host cluster", func() {
+		ctx := context.Background()
+
+		priorityClass := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "pc-"},
+			Value:      1001,
+		}
+
+		err := virtTestEnv.k8sClient.Create(ctx, priorityClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Created priorityClass %s in virtual cluster", priorityClass.Name))
+
+		var hostPriorityClass schedulingv1.PriorityClass
+		hostPriorityClassName := translateName(cluster, priorityClass.Namespace, priorityClass.Name)
+
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostPriorityClassName}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostPriorityClass)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		By(fmt.Sprintf("Created priorityClass %s in host cluster", hostPriorityClassName))
+
+		Expect(hostPriorityClass.Value).To(Equal(priorityClass.Value))
+	})
+
+	It("deletes a priorityClass on the host cluster", func() {
+		ctx := context.Background()
+
+		priorityClass := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "pc-"},
+			Value:      1001,
+		}
+
+		err := virtTestEnv.k8sClient.Create(ctx, priorityClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Created priorityClass %s in virtual cluster", priorityClass.Name))
+
+		var hostPriorityClass schedulingv1.PriorityClass
+		hostPriorityClassName := translateName(cluster, priorityClass.Namespace, priorityClass.Name)
+
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostPriorityClassName}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostPriorityClass)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		By(fmt.Sprintf("Created priorityClass %s in host cluster", hostPriorityClassName))
+
+		Expect(hostPriorityClass.Value).To(Equal(priorityClass.Value))
+
+		err = virtTestEnv.k8sClient.Delete(ctx, priorityClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			key := client.ObjectKey{Name: hostPriorityClassName}
+			err := hostTestEnv.k8sClient.Get(ctx, key, &hostPriorityClass)
+			return apierrors.IsNotFound(err)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeTrue())
+	})
+
+	It("creates a priorityClass on the host cluster with the globalDefault annotation", func() {
+		ctx := context.Background()
+
+		priorityClass := &schedulingv1.PriorityClass{
+			ObjectMeta:    metav1.ObjectMeta{GenerateName: "pc-"},
+			Value:         1001,
+			GlobalDefault: true,
+		}
+
+		err := virtTestEnv.k8sClient.Create(ctx, priorityClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Created priorityClass %s in virtual cluster", priorityClass.Name))
+
+		var hostPriorityClass schedulingv1.PriorityClass
+		hostPriorityClassName := translateName(cluster, priorityClass.Namespace, priorityClass.Name)
+
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostPriorityClassName}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostPriorityClass)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		By(fmt.Sprintf("Created priorityClass %s in host cluster without the GlobalDefault value", hostPriorityClassName))
+
+		Expect(hostPriorityClass.Value).To(Equal(priorityClass.Value))
+		Expect(hostPriorityClass.GlobalDefault).To(BeFalse())
+		Expect(hostPriorityClass.Annotations[controller.PriorityClassGlobalDefaultAnnotation]).To(Equal("true"))
+	})
+}
+
+func translateName(cluster v1alpha1.Cluster, namespace, name string) string {
+	translator := translate.ToHostTranslator{
+		ClusterName:      cluster.Name,
+		ClusterNamespace: cluster.Namespace,
+	}
+
+	return translator.TranslateName(namespace, name)
+}

--- a/k3k-kubelet/controller/priorityclass.go
+++ b/k3k-kubelet/controller/priorityclass.go
@@ -56,8 +56,10 @@ func AddPriorityClassReconciler(ctx context.Context, virtMgr, hostMgr manager.Ma
 		Translator:    translator,
 	}
 
+	name := translator.TranslateName("", priorityClassControllerName)
+
 	return ctrl.NewControllerManagedBy(virtMgr).
-		Named(priorityClassControllerName).
+		Named(name).
 		For(&schedulingv1.PriorityClass{}).
 		WithEventFilter(ignoreSystemPrefixPredicate).
 		Complete(&reconciler)

--- a/k3k-kubelet/controller/priorityclass.go
+++ b/k3k-kubelet/controller/priorityclass.go
@@ -131,6 +131,8 @@ func (r *PriorityClassReconciler) Reconcile(ctx context.Context, req reconcile.R
 		if !apierrors.IsAlreadyExists(err) {
 			return reconcile.Result{}, err
 		}
+
+		return reconcile.Result{}, r.hostClient.Update(ctx, hostPriorityClass)
 	}
 
 	return reconcile.Result{}, nil

--- a/k3k-kubelet/controller/priorityclass.go
+++ b/k3k-kubelet/controller/priorityclass.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	priorityClassControllerName = "priorityclass-syncer-controller"
+	priorityClassFinalizerName  = "priorityclass.k3k.io/finalizer"
+)
+
+type PriorityClassReconciler struct {
+	clusterName      string
+	clusterNamespace string
+
+	virtualClient ctrlruntimeclient.Client
+	hostClient    ctrlruntimeclient.Client
+	Scheme        *runtime.Scheme
+	HostScheme    *runtime.Scheme
+	Translator    translate.ToHostTranslator
+}
+
+// AddPriorityClassReconciler adds a PriorityClass reconciler to k3k-kubelet
+func AddPriorityClassReconciler(ctx context.Context, virtMgr, hostMgr manager.Manager, clusterName, clusterNamespace string) error {
+	translator := translate.ToHostTranslator{
+		ClusterName:      clusterName,
+		ClusterNamespace: clusterNamespace,
+	}
+
+	// initialize a new Reconciler
+	reconciler := PriorityClassReconciler{
+		clusterName:      clusterName,
+		clusterNamespace: clusterNamespace,
+
+		virtualClient: virtMgr.GetClient(),
+		hostClient:    hostMgr.GetClient(),
+		Scheme:        virtMgr.GetScheme(),
+		HostScheme:    hostMgr.GetScheme(),
+		Translator:    translator,
+	}
+
+	return ctrl.NewControllerManagedBy(virtMgr).
+		Named(priorityClassControllerName).
+		For(&schedulingv1.PriorityClass{}).
+		Complete(&reconciler)
+}
+
+func (r *PriorityClassReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("cluster", r.clusterName, "clusterNamespace", r.clusterNamespace)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	var (
+		priorityClass schedulingv1.PriorityClass
+		cluster       v1alpha1.Cluster
+	)
+
+	if err := r.hostClient.Get(ctx, types.NamespacedName{Name: r.clusterName, Namespace: r.clusterNamespace}, &cluster); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.virtualClient.Get(ctx, req.NamespacedName, &priorityClass); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	hostPriorityClass := r.translatePriorityClass(priorityClass)
+
+	// handle deletion
+	if !priorityClass.DeletionTimestamp.IsZero() {
+		// deleting the synced service if exists
+		// TODO add test for previous implementation without err != nil check, and also check the other controllers
+		if err := r.hostClient.Delete(ctx, hostPriorityClass); err != nil && !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		// remove the finalizer after cleaning up the synced service
+		if controllerutil.RemoveFinalizer(&priorityClass, priorityClassFinalizerName) {
+			if err := r.virtualClient.Update(ctx, &priorityClass); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	// Add finalizer if it does not exist
+	if controllerutil.AddFinalizer(&priorityClass, priorityClassFinalizerName) {
+		if err := r.virtualClient.Update(ctx, &priorityClass); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	// create the priorityClass on the host
+	log.Info("creating the priorityClass for the first time on the host cluster")
+
+	return reconcile.Result{}, ctrlruntimeclient.IgnoreAlreadyExists(r.hostClient.Create(ctx, hostPriorityClass))
+}
+
+func (r *PriorityClassReconciler) translatePriorityClass(priorityClass schedulingv1.PriorityClass) *schedulingv1.PriorityClass {
+	hostPriorityClass := priorityClass.DeepCopy()
+	r.Translator.TranslateTo(hostPriorityClass)
+
+	return hostPriorityClass
+}

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -163,6 +163,12 @@ func newKubelet(ctx context.Context, c *config, logger *k3klog.Logger) (*kubelet
 		return nil, errors.New("failed to add pod pvc controller: " + err.Error())
 	}
 
+	logger.Info("adding priorityclass controller")
+
+	if err := k3kkubeletcontroller.AddPriorityClassReconciler(ctx, virtualMgr, hostMgr, c.ClusterName, c.ClusterNamespace); err != nil {
+		return nil, errors.New("failed to add priorityclass controller: " + err.Error())
+	}
+
 	clusterIP, err := clusterIP(ctx, c.ServiceName, c.ClusterNamespace, hostClient)
 	if err != nil {
 		return nil, errors.New("failed to extract the clusterIP for the server service: " + err.Error())

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -373,9 +373,14 @@ func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
 		tPod.Spec.Hostname = k3kcontroller.SafeConcatName(pod.Name)
 	}
 
-	// if the priorityCluss for the virtual cluster is set then override the provided value
+	// if the priorityClass for the virtual cluster is set then override the provided value
 	// Note: the core-dns and local-path-provisioner pod are scheduled by k3s with the
 	// 'system-cluster-critical' and 'system-node-critical' default priority classes.
+	if tPod.Spec.PriorityClassName != "" {
+		tPriorityClassName := p.Translator.TranslateName("", tPod.Spec.PriorityClassName)
+		tPod.Spec.PriorityClassName = tPriorityClassName
+	}
+
 	if cluster.Spec.PriorityClass != "" {
 		tPod.Spec.PriorityClassName = cluster.Spec.PriorityClass
 		tPod.Spec.Priority = nil

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -376,14 +376,16 @@ func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
 	// if the priorityClass for the virtual cluster is set then override the provided value
 	// Note: the core-dns and local-path-provisioner pod are scheduled by k3s with the
 	// 'system-cluster-critical' and 'system-node-critical' default priority classes.
-	if tPod.Spec.PriorityClassName != "" {
-		tPriorityClassName := p.Translator.TranslateName("", tPod.Spec.PriorityClassName)
-		tPod.Spec.PriorityClassName = tPriorityClassName
-	}
+	if !strings.HasPrefix(tPod.Spec.PriorityClassName, "system-") {
+		if tPod.Spec.PriorityClassName != "" {
+			tPriorityClassName := p.Translator.TranslateName("", tPod.Spec.PriorityClassName)
+			tPod.Spec.PriorityClassName = tPriorityClassName
+		}
 
-	if cluster.Spec.PriorityClass != "" {
-		tPod.Spec.PriorityClassName = cluster.Spec.PriorityClass
-		tPod.Spec.Priority = nil
+		if cluster.Spec.PriorityClass != "" {
+			tPod.Spec.PriorityClassName = cluster.Spec.PriorityClass
+			tPod.Spec.Priority = nil
+		}
 	}
 
 	// fieldpath annotations


### PR DESCRIPTION
This PR adds the PriorityClass sync from the virtual cluster to the host cluster.

With this a user will be able to create and assign priority classes also in shared mode, otherwise the priority class for the pod scheduled in the host would failed because of the missing priority class.

If a priorityClass is set as global default then this flag will need to be removed in the host, because only one priority class could be set as default. An annotation to keep track of this will be used (`priorityclass.k3k.io/globalDefault`).

This PR adds a `k3k-priorityclass` ClusterRole, needed by the k3k-kubelet to manage PriorityClasses in the host cluster.

It also add tests to the virtual kubelet, to test the sync of the resources from the virtual cluster to the host.