### PR TITLE
Improve cli

### DIFF
--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -115,17 +115,23 @@ func createAction(appCtx *AppContext, config *CreateConfig) func(cmd *cobra.Comm
 		cluster := newCluster(name, namespace, config)
 
 		persistencemessage := "Ephemeral (data will be lost if all servers are removed)"
+
 		if cluster.Spec.Persistence.Type == v1alpha1.DynamicPersistenceMode {
 			sizemessage := "2Gi"
+
 			if cluster.Spec.Persistence.StorageRequestSize != "" {
 				sizemessage = cluster.Spec.Persistence.StorageRequestSize
 			}
+
 			persistencemessage = fmt.Sprintf("[StorageClass: %s, Size: %s]", ptr.Deref(cluster.Spec.Persistence.StorageClassName, "default"), sizemessage)
 		}
+
 		versionmessage := "Same as host"
+
 		if cluster.Spec.Version != "" {
 			versionmessage = cluster.Spec.Version
 		}
+
 		if cluster.Spec.Mode == v1alpha1.SharedClusterMode {
 			logrus.Infof("Cluster details: \n  Mode: %s\n  Servers: %d\n  Version: %s\n  Persistence: %s", cluster.Spec.Mode, *cluster.Spec.Servers, versionmessage, persistencemessage)
 		} else {


### PR DESCRIPTION
Fix for #483 

During the creation with the `cli` the cluster detail will be showed. 

```
INFO[0000] Cluster details: 
  Mode: virtual
  Servers: 3
  Agents: 1
  Version: Same as host
  Persistence: [StorageClass: default, Size: 2Gi]
```