### PR TITLE
Fix for controller added with same name

### DIFF
--- a/k3k-kubelet/controller/configmap.go
+++ b/k3k-kubelet/controller/configmap.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const ConfigMapSyncerName = "configmap-syncer"
+
 type ConfigMapSyncer struct {
 	mutex sync.RWMutex
 	// VirtualClient is the client for the virtual cluster
@@ -30,6 +32,10 @@ type ConfigMapSyncer struct {
 	// objs are the objects that the syncer should watch/syncronize. Should only be manipulated
 	// through add/remove
 	objs sets.Set[types.NamespacedName]
+}
+
+func (c *ConfigMapSyncer) Name() string {
+	return ConfigMapSyncerName
 }
 
 // Reconcile implements reconcile.Reconciler and synchronizes the objects in objs to the host cluster

--- a/k3k-kubelet/controller/handler.go
+++ b/k3k-kubelet/controller/handler.go
@@ -39,6 +39,7 @@ type ControllerHandler struct {
 // be altered through the Add and Remove methods
 type updateableReconciler interface {
 	reconcile.Reconciler
+	Name() string
 	AddResource(ctx context.Context, namespace string, name string) error
 	RemoveResource(ctx context.Context, namespace string, name string) error
 }
@@ -97,6 +98,7 @@ func (c *ControllerHandler) AddResource(ctx context.Context, obj client.Object) 
 	}
 
 	err := ctrl.NewControllerManagedBy(c.Mgr).
+		Named(r.Name()).
 		For(&v1.ConfigMap{}).
 		Complete(r)
 

--- a/k3k-kubelet/controller/secret.go
+++ b/k3k-kubelet/controller/secret.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const SecretSyncerName = "secret-syncer"
+
 type SecretSyncer struct {
 	mutex sync.RWMutex
 	// VirtualClient is the client for the virtual cluster
@@ -30,6 +32,10 @@ type SecretSyncer struct {
 	// objs are the objects that the syncer should watch/syncronize. Should only be manipulated
 	// through add/remove
 	objs sets.Set[types.NamespacedName]
+}
+
+func (s *SecretSyncer) Name() string {
+	return SecretSyncerName
 }
 
 // Reconcile implements reconcile.Reconciler and synchronizes the objects in objs to the host cluster


### PR DESCRIPTION
The `updateableReconciler` is used to sync ConfigMap and Secrets, but it's watching only configmaps. Because of this it will be added with the same name (the default used is the name of the resource.

```
unable to start configmap controller: controller with name configmap already exists.
Controller names must be unique to avoid multiple controllers reporting to the same metric
```

This is a quick fix, but the reconciler will probably need another review.