### PR TITLE
Add k8s version upgrade test

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -477,13 +477,3 @@ func caCertSecret(name, namespace string, crt, key []byte) *corev1.Secret {
 		},
 	}
 }
-
-func findPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
-	for i := range conditions {
-		if conditions[i].Type == condType {
-			return &conditions[i]
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
The PR adds 2 new tests related to cluster version upgrade, the test consists of the following steps:

- Create a cluster with dynamic persistent storage in shared/virtual mode with version "v1.31.13-k3s1"
- Create a nginx pod on the cluster
- Update the cluster spec to upgrade the version to "v1.32.8-k3s1"
- Check if the server/agents pods are updated with the right version
- Check if the k8s cluster version matches the new version
- Check if nginx pod still intact


- #465 