### PR TITLE
Fix for PortAllocator initialization

### DIFF
--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -682,14 +682,14 @@ func (c *ClusterReconciler) ensureAgent(ctx context.Context, cluster *v1alpha1.C
 		if cluster.Spec.MirrorHostNodes {
 			var err error
 
-			kubeletPort, err = c.PortAllocator.AllocateKubeletPort(ctx, config)
+			kubeletPort, err = c.PortAllocator.AllocateKubeletPort(ctx, cluster.Name, cluster.Namespace)
 			if err != nil {
 				return err
 			}
 
 			cluster.Status.KubeletPort = kubeletPort
 
-			webhookPort, err = c.PortAllocator.AllocateWebhookPort(ctx, config)
+			webhookPort, err = c.PortAllocator.AllocateWebhookPort(ctx, cluster.Name, cluster.Namespace)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/cluster/cluster_finalize.go
+++ b/pkg/controller/cluster/cluster_finalize.go
@@ -41,11 +41,11 @@ func (c *ClusterReconciler) finalizeCluster(ctx context.Context, cluster *v1alph
 	if cluster.Spec.Mode == v1alpha1.SharedClusterMode && cluster.Spec.MirrorHostNodes {
 		log.Info("dellocating ports for kubelet and webhook")
 
-		if err := c.PortAllocator.DeallocateKubeletPort(ctx, c.Client, cluster.Name, cluster.Namespace, cluster.Status.KubeletPort); err != nil {
+		if err := c.PortAllocator.DeallocateKubeletPort(ctx, cluster.Name, cluster.Namespace, cluster.Status.KubeletPort); err != nil {
 			return reconcile.Result{}, err
 		}
 
-		if err := c.PortAllocator.DeallocateWebhookPort(ctx, c.Client, cluster.Name, cluster.Namespace, cluster.Status.WebhookPort); err != nil {
+		if err := c.PortAllocator.DeallocateWebhookPort(ctx, cluster.Name, cluster.Namespace, cluster.Status.WebhookPort); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
This PR fixes a small bug happening at the first initialization and startup of the PortAllocator. When the ConfigMap where not yet created the reference to them was not updated with the last value because of a shadowing of the variable with the same name:

```go
func (a *PortAllocator) getOrCreate(ctx context.Context, configmap *v1.ConfigMap, portRange string) error {
	nn := types.NamespacedName{
		Name:      configmap.Name,
		Namespace: configmap.Namespace,
	}
	if err := a.Client.Get(ctx, nn, configmap); err != nil {
		if !apierrors.IsNotFound(err) {
			return err
		}

		// HERE the configMap has the same name of the PortAllocator ConfigMap, but a different reference
		configmap = a.cm(configmap.Name, configmap.Namespace, portRange)

		// The Create will update this value, and not the original PortAllocatoMap
		if err := a.Client.Create(ctx, configmap); err != nil {
			return fmt.Errorf("failed to create port range configmap: %w", err)
		}
	}

	return nil
}
```

This PR fixes this issue, updating the passed object.

It also adds some const for the map fields, and adds the Client to the PortAllocator.