### PR TITLE
Adding some tests for `k3kcli`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
     - name: Install Ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo
-    
+
     - name: Build and package
       run: |
         make build
@@ -105,12 +105,73 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: k3s-logs
+        name: e2e-k3s-logs
         path: /tmp/k3s.log
-    
+
     - name: Archive k3k logs
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: k3k-logs
+        name: e2e-k3k-logs
+        path: /tmp/k3k.log
+
+  tests-cli:
+    runs-on: ubuntu-latest
+    needs: validate
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Install Ginkgo
+      run: go install github.com/onsi/ginkgo/v2/ginkgo
+    
+    - name: Set coverage environment
+      run: |
+        echo "COVERAGE=true" >> $GITHUB_ENV
+        echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
+    
+    - name: Build and package
+      run: |
+        make build
+        make package
+
+        # add k3kcli to $PATH
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+    - name: Check k3kcli
+      run: k3kcli -v
+
+    - name: Run cli tests
+      run: make test-cli
+
+    - name: Convert coverage data
+      run: go tool covdata textfmt -i=${{ github.workspace }}/covdata -o ${{ github.workspace }}/covdata/cover.out
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ${{ github.workspace }}/covdata/cover.out
+        flags: cli
+
+    - name: Archive k3s logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: cli-k3s-logs
+        path: /tmp/k3s.log
+
+    - name: Archive k3k logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: cli-k3k-logs
         path: /tmp/k3k.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,6 +135,8 @@ jobs:
     
     - name: Set coverage environment
       run: |
+        mkdir ${{ github.workspace }}/covdata
+        
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
     

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 __debug*
 *-kubeconfig.yaml
 .envtest
+cover.out
+covcounters.**
+covmeta.**

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 REPO ?= rancher
+COVERAGE ?= false
 VERSION ?= $(shell git describe --tags --always --dirty --match="v[0-9]*")
 
 ## Dependencies
@@ -29,7 +30,7 @@ version: ## Print the current version
 
 .PHONY: build
 build:	## Build the the K3k binaries (k3k, k3k-kubelet and k3kcli)
-	@VERSION=$(VERSION) ./scripts/build
+	@VERSION=$(VERSION) COVERAGE=$(COVERAGE) ./scripts/build
 
 .PHONY: package
 package: package-k3k package-k3k-kubelet	## Package the k3k and k3k-kubelet Docker images
@@ -68,7 +69,11 @@ test-kubelet-controller:	## Run the controller tests (pkg/controller)
 
 .PHONY: test-e2e
 test-e2e:	## Run the e2e tests
-	$(GINKGO) $(GINKGO_FLAGS) tests
+	$(GINKGO) $(GINKGO_FLAGS) --label-filter=e2e tests
+
+.PHONY: test-cli
+test-cli:	## Run the cli tests
+	$(GINKGO) $(GINKGO_FLAGS) --label-filter=cli tests
 
 .PHONY: generate
 generate:	## Generate the CRDs specs

--- a/scripts/build
+++ b/scripts/build
@@ -4,12 +4,20 @@ set -eou pipefail
 
 LDFLAGS="-X \"github.com/rancher/k3k/pkg/buildinfo.Version=${VERSION}\""
 
+build_args=()
+
+# Check if coverage is enabled, e.g., in CI or when manually set
+if [[ "${COVERAGE:-false}" == "true" ]]; then
+    echo "Coverage build enabled."
+    build_args+=("-cover" "-coverpkg=./..." "-covermode=atomic")
+fi
+
 echo "Building k3k... [cli os/arch: $(go env GOOS)/$(go env GOARCH)]"
 echo "Current TAG: ${VERSION} "
 
 export CGO_ENABLED=0
-GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o bin/k3k
-GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o bin/k3k-kubelet ./k3k-kubelet
+GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" "${build_args[@]}" -o bin/k3k
+GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" "${build_args[@]}" -o bin/k3k-kubelet ./k3k-kubelet
 
 # build the cli for the local OS and ARCH
