### PR TITLE
fix-howto usage of serverEnvs and agentEnvs

### DIFF
--- a/docs/howtos/create-virtual-clusters.md
+++ b/docs/howtos/create-virtual-clusters.md
@@ -265,9 +265,11 @@ metadata:
   name: k3kcluster-http-proxy
 spec:
   serverEnvs:
-    HTTP_PROXY: http://abc.xyz
+    - name: HTTP_PROXY
+      value: "http://abc.xyz"
   agentEnvs:
-    HTTP_PROXY: http://abc.xyz
+    - name: HTTP_PROXY
+      value: "http://abc.xyz"
 ```
 
 This configures an HTTP proxy for both servers and agents in the virtual cluster.  


### PR DESCRIPTION
Fix `serverEnvs` and `agentEnvs` usage in the how-to doc  