### PR TITLE
Fix Network Policy reconciliation

### DIFF
--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -561,6 +561,10 @@ spec:
                 items:
                   type: string
                 type: array
+              virtualClusterPolicy:
+                description: VirtualClusterPolicy specifies the virtual cluster policy
+                  bound to the virtual cluster.
+                type: string
             type: object
         type: object
     served: true

--- a/charts/k3k/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/crds/k3k.io_clusters.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .spec.mode
       name: Mode
       type: string
+    - jsonPath: .status.policyName
+      name: Policy
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -552,6 +555,10 @@ spec:
                 required:
                 - type
                 type: object
+              policyName:
+                description: PolicyName specifies the virtual cluster policy name
+                  bound to the virtual cluster.
+                type: string
               serviceCIDR:
                 description: ServiceCIDR is the CIDR range for service IPs.
                 type: string
@@ -561,10 +568,6 @@ spec:
                 items:
                   type: string
                 type: array
-              virtualClusterPolicy:
-                description: VirtualClusterPolicy specifies the virtual cluster policy
-                  bound to the virtual cluster.
-                type: string
             type: object
         type: object
     served: true

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -11,6 +11,7 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.mode",name=Mode,type=string
+// +kubebuilder:printcolumn:JSONPath=".status.policyName",name=Policy,type=string
 
 // Cluster defines a virtual Kubernetes cluster managed by k3k.
 // It specifies the desired state of a virtual cluster, including version, node configuration, and networking.
@@ -317,10 +318,10 @@ type ClusterStatus struct {
 	// +optional
 	Persistence PersistenceConfig `json:"persistence,omitempty"`
 
-	// VirtualClusterPolicy specifies the virtual cluster policy bound to the virtual cluster.
+	// PolicyName specifies the virtual cluster policy name bound to the virtual cluster.
 	//
 	// +optional
-	VirtualClusterPolicy string `json:"virtualClusterPolicy,omitempty"`
+	PolicyName string `json:"policyName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/k3k.io/v1alpha1/types.go
+++ b/pkg/apis/k3k.io/v1alpha1/types.go
@@ -316,6 +316,11 @@ type ClusterStatus struct {
 	//
 	// +optional
 	Persistence PersistenceConfig `json:"persistence,omitempty"`
+
+	// VirtualClusterPolicy specifies the virtual cluster policy bound to the virtual cluster.
+	//
+	// +optional
+	VirtualClusterPolicy string `json:"virtualClusterPolicy,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/policy/namespace.go
+++ b/pkg/controller/policy/namespace.go
@@ -50,9 +50,10 @@ func (c *VirtualClusterPolicyReconciler) cleanupNamespaces(ctx context.Context) 
 	}
 
 	for _, ns := range namespaces.Items {
-		deleteOpts := []client.DeleteAllOfOption{
-			client.InNamespace(ns.Name),
-			client.MatchingLabels{ManagedByLabelKey: VirtualPolicyControllerName},
+		selector := labels.NewSelector()
+
+		if req, err := labels.NewRequirement(ManagedByLabelKey, selection.Equals, []string{VirtualPolicyControllerName}); err == nil {
+			selector = selector.Add(*req)
 		}
 
 		// if the namespace is bound to a policy -> cleanup resources of other policies
@@ -63,25 +64,13 @@ func (c *VirtualClusterPolicyReconciler) cleanupNamespaces(ctx context.Context) 
 			if err != nil {
 				log.Error(err, "error creating requirement", "policy", ns.Labels[PolicyNameLabelKey])
 			} else {
-				sel := labels.NewSelector().Add(*requirement)
-				deleteOpts = append(deleteOpts, client.MatchingLabelsSelector{Selector: sel})
-
-				log.Info("requirement created", "sel", sel.String())
+				selector = selector.Add(*requirement)
 			}
 		}
 
-		var policies v1alpha1.VirtualClusterPolicyList
-		if err := c.Client.List(ctx, &policies,
+		deleteOpts := []client.DeleteAllOfOption{
 			client.InNamespace(ns.Name),
-			client.MatchingLabels{ManagedByLabelKey: VirtualPolicyControllerName},
-		); err != nil {
-			return err
-		}
-
-		log.Info("getting policies to delete")
-
-		for _, policy := range policies.Items {
-			log.Info("policy to delete: " + policy.Name)
+			client.MatchingLabelsSelector{Selector: selector},
 		}
 
 		if err := c.Client.DeleteAllOf(ctx, &networkingv1.NetworkPolicy{}, deleteOpts...); err != nil {

--- a/pkg/controller/policy/namespace.go
+++ b/pkg/controller/policy/namespace.go
@@ -65,7 +65,23 @@ func (c *VirtualClusterPolicyReconciler) cleanupNamespaces(ctx context.Context) 
 			} else {
 				sel := labels.NewSelector().Add(*requirement)
 				deleteOpts = append(deleteOpts, client.MatchingLabelsSelector{Selector: sel})
+
+				log.Info("requirement created", "sel", sel.String())
 			}
+		}
+
+		var policies v1alpha1.VirtualClusterPolicyList
+		if err := c.Client.List(ctx, &policies,
+			client.InNamespace(ns.Name),
+			client.MatchingLabels{ManagedByLabelKey: VirtualPolicyControllerName},
+		); err != nil {
+			return err
+		}
+
+		log.Info("getting policies to delete")
+
+		for _, policy := range policies.Items {
+			log.Info("policy to delete: " + policy.Name)
 		}
 
 		if err := c.Client.DeleteAllOf(ctx, &networkingv1.NetworkPolicy{}, deleteOpts...); err != nil {

--- a/pkg/controller/policy/policy.go
+++ b/pkg/controller/policy/policy.go
@@ -66,7 +66,6 @@ func namespaceEventHandler() handler.Funcs {
 			if ns.Labels[PolicyNameLabelKey] != "" {
 				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ns.Labels[PolicyNameLabelKey]}})
 			}
-
 		},
 		// When a Namespace is updated, if it has the "policy.k3k.io/policy-name" label
 		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {


### PR DESCRIPTION
This PR fixes the reconciliation for the network policies of the virtual clusters when a policy is applied, or removed.

A Watch on the Namespaces will now trigger the ClusterReconciler, adding to the cluster a `policyName` field in the status, if the namespace where the Cluster is managed by a VirtualClusterPolicy. If so it will not create any NetworkPolicy because the one created by the VirtualClusterPolicy will take place, so we don't even have multiple NetPols with the same configuration.

It also adds a printColumn for printing the policy associated with the clusters with a `k3kcli cluster list` or `kubectl get clusters.k3k.io`.

```
-> % k3kcli cluster list
NAMESPACE        NAME         MODE     POLICY
k3k-mycluster2   mycluster2   shared   policy2
myns             mycluster    shared   <none>
myns             mycluster2   shared   <none>
myns             mycluster3   shared   <none>
myns             mycluster4   shared   <none>
```

```
-> % kubectl get clusters.k3k.io -A                                 
NAMESPACE        NAME         MODE     POLICY
k3k-mycluster2   mycluster2   shared   policy2
myns             mycluster    shared   
myns             mycluster2   shared   
myns             mycluster3   shared   
myns             mycluster4   shared   
```