### PR TITLE
Fixed panic during kubeconfig generate

### DIFF
--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -108,25 +108,25 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1bet
 	ip := k3kService.Spec.ClusterIP
 	port := int32(443)
 
+	if len(k3kService.Spec.Ports) == 0 {
+		logrus.Warn("No ports exposed by the cluster service.")
+	}
+
 	switch k3kService.Spec.Type {
 	case v1.ServiceTypeNodePort:
 		ip = hostServerIP
 
-		if len(k3kService.Spec.Ports) == 0 {
-			logrus.Warn("No exposed port in NodePort service.")
-		} else {
+		if len(k3kService.Spec.Ports) > 0 {
 			port = k3kService.Spec.Ports[0].NodePort
 		}
 	case v1.ServiceTypeLoadBalancer:
-		if len(k3kService.Status.LoadBalancer.Ingress) == 0 {
-			logrus.Warn("No ingress found in LoadBalancer service.")
-		} else {
+		if len(k3kService.Status.LoadBalancer.Ingress) > 0 {
 			ip = k3kService.Status.LoadBalancer.Ingress[0].IP
+		} else {
+			logrus.Warn("No ingress found in LoadBalancer service.")
 		}
 
-		if len(k3kService.Spec.Ports) == 0 {
-			logrus.Warn("No exposed port in LoadBalancer service.")
-		} else {
+		if len(k3kService.Spec.Ports) > 0 {
 			port = k3kService.Spec.Ports[0].Port
 		}
 	}


### PR DESCRIPTION
Fix #432 

When a Cluster is exposed with a LoadBalancer but the IP is not yet issued the Status of the Service is empty, because the ExternalIP is still in a `<pending>` state.

This PR adds a check, and logs a warning.

<img width="965" height="228" alt="image" src="https://github.com/user-attachments/assets/276a5269-a6eb-450f-a53b-2e8ab19cb184" />
