### PR TITLE
Fix Service reconciliation error loop

### DIFF
--- a/pkg/controller/cluster/client.go
+++ b/pkg/controller/cluster/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rancher/k3k/pkg/controller"
 )
 
-// newVirtualClient
+// newVirtualClient creates a new Client that can be used to interact with the virtual cluster
 func newVirtualClient(ctx context.Context, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace string) (ctrlruntimeclient.Client, error) {
 	var clusterKubeConfig v1.Secret
 

--- a/pkg/controller/cluster/service.go
+++ b/pkg/controller/cluster/service.go
@@ -74,14 +74,14 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		Namespace: virtualServiceNamespace,
 	}
 
-	var virtService v1.Service
-	if err := virtualClient.Get(ctx, virtualServiceKey, &virtService); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get virt service: %v", err)
+	var virtualService v1.Service
+	if err := virtualClient.Get(ctx, virtualServiceKey, &virtualService); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get virtual service: %v", err)
 	}
 
-	if !equality.Semantic.DeepEqual(virtService.Status.LoadBalancer, hostService.Status.LoadBalancer) {
-		virtService.Status.LoadBalancer = hostService.Status.LoadBalancer
-		if err := virtualClient.Status().Update(ctx, &virtService); err != nil {
+	if !equality.Semantic.DeepEqual(virtualService.Status.LoadBalancer, hostService.Status.LoadBalancer) {
+		virtualService.Status.LoadBalancer = hostService.Status.LoadBalancer
+		if err := virtualClient.Status().Update(ctx, &virtualService); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
Fix #496 by checking that the Services owned by the Cluster are resources within the virtual cluster.