### PR TITLE
Fix kubeconfig flag being recognised

### DIFF
--- a/cli/cmds/cluster_list.go
+++ b/cli/cmds/cluster_list.go
@@ -12,8 +12,17 @@ import (
 )
 
 func NewClusterListCmd(appCtx *AppContext) *cli.Command {
-	flags := CommonFlags(appCtx)
-	flags = append(flags, FlagNamespace(appCtx))
+	// flags := CommonFlags(appCtx)
+	// flags = append(flags, FlagNamespace(appCtx))
+
+	flags := []cli.Flag{
+		FlagNamespace(appCtx),
+		// prevents overwriting of kubeconfig specified globally
+		&cli.StringFlag{
+			Name:  "kubeconfig",
+			Usage: "kubeconfig path",
+		},
+	}
 
 	return &cli.Command{
 		Name:            "list",
@@ -23,7 +32,10 @@ func NewClusterListCmd(appCtx *AppContext) *cli.Command {
 		Flags:           flags,
 		HideHelpCommand: true,
 		Before: func(clx *cli.Context) error {
-	        appCtx.Kubeconfig = clx.String("kubeconfig")
+			// get command-level kubeconfig and assign to appCtx if not empty
+			if cmdKubeconfig := clx.String("kubeconfig"); cmdKubeconfig != "" {
+				appCtx.Kubeconfig = cmdKubeconfig
+			}
 	        return initializeClient(appCtx)
 	    },
 	}

--- a/cli/cmds/cluster_list.go
+++ b/cli/cmds/cluster_list.go
@@ -22,6 +22,10 @@ func NewClusterListCmd(appCtx *AppContext) *cli.Command {
 		Action:          list(appCtx),
 		Flags:           flags,
 		HideHelpCommand: true,
+		Before: func(clx *cli.Context) error {
+	        appCtx.Kubeconfig = clx.String("kubeconfig")
+	        return initializeClient(appCtx)
+	    },
 	}
 }
 

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -38,24 +38,6 @@ func NewApp() *cli.App {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 
-		restConfig, err := loadRESTConfig(appCtx.Kubeconfig)
-		if err != nil {
-			return err
-		}
-
-		scheme := runtime.NewScheme()
-		_ = clientgoscheme.AddToScheme(scheme)
-		_ = v1alpha1.AddToScheme(scheme)
-		_ = apiextensionsv1.AddToScheme(scheme)
-
-		ctrlClient, err := client.New(restConfig, client.Options{Scheme: scheme})
-		if err != nil {
-			return err
-		}
-
-		appCtx.RestConfig = restConfig
-		appCtx.Client = ctrlClient
-
 		return nil
 	}
 
@@ -71,6 +53,28 @@ func NewApp() *cli.App {
 	}
 
 	return app
+}
+
+func initializeClient(appCtx *AppContext) error {
+
+	restConfig, err := loadRESTConfig(appCtx.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	ctrlClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return err
+	}
+
+	appCtx.RestConfig = restConfig
+	appCtx.Client = ctrlClient
+	return nil
 }
 
 func (ctx *AppContext) Namespace(name string) string {


### PR DESCRIPTION
This is a fix for #414 
It works by running the app.Before, then Before from cluster_list.go, then runs initialiseClient.

The issue stems from the kubeconfig flag being at the end of the command and thus not having been parsed yet at the app.Before stage. Hence `k3kcli cluster list --kubeconfig=/kubeconfig` failed while `k3kcli --kubeconfig=/kubeconfig cluster list` worked.

The fix is to only initialise the client *after* the kubeconfig flag has been read in the former case.