### PR TITLE
Improve chart-release workflow

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,1 +1,3 @@
 release-name-template: chart-{{ .Version }}
+make-release-latest: false
+skip-existing: true

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -2,9 +2,6 @@ name: Chart
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-    - "chart-*"
 
 permissions:
     contents: write
@@ -17,15 +14,6 @@ jobs:
       uses: actions/checkout@v4
       with:
           fetch-depth: 0
-
-    - name: Check tag
-      if: github.event_name == 'push'
-      run: |
-        pushed_tag=$(echo ${{ github.ref_name }} | sed "s/chart-//")
-        chart_tag=$(yq .version charts/k3k/Chart.yaml)
-        
-        echo pushed_tag=${pushed_tag} chart_tag=${chart_tag}
-        [ "${pushed_tag}" == "${chart_tag}" ]
 
     - name: Configure Git
       run: |


### PR DESCRIPTION
This should fix https://github.com/rancher/k3k/issues/404

With this changes the new release of the charts will not be marked as "latest", and will not fail if the release already exists.

It also removes the need for the tag. To release now we just need to run manually the workflow, and if the version in the Chart.yaml changed, then a new release will be created.