### PR TITLE
Fix for `k3kcli policy delete`

### DIFF
--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -41,14 +41,17 @@ type CreateConfig struct {
 
 func NewClusterCreateCmd(appCtx *AppContext) *cli.Command {
 	createConfig := &CreateConfig{}
-	createFlags := NewCreateFlags(createConfig)
+
+	flags := CommonFlags(appCtx)
+	flags = append(flags, FlagNamespace(appCtx))
+	flags = append(flags, newCreateFlags(createConfig)...)
 
 	return &cli.Command{
 		Name:            "create",
 		Usage:           "Create new cluster",
 		UsageText:       "k3kcli cluster create [command options] NAME",
 		Action:          createAction(appCtx, createConfig),
-		Flags:           WithCommonFlags(appCtx, createFlags...),
+		Flags:           flags,
 		HideHelpCommand: true,
 	}
 }

--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewCreateFlags(config *CreateConfig) []cli.Flag {
+func newCreateFlags(config *CreateConfig) []cli.Flag {
 	return []cli.Flag{
 		&cli.IntFlag{
 			Name:        "servers",

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -20,16 +20,22 @@ import (
 var keepData bool
 
 func NewClusterDeleteCmd(appCtx *AppContext) *cli.Command {
-	return &cli.Command{
-		Name:      "delete",
-		Usage:     "Delete an existing cluster",
-		UsageText: "k3kcli cluster delete [command options] NAME",
-		Action:    delete(appCtx),
-		Flags: WithCommonFlags(appCtx, &cli.BoolFlag{
+	flags := CommonFlags(appCtx)
+	flags = append(flags, FlagNamespace(appCtx))
+	flags = append(flags,
+		&cli.BoolFlag{
 			Name:        "keep-data",
 			Usage:       "keeps persistence volumes created for the cluster after deletion",
 			Destination: &keepData,
-		}),
+		},
+	)
+
+	return &cli.Command{
+		Name:            "delete",
+		Usage:           "Delete an existing cluster",
+		UsageText:       "k3kcli cluster delete [command options] NAME",
+		Action:          delete(appCtx),
+		Flags:           flags,
 		HideHelpCommand: true,
 	}
 }

--- a/cli/cmds/cluster_list.go
+++ b/cli/cmds/cluster_list.go
@@ -12,12 +12,15 @@ import (
 )
 
 func NewClusterListCmd(appCtx *AppContext) *cli.Command {
+	flags := CommonFlags(appCtx)
+	flags = append(flags, FlagNamespace(appCtx))
+
 	return &cli.Command{
 		Name:            "list",
 		Usage:           "List all the existing cluster",
 		UsageText:       "k3kcli cluster list [command options]",
 		Action:          list(appCtx),
-		Flags:           WithCommonFlags(appCtx),
+		Flags:           flags,
 		HideHelpCommand: true,
 	}
 }

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -23,14 +23,17 @@ import (
 )
 
 var (
-	name                    string
-	cn                      string
-	org                     cli.StringSlice
-	altNames                cli.StringSlice
-	expirationDays          int64
-	configName              string
-	kubeconfigServerHost    string
-	generateKubeconfigFlags = []cli.Flag{
+	name                 string
+	cn                   string
+	org                  cli.StringSlice
+	altNames             cli.StringSlice
+	expirationDays       int64
+	configName           string
+	kubeconfigServerHost string
+)
+
+func newGenerateKubeconfigFlags(appCtx *AppContext) []cli.Flag {
+	return []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
 			Usage:       "cluster name",
@@ -70,7 +73,7 @@ var (
 			Value:       "",
 		},
 	}
-)
+}
 
 func NewKubeconfigCmd(appCtx *AppContext) *cli.Command {
 	return &cli.Command{
@@ -83,12 +86,16 @@ func NewKubeconfigCmd(appCtx *AppContext) *cli.Command {
 }
 
 func NewKubeconfigGenerateCmd(appCtx *AppContext) *cli.Command {
+	flags := CommonFlags(appCtx)
+	flags = append(flags, FlagNamespace(appCtx))
+	flags = append(flags, newGenerateKubeconfigFlags(appCtx)...)
+
 	return &cli.Command{
 		Name:            "generate",
 		Usage:           "Generate kubeconfig for clusters",
 		SkipFlagParsing: false,
 		Action:          generate(appCtx),
-		Flags:           WithCommonFlags(appCtx, generateKubeconfigFlags...),
+		Flags:           flags,
 	}
 }
 

--- a/cli/cmds/policy_create.go
+++ b/cli/cmds/policy_create.go
@@ -22,7 +22,8 @@ type VirtualClusterPolicyCreateConfig struct {
 func NewPolicyCreateCmd(appCtx *AppContext) *cli.Command {
 	config := &VirtualClusterPolicyCreateConfig{}
 
-	createFlags := []cli.Flag{
+	flags := CommonFlags(appCtx)
+	flags = append(flags,
 		&cli.StringFlag{
 			Name:        "mode",
 			Usage:       "The allowed mode type of the policy",
@@ -37,14 +38,14 @@ func NewPolicyCreateCmd(appCtx *AppContext) *cli.Command {
 				}
 			},
 		},
-	}
+	)
 
 	return &cli.Command{
 		Name:            "create",
 		Usage:           "Create new policy",
 		UsageText:       "k3kcli policy create [command options] NAME",
 		Action:          policyCreateAction(appCtx, config),
-		Flags:           WithCommonFlags(appCtx, createFlags...),
+		Flags:           flags,
 		HideHelpCommand: true,
 	}
 }

--- a/cli/cmds/policy_delete.go
+++ b/cli/cmds/policy_delete.go
@@ -2,14 +2,11 @@ package cmds
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
-	k3kcluster "github.com/rancher/k3k/pkg/controller/cluster"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewPolicyDeleteCmd(appCtx *AppContext) *cli.Command {
@@ -18,7 +15,7 @@ func NewPolicyDeleteCmd(appCtx *AppContext) *cli.Command {
 		Usage:           "Delete an existing policy",
 		UsageText:       "k3kcli policy delete [command options] NAME",
 		Action:          policyDeleteAction(appCtx),
-		Flags:           WithCommonFlags(appCtx),
+		Flags:           CommonFlags(appCtx),
 		HideHelpCommand: true,
 	}
 }
@@ -33,24 +30,13 @@ func policyDeleteAction(appCtx *AppContext) cli.ActionFunc {
 		}
 
 		name := clx.Args().First()
-		if name == k3kcluster.ClusterInvalidName {
-			return errors.New("invalid cluster name")
-		}
 
-		namespace := appCtx.Namespace(name)
-
-		logrus.Infof("Deleting policy in namespace [%s]", namespace)
-
-		policy := &v1alpha1.VirtualClusterPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "default",
-				Namespace: namespace,
-			},
-		}
+		policy := &v1alpha1.VirtualClusterPolicy{}
+		policy.Name = name
 
 		if err := client.Delete(ctx, policy); err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Warnf("Policy not found in namespace [%s]", namespace)
+				logrus.Warnf("Policy not found")
 			} else {
 				return err
 			}

--- a/cli/cmds/policy_list.go
+++ b/cli/cmds/policy_list.go
@@ -16,7 +16,7 @@ func NewPolicyListCmd(appCtx *AppContext) *cli.Command {
 		Usage:           "List all the existing policies",
 		UsageText:       "k3kcli policy list [command options]",
 		Action:          policyList(appCtx),
-		Flags:           WithCommonFlags(appCtx),
+		Flags:           CommonFlags(appCtx),
 		HideHelpCommand: true,
 	}
 }

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -31,7 +31,6 @@ func NewApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "k3kcli"
 	app.Usage = "CLI for K3K"
-	app.Flags = WithCommonFlags(appCtx)
 
 	app.Before = func(clx *cli.Context) error {
 		if appCtx.Debug {
@@ -94,27 +93,36 @@ func loadRESTConfig(kubeconfig string) (*rest.Config, error) {
 	return kubeConfig.ClientConfig()
 }
 
-func WithCommonFlags(appCtx *AppContext, flags ...cli.Flag) []cli.Flag {
-	commonFlags := []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "debug",
-			Usage:       "Turn on debug logs",
-			Destination: &appCtx.Debug,
-			EnvVars:     []string{"K3K_DEBUG"},
-		},
-		&cli.StringFlag{
-			Name:        "kubeconfig",
-			Usage:       "kubeconfig path",
-			Destination: &appCtx.Kubeconfig,
-			DefaultText: "$HOME/.kube/config or $KUBECONFIG if set",
-		},
-		&cli.StringFlag{
-			Name:        "namespace",
-			Usage:       "namespace to create the k3k cluster in",
-			Aliases:     []string{"n"},
-			Destination: &appCtx.namespace,
-		},
+func CommonFlags(appCtx *AppContext) []cli.Flag {
+	return []cli.Flag{
+		FlagDebug(appCtx),
+		FlagKubeconfig(appCtx),
 	}
+}
 
-	return append(commonFlags, flags...)
+func FlagDebug(appCtx *AppContext) *cli.BoolFlag {
+	return &cli.BoolFlag{
+		Name:        "debug",
+		Usage:       "Turn on debug logs",
+		Destination: &appCtx.Debug,
+		EnvVars:     []string{"K3K_DEBUG"},
+	}
+}
+
+func FlagKubeconfig(appCtx *AppContext) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "kubeconfig",
+		Usage:       "kubeconfig path",
+		Destination: &appCtx.Kubeconfig,
+		DefaultText: "$HOME/.kube/config or $KUBECONFIG if set",
+	}
+}
+
+func FlagNamespace(appCtx *AppContext) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "namespace",
+		Usage:       "namespace of the k3k cluster",
+		Aliases:     []string{"n"},
+		Destination: &appCtx.namespace,
+	}
 }


### PR DESCRIPTION
When trying to delete a policy with the `k3kcli` this was not possible. The cli was still trying to delete a `default` policy in the specified namespace.

This PR fixes the issue deleting the Cluster scoped policy, with the specified name. It also removes the namespace flag from the `k3kcli policy delete` command, and a general refactor for the flags. Since the `namespace` is sometimes not needed I had to remove it from the _CommonFlags_.