### PR TITLE
Fix pseudo PV deletion

### DIFF
--- a/k3k-kubelet/controller/syncer/pod.go
+++ b/k3k-kubelet/controller/syncer/pod.go
@@ -211,5 +211,5 @@ func (r *PodReconciler) handlePodDeletion(ctx context.Context, pv *v1.Persistent
 		return err
 	}
 
-	return ctrlruntimeclient.IgnoreNotFound(r.VirtualClient.Delete(ctx, pv))
+	return ctrlruntimeclient.IgnoreNotFound(r.VirtualClient.Delete(ctx, &currentPV))
 }


### PR DESCRIPTION
- #478 
This PR instructs the controller to delete the pseudo PV if the pod claiming it is deleted, allowing for recreation of the pod and reusing of the pvc