### PR TITLE
Add k3k controller coverage data

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,6 +79,13 @@ jobs:
 
     - name: Install Ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo
+    
+    - name: Set coverage environment
+      run: |
+        mkdir ${{ github.workspace }}/covdata
+        
+        echo "COVERAGE=true" >> $GITHUB_ENV
+        echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
 
     - name: Build and package
       run: |
@@ -93,6 +100,18 @@ jobs:
 
     - name: Run e2e tests
       run: make test-e2e
+
+    - name: Convert coverage data
+      run: |
+        ls -al ${GOCOVERDIR}
+        go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out
+    
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ${GOCOVERDIR}/cover.out
+        flags: controller
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,18 +102,16 @@ jobs:
       run: make test-e2e
 
     - name: Convert coverage data
-      run: |
-        ls -al ${GOCOVERDIR}
-        go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out
+      run: go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out
     
-    - name: Upload coverage reports to Codecov
+    - name: Upload coverage reports to Codecov (controller)
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${GOCOVERDIR}/cover.out
         flags: controller
 
-    - name: Upload coverage reports to Codecov
+    - name: Upload coverage reports to Codecov (e2e)
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/go-logr/zapr"
 	"github.com/spf13/cobra"
@@ -79,7 +82,8 @@ func main() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	logger.Info("Starting k3k - Version: " + buildinfo.Version)
 
@@ -128,6 +132,8 @@ func run(cmd *cobra.Command, args []string) error {
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start the manager: %v", err)
 	}
+
+	logger.Info("controller manager stopped")
 
 	return nil
 }


### PR DESCRIPTION
Fix partially #428 

This PR adds the coverage report of the controller. It will be build with the `-cover` flag, and a PVC where to download the report will be patched to the deployment.

At the end of the tests the container of the controller will be restarted to force a dump, and the report collected and uploaded.

From the report we will increase the coverage by +12%:

```
@@             Coverage Diff             @@
##             main     #452       +/-   ##
===========================================
+ Coverage   40.18%   52.61%   +12.42%     
===========================================
```