### PR TITLE
Added `trivy` vulns check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,21 @@ jobs:
         REPO: ${{ github.repository }}
         REGISTRY: ""
 
-    - name: Run Trivy vulnerability scanner (k3k)
+    - name: Run Trivy vulnerability scanner (k3kcli)
       uses: aquasecurity/trivy-action@0.28.0
       with:
         ignore-unfixed: true
         severity: 'MEDIUM,HIGH,CRITICAL'
-        scan-type: 'image'
-        scan-ref: '${{ github.repository }}:v0.0.0-amd64'
+        scan-type: 'fs'
+        scan-ref: 'dist/k3kcli_linux_amd64_v1/k3kcli'
+        format: 'sarif'
+        output: 'trivy-results-k3kcli.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab (k3kcli)
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: trivy-results-k3kcli.sarif
+        category: k3kcli
 
     - name: Run Trivy vulnerability scanner (k3k)
       uses: aquasecurity/trivy-action@0.28.0


### PR DESCRIPTION
This PR adds the `trivy` actio nto check for vulnerabilities in the `k3kcli`, and `k3k`/`k3k-kubelet` images.

The reports will be uploaded to the Github Security tab.