### PR TITLE
Add `security-events` permission to upload SARIF results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
It looks like to upload the reports we need to add the `security-events` permission to the workflow:
- https://github.com/rancher/k3k/actions/runs/19134598870/job/54683395103

Checking the integration we need to add `security-events: write` to upload SARIF results.