### PR TITLE
Fix for pod eviction in host cluster

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,29 +114,35 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := cluster.Add(ctx, mgr, &config, maxConcurrentReconciles, portAllocator, nil); err != nil {
-		return fmt.Errorf("failed to add the new cluster controller: %v", err)
+		return fmt.Errorf("failed to add cluster controller: %v", err)
 	}
 
 	logger.Info("adding statefulset controller")
 
 	if err := cluster.AddStatefulSetController(ctx, mgr, maxConcurrentReconciles); err != nil {
-		return fmt.Errorf("failed to add the statefulset controller: %v", err)
+		return fmt.Errorf("failed to add statefulset controller: %v", err)
 	}
 
 	logger.Info("adding service controller")
 
 	if err := cluster.AddServiceController(ctx, mgr, maxConcurrentReconciles); err != nil {
-		return fmt.Errorf("failed to add the new service controller: %v", err)
+		return fmt.Errorf("failed to add service controller: %v", err)
+	}
+
+	logger.Info("adding pod controller")
+
+	if err := cluster.AddPodController(ctx, mgr, maxConcurrentReconciles); err != nil {
+		return fmt.Errorf("failed to add pod controller: %v", err)
 	}
 
 	logger.Info("adding clusterpolicy controller")
 
 	if err := policy.Add(mgr, config.ClusterCIDR, maxConcurrentReconciles); err != nil {
-		return fmt.Errorf("failed to add the clusterpolicy controller: %v", err)
+		return fmt.Errorf("failed to add clusterpolicy controller: %v", err)
 	}
 
 	if err := mgr.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start the manager: %v", err)
+		return fmt.Errorf("failed to start manager: %v", err)
 	}
 
 	logger.Info("controller manager stopped")

--- a/pkg/controller/cluster/client.go
+++ b/pkg/controller/cluster/client.go
@@ -1,0 +1,35 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+
+	v1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/k3k/pkg/controller"
+)
+
+// newVirtualClient
+func newVirtualClient(ctx context.Context, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace string) (ctrlruntimeclient.Client, error) {
+	var clusterKubeConfig v1.Secret
+
+	kubeconfigSecretName := types.NamespacedName{
+		Name:      controller.SafeConcatNameWithPrefix(clusterName, "kubeconfig"),
+		Namespace: clusterNamespace,
+	}
+
+	if err := hostClient.Get(ctx, kubeconfigSecretName, &clusterKubeConfig); err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig secret: %w", err)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(clusterKubeConfig.Data["kubeconfig.yaml"])
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config from kubeconfig file: %w", err)
+	}
+
+	return ctrlruntimeclient.New(restConfig, ctrlruntimeclient.Options{})
+}

--- a/pkg/controller/cluster/filter.go
+++ b/pkg/controller/cluster/filter.go
@@ -1,0 +1,38 @@
+package cluster
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+)
+
+func newClusterPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		owner := metav1.GetControllerOf(object)
+
+		return owner != nil &&
+			owner.Kind == "Cluster" &&
+			owner.APIVersion == v1alpha1.SchemeGroupVersion.String()
+	})
+}
+
+func clusterNamespacedName(object client.Object) types.NamespacedName {
+	var clusterName string
+
+	owner := metav1.GetControllerOf(object)
+	if owner != nil && owner.Kind == "Cluster" && owner.APIVersion == v1alpha1.SchemeGroupVersion.String() {
+		clusterName = owner.Name
+	} else {
+		clusterName = object.GetLabels()[translate.ClusterNameLabel]
+	}
+
+	return types.NamespacedName{
+		Name:      clusterName,
+		Namespace: object.GetNamespace(),
+	}
+}

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -56,8 +56,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 			return reconcile.Result{}, err
 		}
 
