### PR TITLE
[WIP] Simplify e2e tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -140,8 +140,8 @@ jobs:
 
     - name: Run e2e tests
       run: |
-        REPO: k3k-registry:12345
-        VERSION=$(make version)
+        export REPO=k3k-registry:12345
+        export VERSION=$(make version)
 
         make test-e2e
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,33 @@ jobs:
 
     - name: Install Ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo
-    
+
+    - name: Install helm
+      uses: azure/setup-helm@v4.3.0
+
+    - name: Install k3d and kubectl
+      run: |
+        wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d version
+
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+    - name: Setup Kubernetes (k3d)
+      env:
+        REPO_NAME: k3k-registry
+        REPO_PORT: 12345
+      run: |
+        echo "127.0.0.1 ${REPO_NAME}" | sudo tee -a /etc/hosts
+
+        k3d registry create ${REPO_NAME} --port ${REPO_PORT}
+        
+        k3d cluster create k3k --servers 3 \
+          -p "30000-30010:30000-30010@server:0" \
+          --registry-use k3d-${REPO_NAME}:${REPO_PORT}
+        
+        kubectl cluster-info
+        kubectl get nodes
+
     - name: Set coverage environment
       run: |
         mkdir ${{ github.workspace }}/covdata
@@ -87,13 +113,27 @@ jobs:
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
 
-    - name: Build and package
+    - name: Setup K3k
+      env:
+        REPO: k3k-registry:12345
       run: |
+        echo "127.0.0.1 k3k-registry" | sudo tee -a /etc/hosts
+
         make build
         make package
+        make push
 
         # add k3kcli to $PATH
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+        VERSION=$(make version)
+        k3d image import ${REPO}/k3k:${VERSION} -c k3k --verbose
+        k3d image import ${REPO}/k3k-kubelet:${VERSION} -c k3k --verbose
+
+        make install
+        
+        echo "Wait for K3k controller to be available"
+        kubectl wait -n k3k-system pod --for condition=Ready -l "app.kubernetes.io/name=k3k" --timeout=5m
 
     - name: Check k3kcli
       run: k3kcli -v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,7 +139,11 @@ jobs:
       run: k3kcli -v
 
     - name: Run e2e tests
-      run: make test-e2e
+      run: |
+        REPO: k3k-registry:12345
+        VERSION=$(make version)
+
+        make test-e2e
 
     - name: Convert coverage data
       run: go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -161,7 +161,17 @@ func installK3kChart(ctx context.Context, kubeconfig []byte) {
 		"tag":        "dev",
 	})
 
-	err = k3sContainer.LoadImages(ctx, "rancher/k3k:dev", "rancher/k3k-kubelet:dev")
+	repo := "rancher"
+	if repoEnv := os.Getenv("REPO"); repoEnv != "" {
+		repo = repoEnv
+	}
+
+	version := "dev"
+	if versionEnv := os.Getenv("VERSION"); versionEnv != "" {
+		version = versionEnv
+	}
+
+	err = k3sContainer.LoadImages(ctx, repo+"/k3k:"+version, repo+"/k3k-kubelet:"+version)
 	Expect(err).To(Not(HaveOccurred()))
 
 	release, err := iCli.Run(k3kChart, k3kChart.Values)


### PR DESCRIPTION
E2e are using testcontainers. While this is nice to run tests without being worried about the environment it's hard to debug them checking the running pods, or looking at what's happening in the cluster.

This PR tries to simplify the tests, keeping the chance to run them in containers, isolated, or targeting an external cluster.