### PR TITLE
Switch to `text` log format as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,8 @@ validate: generate docs fmt ## Validate the project checking for any dependency 
 .PHONY: install
 install:	## Install K3k with Helm on the targeted Kubernetes cluster
 	helm upgrade --install --namespace k3k-system --create-namespace \
-		--set controller.extraEnv[0].name=LOG_FORMAT \
-		--set controller.extraEnv[0].value=console \
-		--set controller.extraEnv[1].name=DEBUG \
+		--set controller.extraEnv[0].name=DEBUG \
+		--set-string controller.extraEnv[0].value=true \
 		--set controller.image.repository=$(REPO)/k3k \
 		--set controller.image.tag=$(VERSION) \
 		--set agent.shared.image.repository=$(REPO)/k3k-kubelet \

--- a/k3k-kubelet/main.go
+++ b/k3k-kubelet/main.go
@@ -43,8 +43,8 @@ func main() {
 		RunE: run,
 	}
 
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug logging")
-	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "json", "Log format (json or console)")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "Enable debug logging")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format (text or json)")
 	rootCmd.PersistentFlags().StringVar(&cfg.ClusterName, "cluster-name", "", "Name of the k3k cluster")
 	rootCmd.PersistentFlags().StringVar(&cfg.ClusterNamespace, "cluster-namespace", "", "Namespace of the k3k cluster")
 	rootCmd.PersistentFlags().StringVar(&cfg.Token, "token", "", "K3S token of the k3k cluster")

--- a/main.go
+++ b/main.go
@@ -62,8 +62,8 @@ func main() {
 		RunE: run,
 	}
 
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Debug level logging")
-	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "json", "Log format (json or console)")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "Debug level logging")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format (text or json)")
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "kubeconfig path")
 	rootCmd.PersistentFlags().StringVar(&config.ClusterCIDR, "cluster-cidr", "", "Cluster CIDR to be added to the networkpolicy")
 	rootCmd.PersistentFlags().StringVar(&config.SharedAgentImage, "agent-shared-image", "rancher/k3k-kubelet", "K3K Virtual Kubelet image")

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -27,7 +27,7 @@ func newEncoder(format string) zapcore.Encoder {
 	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	var encoder zapcore.Encoder
-	if format == "console" {
+	if format == "text" {
 		encCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		encoder = zapcore.NewConsoleEncoder(encCfg)
 	} else {


### PR DESCRIPTION
This PR switch to the `text` log format as default, following the Kubernetes API conventions, and the Rancher one.

It also rename the format value to `text` instead of `console` (less idiomatic).

Note: the switch from `BoolVar` to `BoolVarP` was to add the possibility to use the `--flag` even without a defined value. Otherwise the bool value needs to be specified. This is still needed when the flag is provided via the environment var, so we still need the `DEBUG=true`.