-		// TODO: should we delete it anyway?
-
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -1,0 +1,105 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1alpha1"
+	k3kcontroller "github.com/rancher/k3k/pkg/controller"
+)
+
+const (
+	podController = "k3k-pod-controller"
+)
+
+type PodReconciler struct {
+	Client ctrlruntimeclient.Client
+	Scheme *runtime.Scheme
+}
+
+// Add adds a new controller to the manager
+func AddPodController(ctx context.Context, mgr manager.Manager, maxConcurrentReconciles int) error {
+	// initialize a new Reconciler
+	reconciler := PodReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.Pod{}).
+		Named(podController).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(&reconciler)
+}
+
+func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("reconciling pod")
+
+	var pod v1.Pod
+	if err := r.Client.Get(ctx, req.NamespacedName, &pod); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		// TODO: should we delete it anyway?
+
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	owner := metav1.GetControllerOf(&pod)
+	if owner == nil || owner.APIVersion != v1alpha1.SchemeGroupVersion.String() || owner.Kind != "Cluster" {
+		log.Info("Pod is not owned by a k3k Cluster, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	key := types.NamespacedName{
+		Name:      k3kcontroller.SafeConcatNameWithPrefix(owner.Name, "kubeconfig"),
+		Namespace: pod.Namespace,
+	}
+
+	var clusterKubeConfig v1.Secret
+	if err := r.Client.Get(ctx, key, &clusterKubeConfig); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	virtConfig, err := clientcmd.RESTConfigFromKubeConfig(clusterKubeConfig.Data["kubeconfig.yaml"])
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to create config from kubeconfig file: %v", err)
+	}
+
+	virtClient, err := ctrlruntimeclient.New(virtConfig, ctrlruntimeclient.Options{})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if !pod.DeletionTimestamp.IsZero() {
+		virtName := pod.GetAnnotations()[translate.ResourceNameAnnotation]
+		virtNamespace := pod.GetAnnotations()[translate.ResourceNamespaceAnnotation]
+
+		virtPod := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      virtName,
+				Namespace: virtNamespace,
+			},
+		}
+
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(virtClient.Delete(ctx, &virtPod))
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/cluster/service.go
+++ b/pkg/controller/cluster/service.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "k8s.io/api/core/v1"
@@ -33,55 +32,39 @@ func AddServiceController(ctx context.Context, mgr manager.Manager, maxConcurren
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(serviceController).
-		For(&v1.Service{}).WithEventFilter(predicate.NewPredicateFuncs(reconciler.filterResources)).
+		For(&v1.Service{}).
+		WithEventFilter(newClusterPredicate()).
 		Complete(&reconciler)
-}
-
-func (r *ServiceReconciler) filterResources(object ctrlruntimeclient.Object) bool {
-	_, hasClusterNameLabel := object.GetLabels()[translate.ClusterNameLabel]
-	_, hasNameAnnotation := object.GetAnnotations()[translate.ResourceNameAnnotation]
-	_, hasNamespaceAnnotation := object.GetAnnotations()[translate.ResourceNamespaceAnnotation]
-
-	// Return true only if all were found
-	return hasClusterNameLabel && hasNameAnnotation && hasNamespaceAnnotation
 }
 
 func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("ensuring service status to virtual cluster")
 
-	var (
-		virtServiceName, virtServiceNamespace string
-		hostService, virtService              v1.Service
-	)
+	var hostService, virtService v1.Service
 
 	if err := r.HostClient.Get(ctx, req.NamespacedName, &hostService); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
-	// get cluster information from the object
-	labels := hostService.GetLabels()
+	// get cluster from the object
+	cluster := clusterNamespacedName(&hostService)
 
-	clusterName, ok := labels[translate.ClusterNameLabel]
-	if !ok {
-		return reconcile.Result{}, fmt.Errorf("cluster name label is not found")
-	}
-
-	clusterNamespace := hostService.GetNamespace()
-
-	virtualClient, err := newVirtualClient(ctx, r.HostClient, clusterName, clusterNamespace)
+	virtualClient, err := newVirtualClient(ctx, r.HostClient, cluster.Name, cluster.Namespace)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster info: %v", err)
 	}
-
-	virtServiceName = hostService.Annotations[translate.ResourceNameAnnotation]
-	virtServiceNamespace = hostService.Annotations[translate.ResourceNamespaceAnnotation]
 
 	if !hostService.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, nil
 	}
 
