### PR TITLE
Add scheduled Conformance tests for shared mode

### DIFF
--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -28,13 +28,143 @@ permissions:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    if: inputs.test == '' || inputs.test == 'conformance'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Install helm
+      uses: azure/setup-helm@v4.3.0
+    
+    - name: Install hydrophone
+      run: go install sigs.k8s.io/hydrophone@latest
+
+    - name: Install k3d and kubectl
+      run: |
+        wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d version
+
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+    - name: Setup Kubernetes (k3d)
+      env:
+        REPO_NAME: k3k-registry
+        REPO_PORT: 12345
+      run: |
+        echo "127.0.0.1 ${REPO_NAME}" | sudo tee -a /etc/hosts
+
+        k3d registry create ${REPO_NAME} --port ${REPO_PORT}
+        
+        k3d cluster create k3k --servers 3 \
+          -p "30000-30010:30000-30010@server:0" \
+          --registry-use k3d-${REPO_NAME}:${REPO_PORT}
+        
+        kubectl cluster-info
+        kubectl get nodes
+
+    - name: Setup K3k
+      env:
+        REPO: k3k-registry:12345
+      run: |
+        echo "127.0.0.1 k3k-registry" | sudo tee -a /etc/hosts
+
+        make build
+        make package
+        make push
+
+        # add k3kcli to $PATH
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+        VERSION=$(make version)
+        k3d image import ${REPO}/k3k:${VERSION} -c k3k --verbose
+        k3d image import ${REPO}/k3k-kubelet:${VERSION} -c k3k --verbose
+
+        make install
+        
+        echo "Wait for K3k controller to be available"
+        kubectl wait -n k3k-system pod --for condition=Ready -l "app.kubernetes.io/name=k3k" --timeout=5m
+
+    - name: Check k3kcli
+      run: k3kcli -v
+
+    - name: Create virtual cluster
+      run: |
+        kubectl create namespace k3k-mycluster
+
+        cat <<EOF | kubectl apply -f -
+        apiVersion: k3k.io/v1alpha1
+        kind: Cluster
+        metadata:
+          name: mycluster
+          namespace: k3k-mycluster
+        spec:
+          servers: 2
+          tlsSANs:
+            - "127.0.0.1"
+          expose:
+            nodePort:
+              serverPort: 30001
+        EOF
+
+        echo "Wait for bootstrap secret to be available"
+        kubectl wait -n k3k-mycluster --for=create secret k3k-mycluster-bootstrap --timeout=5m
+
+        k3kcli kubeconfig generate --name mycluster
+
+        export KUBECONFIG=${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
+        
+        kubectl cluster-info
+        kubectl get nodes
+        kubectl get pods -A
+    
+    - name: Run conformance tests (parallel)
+      run: |
+        # Run conformance tests in parallel mode (skipping serial)
+        hydrophone --conformance --parallel 4 --skip='\[Serial\]' \
+          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
+          --output-dir /tmp
+    
+    - name: Keep parallel conformance logs
+      if: success() || failure()
+      run: mv /tmp/e2e.log /tmp/e2e.log.parallel
+
+    - name: Run conformance tests (serial)
+      if: success() || failure()
+      run: |        
+        # Run serial conformance tests
+        hydrophone --focus='\[Serial\].*\[Conformance\]' \
+          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
+          --output-dir /tmp
+
+    - name: Merge conformance logs
+      if: success() || failure()
+      run: |
+        echo "\n\nParallel Tests:\n" >> /tmp/e2e.log
+        cat /tmp/e2e.log.parallel >> /tmp/e2e.log        
+
+    - name: Archive conformance logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: conformance-logs
+        path: /tmp/e2e.log
+
+  sigs:
+    runs-on: ubuntu-latest
+    if: inputs.test == '' || inputs.test != 'conformance'
 
     strategy:
       fail-fast: false
       matrix:
         tests:
-          - name: conformance
-            focus: '\[Conformance\]'
           - name: sig-api-machinery
             focus: '\[sig-api-machinery\].*\[Conformance\]'
           - name: sig-apps
@@ -150,33 +280,8 @@ jobs:
         kubectl cluster-info
         kubectl get nodes
         kubectl get pods -A
-    
-    - name: Run conformance tests
-      if: inputs.test == 'conformance' || (inputs.test == '' && matrix.tests.name == 'conformance')
-      env:
-        KUBECONFIG: ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
-      run: |
-        export KUBECONFIG=${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
-
-        # Run conformance tests in parallel mode (skipping serial)
-        hydrophone --conformance --parallel 4 --skip='\[Serial\]' \
-          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
-          --output-dir /tmp
-        
-        mv /tmp/e2e.log /tmp/e2e.log.parallel
-        
-        # Run serial conformance tests
-        hydrophone --focus='\[Serial\].*\[Conformance\]' \
-          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
-          --output-dir /tmp
-        
-        echo "\n\nParallel Tests:\n" >> /tmp/e2e.log
-        cat /tmp/e2e.log.parallel >> /tmp/e2e.log
 
     - name: Run sigs tests
-      if: (inputs.test != '' && inputs.test != 'conformance') || (inputs.test == '' && matrix.tests.name != 'conformance')
-      env:
-        KUBECONFIG: ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
       run: |
         FOCUS="${{ matrix.tests.focus }}"
         if [ -n "${{ inputs.test }}" ]; then
@@ -184,8 +289,6 @@ jobs:
         fi
 
         echo "Running with --focus=${FOCUS}"
-
-        export KUBECONFIG=${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
 
         hydrophone --focus ${FOCUS} \
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -282,15 +282,12 @@ jobs:
         kubectl get pods -A
 
     - name: Run sigs tests
+      if: inputs.test == '' || inputs.test == matrix.tests.name
       run: |
         FOCUS="${{ matrix.tests.focus }}"
-        if [ -n "${{ inputs.test }}" ]; then
-          FOCUS="${{ inputs.test }}"
-        fi
-
         echo "Running with --focus=${FOCUS}"
 
-        hydrophone --focus ${FOCUS} \
+        hydrophone --focus "${FOCUS}" \
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
           --output-dir /tmp
 

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -1,7 +1,6 @@
 name: Conformance Tests
 
 on:
-  push:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -1,9 +1,9 @@
 name: Conformance Tests
 
 on:
+  push:
   schedule:
     - cron: "0 1 * * *"
-
   workflow_dispatch:
     inputs:
       test:

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -132,9 +132,11 @@ jobs:
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
           --output-dir /tmp
     
-    - name: Keep parallel conformance logs
+    - name: Keep parallel conformance logs and cleanup
       if: success() || failure()
-      run: mv /tmp/e2e.log /tmp/e2e.log.parallel
+      run: |
+        mv /tmp/e2e.log /tmp/e2e.log.parallel
+        kubectl delete namespace conformance-serviceaccou
 
     - name: Run conformance tests (serial)
       if: success() || failure()

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -1,0 +1,199 @@
+name: Conformance Tests
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+
+  workflow_dispatch:
+    inputs:
+      test:
+        description: "Run specific test"
+        type: choice
+        options:
+          - conformance
+          - sig-api-machinery
+          - sig-apps
+          - sig-architecture
+          - sig-auth
+          - sig-cli
+          - sig-instrumentation
+          - sig-network
+          - sig-node
+          - sig-scheduling
+          - sig-storage
+
+permissions:
+    contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - name: conformance
+            focus: '\[Conformance\]'
+          - name: sig-api-machinery
+            focus: '\[sig-api-machinery\].*\[Conformance\]'
+          - name: sig-apps
+            focus: '\[sig-apps\].*\[Conformance\]'
+          - name: sig-architecture
+            focus: '\[sig-architecture\].*\[Conformance\]'
+          - name: sig-auth
+            focus: '\[sig-auth\].*\[Conformance\]'
+          - name: sig-cli
+            focus: '\[sig-cli\].*\[Conformance\]'
+          - name: sig-instrumentation
+            focus: '\[sig-instrumentation\].*\[Conformance\]'
+          - name: sig-network
+            focus: '\[sig-network\].*\[Conformance\]'
+          - name: sig-node
+            focus: '\[sig-node\].*\[Conformance\]'
+          - name: sig-scheduling
+            focus: '\[sig-scheduling\].*\[Conformance\]'
+          - name: sig-storage
+            focus: '\[sig-storage\].*\[Conformance\]'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Install helm
+      uses: azure/setup-helm@v4.3.0
+    
+    - name: Install hydrophone
+      run: go install sigs.k8s.io/hydrophone@latest
+
+    - name: Install k3d and kubectl
+      run: |
+        wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d version
+
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+    - name: Setup Kubernetes (k3d)
+      env:
+        REPO_NAME: k3k-registry
+        REPO_PORT: 12345
+      run: |
+        echo "127.0.0.1 ${REPO_NAME}" | sudo tee -a /etc/hosts
+
+        k3d registry create ${REPO_NAME} --port ${REPO_PORT}
+        
+        k3d cluster create k3k --servers 3 \
+          -p "30000-30010:30000-30010@server:0" \
+          --registry-use k3d-${REPO_NAME}:${REPO_PORT}
+        
+        kubectl cluster-info
+        kubectl get nodes
+
+    - name: Setup K3k
+      env:
+        REPO: k3k-registry:12345
+      run: |
+        echo "127.0.0.1 k3k-registry" | sudo tee -a /etc/hosts
+
+        make build
+        make package
+        make push
+
+        # add k3kcli to $PATH
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+        VERSION=$(make version)
+        k3d image import ${REPO}/k3k:${VERSION} -c k3k --verbose
+        k3d image import ${REPO}/k3k-kubelet:${VERSION} -c k3k --verbose
+
+        make install
+        
+        echo "Wait for K3k controller to be available"
+        kubectl wait -n k3k-system pod --for condition=Ready -l "app.kubernetes.io/name=k3k" --timeout=5m
+
+    - name: Check k3kcli
+      run: k3kcli -v
+
+    - name: Create virtual cluster
+      run: |
+        kubectl create namespace k3k-mycluster
+
+        cat <<EOF | kubectl apply -f -
+        apiVersion: k3k.io/v1alpha1
+        kind: Cluster
+        metadata:
+          name: mycluster
+          namespace: k3k-mycluster
+        spec:
+          servers: 2
+          tlsSANs:
+            - "127.0.0.1"
+          expose:
+            nodePort:
+              serverPort: 30001
+        EOF
+
+        echo "Wait for bootstrap secret to be available"
+        kubectl wait -n k3k-mycluster --for=create secret k3k-mycluster-bootstrap --timeout=5m
+
+        k3kcli kubeconfig generate --name mycluster
+
+        export KUBECONFIG=${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
+        
+        kubectl cluster-info
+        kubectl get nodes
+        kubectl get pods -A
+    
+    - name: Run conformance tests
+      if: inputs.test == 'conformance' || (inputs.test == '' && matrix.tests.name == 'conformance')
+      env:
+        KUBECONFIG: ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
+      run: |
+        export KUBECONFIG=${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
+
+        # Run conformance tests in parallel mode (skipping serial)
+        hydrophone --conformance --parallel 4 --skip='\[Serial\]' \
+          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
+          --output-dir /tmp
+        
+        mv /tmp/e2e.log /tmp/e2e.log.parallel
+        
+        # Run serial conformance tests
+        hydrophone --focus --parallel 4 --skip='\[Serial\].*\[Conformance\]' \
+          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
+          --output-dir /tmp
+        
+        echo "\n\nParallel Tests:\n" >> /tmp/e2e.log
+        cat /tmp/e2e.log.parallel >> /tmp/e2e.log
+
+    - name: Run sigs tests
+      if: (inputs.test != '' && inputs.test != 'conformance') || (inputs.test == '' && matrix.tests.name != 'conformance')
+      env:
+        KUBECONFIG: ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
+      run: |
+        FOCUS="${{ matrix.tests.focus }}"
+        if [ -n "${{ inputs.test }}" ]; then
+          FOCUS="${{ inputs.test }}"
+        fi
+
+        echo "Running with --focus=${FOCUS}"
+
+        export KUBECONFIG=${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml
+
+        hydrophone --focus ${FOCUS} \
+          --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
+          --output-dir /tmp
+
+    - name: Archive conformance logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: ${{ matrix.tests.name }}-logs
+        path: /tmp/e2e.log

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -30,6 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.test == '' || inputs.test == 'conformance'
 
+    strategy:
+      fail-fast: false
+      matrix:
+        type:
+        - parallel
+        - serial
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -126,37 +133,26 @@ jobs:
         kubectl get pods -A
     
     - name: Run conformance tests (parallel)
+      if: matrix.type == 'parallel'
       run: |
         # Run conformance tests in parallel mode (skipping serial)
         hydrophone --conformance --parallel 4 --skip='\[Serial\]' \
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
           --output-dir /tmp
-    
-    - name: Keep parallel conformance logs and cleanup
-      if: success() || failure()
-      run: |
-        mv /tmp/e2e.log /tmp/e2e.log.parallel
-        kubectl delete namespace conformance-serviceaccou
 
     - name: Run conformance tests (serial)
-      if: success() || failure()
+      if: matrix.type == 'serial'
       run: |        
         # Run serial conformance tests
         hydrophone --focus='\[Serial\].*\[Conformance\]' \
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
-          --output-dir /tmp
-
-    - name: Merge conformance logs
-      if: success() || failure()
-      run: |
-        echo "\n\nParallel Tests:\n" >> /tmp/e2e.log
-        cat /tmp/e2e.log.parallel >> /tmp/e2e.log        
+          --output-dir /tmp 
 
     - name: Archive conformance logs
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: conformance-logs
+        name: conformance-${{ matrix.type }}-logs
         path: /tmp/e2e.log
 
   sigs:

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -166,7 +166,7 @@ jobs:
         mv /tmp/e2e.log /tmp/e2e.log.parallel
         
         # Run serial conformance tests
-        hydrophone --focus --parallel 4 --skip='\[Serial\].*\[Conformance\]' \
+        hydrophone --focus='\[Serial\].*\[Conformance\]' \
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
           --output-dir /tmp
         


### PR DESCRIPTION
This PR introduces a new nightly (01:00) job to execute Conformance tests in "shared" mode.

The job will perform the following:
- Run the full Conformance test suite in parallel, skipping `[Serial]` tests.
- Subsequently, run `[Serial].*[Conformance]` tests serially.
- Concurrently, execute Conformance tests categorized by SIGs.

These tests can also be triggered manually with a specified execution type.

For more information, please refer to the [K8s Conformance documentation](https://github.com/cncf/k8s-conformance/tree/master/docs).

Ref: #166 #331 