### PR TITLE
Added check for failing tests

### DIFF
--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -148,8 +148,11 @@ jobs:
         RESULTS=$(echo $RESULTS | grep -oE '[0-9]+' | xargs | sed 's/ / | /g')
         echo "| $RESULTS |" >> $GITHUB_STEP_SUMMARY
 
-        echo ''                       >> $GITHUB_STEP_SUMMARY
-        echo '### Failed Tests'       >> $GITHUB_STEP_SUMMARY
-        echo '```'                    >> $GITHUB_STEP_SUMMARY
-        grep '\[FAIL\]' /tmp/e2e.log  >> $GITHUB_STEP_SUMMARY
-        echo '```'                    >> $GITHUB_STEP_SUMMARY
+        # only include failed tests section if there are any
+        if grep -q '\[FAIL\]' /tmp/e2e.log; then
+          echo ''                       >> $GITHUB_STEP_SUMMARY
+          echo '### Failed Tests'       >> $GITHUB_STEP_SUMMARY
+          echo '```'                    >> $GITHUB_STEP_SUMMARY
+          grep '\[FAIL\]' /tmp/e2e.log  >> $GITHUB_STEP_SUMMARY
+          echo '```'                    >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -135,8 +135,11 @@ jobs:
         RESULTS=$(echo $RESULTS | grep -oE '[0-9]+' | xargs | sed 's/ / | /g')
         echo "| $RESULTS |" >> $GITHUB_STEP_SUMMARY
 
-        echo ''                       >> $GITHUB_STEP_SUMMARY
-        echo '### Failed Tests'       >> $GITHUB_STEP_SUMMARY
-        echo '```'                    >> $GITHUB_STEP_SUMMARY
-        grep '\[FAIL\]' /tmp/e2e.log  >> $GITHUB_STEP_SUMMARY
-        echo '```'                    >> $GITHUB_STEP_SUMMARY
+        # only include failed tests section if there are any
+        if grep -q '\[FAIL\]' /tmp/e2e.log; then
+          echo ''                       >> $GITHUB_STEP_SUMMARY
+          echo '### Failed Tests'       >> $GITHUB_STEP_SUMMARY
+          echo '```'                    >> $GITHUB_STEP_SUMMARY
+          grep '\[FAIL\]' /tmp/e2e.log  >> $GITHUB_STEP_SUMMARY
+          echo '```'                    >> $GITHUB_STEP_SUMMARY
+        fi


### PR DESCRIPTION
<img width="501" height="137" alt="image" src="https://github.com/user-attachments/assets/d1ac7054-31d5-4e47-a42a-80e6099fa90c" />

https://github.com/rancher/k3k/actions/runs/19283531464

The conformance test action is failing even though all tests are passing.
The failure is due to a failing grep of the Job Summary, not finding any `[FAIL]` line in the test report.
This PR fix this adding a check.

Validation: https://github.com/enrichman/k3k/actions/runs/19427330445