-go build -ldflags="${LDFLAGS}" -o bin/k3kcli ./cli
+go build -ldflags="${LDFLAGS}" "${build_args[@]}" -o bin/k3kcli ./cli

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"os/exec"
 
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func K3kcli(args ...string) (string, string, error) {
@@ -23,23 +24,26 @@ func K3kcli(args ...string) (string, string, error) {
 	return stdout.String(), stderr.String(), err
 }
 
-var _ = When("using the k3kcli", Label("e2e"), Label("cli"), func() {
-
+var _ = When("using the k3kcli", Label("cli"), func() {
 	It("can get the version", func() {
-		stdout, stderr, err := K3kcli("--version")
+		stdout, _, err := K3kcli("--version")
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(stdout).To(ContainSubstring("k3kcli Version: v"))
-		Expect(stderr).To(BeEmpty())
 	})
 
 	When("trying the cluster commands", func() {
 		It("can create, list and delete a cluster", func() {
+			var (
+				stdout string
+				stderr string
+				err    error
+			)
+
 			clusterName := "cluster-" + rand.String(5)
 			clusterNamespace := "k3k-" + clusterName
 
-			stdout, stderr, err := K3kcli("cluster", "create", clusterName)
+			_, stderr, err = K3kcli("cluster", "create", clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
-			Expect(stdout).To(BeEmpty())
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
 
 			stdout, stderr, err = K3kcli("cluster", "list")
@@ -47,9 +51,8 @@ var _ = When("using the k3kcli", Label("e2e"), Label("cli"), func() {
 			Expect(stderr).To(BeEmpty())
 			Expect(stdout).To(ContainSubstring(clusterNamespace))
 
-			stdout, stderr, err = K3kcli("cluster", "delete", clusterName)
+			_, stderr, err = K3kcli("cluster", "delete", clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
-			Expect(stdout).To(BeEmpty())
 			Expect(stderr).To(ContainSubstring(fmt.Sprintf("Deleting [%s] cluster in namespace [%s]", clusterName, clusterNamespace)))
 		})
 	})

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -1,0 +1,56 @@
+package k3k_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func K3kcli(args ...string) (string, string, error) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+
+	cmd := exec.CommandContext(context.Background(), "k3kcli", args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+
+	return stdout.String(), stderr.String(), err
+}
+
+var _ = When("using the k3kcli", Label("e2e"), Label("cli"), func() {
+
+	It("can get the version", func() {
+		stdout, stderr, err := K3kcli("--version")
+		Expect(err).To(Not(HaveOccurred()))
+		Expect(stdout).To(ContainSubstring("k3kcli Version: v"))
+		Expect(stderr).To(BeEmpty())
+	})
+
+	When("trying the cluster commands", func() {
+		It("can create, list and delete a cluster", func() {
+			clusterName := "cluster-" + rand.String(5)
+			clusterNamespace := "k3k-" + clusterName
+
+			stdout, stderr, err := K3kcli("cluster", "create", clusterName)
+			Expect(err).To(Not(HaveOccurred()), string(stderr))
+			Expect(stdout).To(BeEmpty())
+			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			stdout, stderr, err = K3kcli("cluster", "list")
+			Expect(err).To(Not(HaveOccurred()), string(stderr))
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring(clusterNamespace))
+
+			stdout, stderr, err = K3kcli("cluster", "delete", clusterName)
+			Expect(err).To(Not(HaveOccurred()), string(stderr))
+			Expect(stdout).To(BeEmpty())
+			Expect(stderr).To(ContainSubstring(fmt.Sprintf("Deleting [%s] cluster in namespace [%s]", clusterName, clusterNamespace)))
+		})
+	})
+})

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -67,12 +67,14 @@ var _ = BeforeSuite(func() {
 
 	tmpFile, err := os.CreateTemp("", "kubeconfig-")
 	Expect(err).To(Not(HaveOccurred()))
-	defer tmpFile.Close()
+
+	defer Expect(tmpFile.Close()).To(Succeed())
 
 	_, err = tmpFile.Write(kubeconfig)
 	Expect(err).To(Not(HaveOccurred()))
 	kubeconfigPath = tmpFile.Name()
-	os.Setenv("KUBECONFIG", kubeconfigPath)
+
+	Expect(os.Setenv("KUBECONFIG", kubeconfigPath)).To(Succeed())
 
 	DeferCleanup(os.Remove, kubeconfigPath)
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -52,6 +52,8 @@ var _ = BeforeSuite(func() {
 	var err error
 	ctx := context.Background()
 
+	GinkgoWriter.Println("GOCOVERDIR:", os.Getenv("GOCOVERDIR"))
+
 	k3sContainer, err = k3s.Run(ctx, "rancher/k3s:v1.32.1-k3s1")
 	Expect(err).To(Not(HaveOccurred()))
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -68,10 +68,10 @@ var _ = BeforeSuite(func() {
 	tmpFile, err := os.CreateTemp("", "kubeconfig-")
 	Expect(err).To(Not(HaveOccurred()))
 
-	defer Expect(tmpFile.Close()).To(Succeed())
-
 	_, err = tmpFile.Write(kubeconfig)
 	Expect(err).To(Not(HaveOccurred()))
+	Expect(tmpFile.Close()).To(Succeed())
+
 	kubeconfigPath = tmpFile.Name()
 
 	Expect(os.Setenv("KUBECONFIG", kubeconfigPath)).To(Succeed())


### PR DESCRIPTION
This PR adds some scaffolding and some e2e tests for the `k3kcli`.

It also adds the support to build the K3k binaries with the coverage support, uploading the `k3kcli` coverage with the `cli` flag. This should increase the coverage, including the `cli` folder.

To run the tests: `make test-cli`