-	if err := virtualClient.Get(ctx, types.NamespacedName{Name: virtServiceName, Namespace: virtServiceNamespace}, &virtService); err != nil {
+	virtualServiceKey := types.NamespacedName{
+		Name:      hostService.Annotations[translate.ResourceNameAnnotation],
+		Namespace: hostService.Annotations[translate.ResourceNamespaceAnnotation],
+	}
+
+	if err := virtualClient.Get(ctx, virtualServiceKey, &virtService); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get virt service: %v", err)
 	}
 

--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -23,6 +23,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -63,35 +64,45 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("reconciling statefulset")
 
-	s := strings.Split(req.Name, "-")
-	if len(s) < 1 {
-		return reconcile.Result{}, nil
-	}
-
-	if s[0] != "k3k" {
-		return reconcile.Result{}, nil
-	}
-
-	clusterName := s[1]
-
-	var cluster v1alpha1.Cluster
-	if err := p.Client.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: req.Namespace}, &cluster); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-	}
-
-	matchingLabels := ctrlruntimeclient.MatchingLabels(map[string]string{"role": "server"})
-	listOpts := &ctrlruntimeclient.ListOptions{Namespace: req.Namespace}
-	matchingLabels.ApplyToList(listOpts)
-
-	var podList v1.PodList
-	if err := p.Client.List(ctx, &podList, listOpts); err != nil {
+	var sts apps.StatefulSet
+	if err := p.Client.Get(ctx, req.NamespacedName, &sts); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
-	if len(podList.Items) == 1 {
+	// We only care about statefulsets for k3k servers
+	if sts.Labels["role"] != "server" || !strings.HasPrefix(sts.Name, "k3k-") {
 		return reconcile.Result{}, nil
+	}
+
+	owner := metav1.GetControllerOf(&sts)
+	if owner == nil || owner.APIVersion != v1alpha1.SchemeGroupVersion.String() || owner.Kind != "Cluster" {
+		log.Info("StatefulSet is not owned by a k3k Cluster, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	var cluster v1alpha1.Cluster
+	if err := p.Client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: req.Namespace}, &cluster); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		// The owning cluster is gone, nothing to do.
+		return reconcile.Result{}, nil
+	}
+
+	// If the statefulset is being deleted, we don't need to do anything,
+	// as the pods will be deleted and trigger their own reconciliation.
+	if !sts.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
+	}
+
+	// Check if we need to scale down
+	if *sts.Spec.Replicas > 0 && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
+		log.Info("StatefulSet is not fully ready, checking for pods to remove from etcd", "ready", sts.Status.ReadyReplicas, "desired", *sts.Spec.Replicas)
+	}
+
+	var podList v1.PodList
+	if err := p.Client.List(ctx, &podList, ctrlruntimeclient.InNamespace(req.Namespace), ctrlruntimeclient.MatchingLabels(sts.Spec.Selector.MatchLabels)); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
 	for _, pod := range podList.Items {

--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -85,6 +85,7 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
+
 		// The owning cluster is gone, nothing to do.
 		return reconcile.Result{}, nil
 	}
@@ -103,6 +104,10 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	var podList v1.PodList
 	if err := p.Client.List(ctx, &podList, ctrlruntimeclient.InNamespace(req.Namespace), ctrlruntimeclient.MatchingLabels(sts.Spec.Selector.MatchLabels)); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if len(podList.Items) == 1 {
+		return reconcile.Result{}, nil
 	}
 
 	for _, pod := range podList.Items {

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -35,6 +35,8 @@ type VirtualCluster struct {
 }
 
 func NewVirtualCluster() *VirtualCluster { // By default, create an ephemeral cluster
+	GinkgoHelper()
+
 	return NewVirtualClusterWithType(v1alpha1.EphemeralPersistenceMode)
 }
 


### PR DESCRIPTION
This PR fixes #454. It adds a PodController that will observe the host pods, and when a pod owned by a Cluster is deleted, then it will delete the corresponding pod on the virtual cluster.