### PR TITLE
Added test for SubPathExpr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CRD_REF_DOCS := go run github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VER)
 ENVTEST ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 ENVTEST_DIR ?= $(shell pwd)/.envtest
 
-E2E_LABEL_FILTER ?= "e2e"
+E2E_LABEL_FILTER ?= e2e
 
 export KUBEBUILDER_ASSETS ?= $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR) -p path)
 

--- a/tests/cluster_certs_test.go
+++ b/tests/cluster_certs_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = When("a cluster with custom certificates is installed with individual cert secrets", Label("e2e"), Label(certificatesTestsLabel), func() {
+var _ = When("a cluster with custom certificates is installed with individual cert secrets", Label(e2eTestLabel), Label(certificatesTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 
 	BeforeEach(func() {

--- a/tests/cluster_network_test.go
+++ b/tests/cluster_network_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = When("two virtual clusters are installed", Label("e2e"), Label(networkingTestsLabel), func() {
+var _ = When("two virtual clusters are installed", Label(e2eTestLabel), Label(networkingTestsLabel), func() {
 	var (
 		cluster1 *VirtualCluster
 		cluster2 *VirtualCluster

--- a/tests/cluster_persistence_test.go
+++ b/tests/cluster_persistence_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = When("an ephemeral cluster is installed", Label("e2e"), Label(persistenceTestsLabel), func() {
+var _ = When("an ephemeral cluster is installed", Label(e2eTestLabel), Label(persistenceTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 
 	BeforeEach(func() {
@@ -110,7 +110,7 @@ var _ = When("an ephemeral cluster is installed", Label("e2e"), Label(persistenc
 	})
 })
 
-var _ = When("a dynamic cluster is installed", Label("e2e"), Label(persistenceTestsLabel), func() {
+var _ = When("a dynamic cluster is installed", Label(e2eTestLabel), Label(persistenceTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 
 	BeforeEach(func() {

--- a/tests/cluster_pod_test.go
+++ b/tests/cluster_pod_test.go
@@ -21,7 +21,6 @@ var _ = When("a cluster creates a pod with an invalid configuration", Label(e2eT
 		virtualPod     *v1.Pod
 	)
 
-	// This BeforeEach/AfterEach will create a new namespace and a default policy for each test.
 	BeforeEach(func() {
 		virtualCluster = NewVirtualCluster()
 

--- a/tests/cluster_pod_test.go
+++ b/tests/cluster_pod_test.go
@@ -1,0 +1,177 @@
+package k3k_test
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api/v1/pod"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = When("a cluster creates a pod with an invalid configuration", Label(e2eTestLabel), func() {
+	var (
+		virtualCluster *VirtualCluster
+		virtualPod     *v1.Pod
+	)
+
+	// This BeforeEach/AfterEach will create a new namespace and a default policy for each test.
+	BeforeEach(func() {
+		virtualCluster = NewVirtualCluster()
+
+		DeferCleanup(func() {
+			DeleteNamespaces(virtualCluster.Cluster.Namespace)
+		})
+
+		p := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "nginx-",
+				Namespace:    "default",
+				Labels: map[string]string{
+					"name": "var-expansion-test",
+				},
+				Annotations: map[string]string{
+					"notmysubpath": "mypath",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx",
+						Env: []v1.EnvVar{
+							{
+								Name:  "POD_NAME",
+								Value: "nginx",
+							},
+							{
+								Name: "ANNOTATION",
+								ValueFrom: &v1.EnvVarSource{
+									FieldRef: &v1.ObjectFieldSelector{
+										FieldPath: "metadata.annotations['mysubpath']",
+									},
+								},
+							},
+						},
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "workdir",
+								MountPath: "/volume_mount",
+							},
+							{
+								Name:        "workdir",
+								MountPath:   "/subpath_mount",
+								SubPathExpr: "$(ANNOTATION)/$(POD_NAME)",
+							},
+						},
+					},
+				},
+				Volumes: []v1.Volume{{
+					Name:         "workdir",
+					VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+				}},
+			},
+		}
+
+		ctx := context.Background()
+		var err error
+
+		virtualPod, err = virtualCluster.Client.CoreV1().Pods(p.Namespace).Create(ctx, p, metav1.CreateOptions{})
+		Expect(err).To(Not(HaveOccurred()))
+	})
+
+	It("should be in Pending status with the CreateContainerConfigError until we fix the annotation", func() {
+		ctx := context.Background()
+
+		By("Checking the container status of the Pod in the Virtual Cluster")
+
+		Eventually(func(g Gomega) {
+			pod, err := virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Get(ctx, virtualPod.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(pod.Status.Phase).To(Equal(v1.PodPending))
+
+			containerStatuses := pod.Status.ContainerStatuses
+			g.Expect(containerStatuses).To(HaveLen(1))
+
+			waitingState := containerStatuses[0].State.Waiting
+			g.Expect(waitingState).NotTo(BeNil())
+			g.Expect(waitingState.Reason).To(Equal("CreateContainerConfigError"))
+		}).
+			WithPolling(time.Second).
+			WithTimeout(time.Minute).
+			Should(Succeed())
+
+		By("Checking the container status of the Pod in the Host Cluster")
+
+		Eventually(func(g Gomega) {
+			translator := translate.NewHostTranslator(virtualCluster.Cluster)
+			hostPodName := translator.NamespacedName(virtualPod)
+
+			pod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(pod.Status.Phase).To(Equal(v1.PodPending))
+
+			containerStatuses := pod.Status.ContainerStatuses
+			g.Expect(containerStatuses).To(HaveLen(1))
+
+			waitingState := containerStatuses[0].State.Waiting
+			g.Expect(waitingState).NotTo(BeNil())
+			g.Expect(waitingState.Reason).To(Equal("CreateContainerConfigError"))
+		}).
+			WithPolling(time.Second).
+			WithTimeout(time.Minute).
+			Should(Succeed())
+
+		By("Fixing the annotation")
+
+		var err error
+
+		virtualPod, err = virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Get(ctx, virtualPod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		virtualPod.Annotations["mysubpath"] = virtualPod.Annotations["notmysubpath"]
+		delete(virtualPod.Annotations, "notmysubpath")
+
+		virtualPod, err = virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Update(ctx, virtualPod, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking the status of the Pod in the Virtual Cluster")
+
+		Eventually(func(g Gomega) {
+			vPod, err := virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Get(ctx, virtualPod.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			_, cond := pod.GetPodCondition(&vPod.Status, v1.PodReady)
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+		}).
+			WithPolling(time.Second).
+			WithTimeout(time.Minute).
+			Should(Succeed())
+
+		By("Checking the status of the Pod in the Host Cluster")
+
+		Eventually(func(g Gomega) {
+			translator := translate.NewHostTranslator(virtualCluster.Cluster)
+			hostPodName := translator.NamespacedName(virtualPod)
+
+			hPod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			_, cond := pod.GetPodCondition(&hPod.Status, v1.PodReady)
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+		}).
+			WithPolling(time.Second).
+			WithTimeout(time.Minute).
+			Should(Succeed())
+	})
+})

--- a/tests/cluster_status_test.go
+++ b/tests/cluster_status_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = When("a cluster's status is tracked", Label("e2e"), Label(statusTestsLabel), func() {
+var _ = When("a cluster's status is tracked", Label(e2eTestLabel), Label(statusTestsLabel), func() {
 	var (
 		namespace *corev1.Namespace
 		vcp       *v1beta1.VirtualClusterPolicy

--- a/tests/cluster_sync_test.go
+++ b/tests/cluster_sync_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = When("a shared mode cluster is created", Ordered, Label("e2e"), func() {
+var _ = When("a shared mode cluster is created", Ordered, Label(e2eTestLabel), func() {
 	var (
 		virtualCluster   *VirtualCluster
 		virtualConfigMap *corev1.ConfigMap

--- a/tests/cluster_update_test.go
+++ b/tests/cluster_update_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = When("a shared mode cluster update its envs", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 	ctx := context.Background()
 	BeforeEach(func() {
@@ -162,7 +162,7 @@ var _ = When("a shared mode cluster update its envs", Label("e2e"), Label(update
 	})
 })
 
-var _ = When("a shared mode cluster update its server args", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a shared mode cluster update its server args", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 	ctx := context.Background()
 	BeforeEach(func() {
@@ -221,7 +221,7 @@ var _ = When("a shared mode cluster update its server args", Label("e2e"), Label
 	})
 })
 
-var _ = When("a virtual mode cluster update its envs", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 	ctx := context.Background()
 	BeforeEach(func() {
@@ -362,7 +362,7 @@ var _ = When("a virtual mode cluster update its envs", Label("e2e"), Label(updat
 	})
 })
 
-var _ = When("a virtual mode cluster update its server args", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a virtual mode cluster update its server args", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var virtualCluster *VirtualCluster
 	ctx := context.Background()
 	BeforeEach(func() {
@@ -424,7 +424,7 @@ var _ = When("a virtual mode cluster update its server args", Label("e2e"), Labe
 	})
 })
 
-var _ = When("a shared mode cluster update its version", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a shared mode cluster update its version", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
 		nginxPod       *v1.Pod
@@ -510,7 +510,7 @@ var _ = When("a shared mode cluster update its version", Label("e2e"), Label(upd
 	})
 })
 
-var _ = When("a virtual mode cluster update its version", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a virtual mode cluster update its version", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
 		nginxPod       *v1.Pod
@@ -611,7 +611,7 @@ var _ = When("a virtual mode cluster update its version", Label("e2e"), Label(up
 	})
 })
 
-var _ = When("a shared mode cluster scales up servers", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a shared mode cluster scales up servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
 		nginxPod       *v1.Pod
@@ -696,7 +696,7 @@ var _ = When("a shared mode cluster scales up servers", Label("e2e"), Label(upda
 	})
 })
 
-var _ = When("a shared mode cluster scales down servers", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a shared mode cluster scales down servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
 		nginxPod       *v1.Pod
@@ -783,7 +783,7 @@ var _ = When("a shared mode cluster scales down servers", Label("e2e"), Label(up
 	})
 })
 
-var _ = When("a virtual mode cluster scales up servers", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a virtual mode cluster scales up servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
 		nginxPod       *v1.Pod
@@ -868,7 +868,7 @@ var _ = When("a virtual mode cluster scales up servers", Label("e2e"), Label(upd
 	})
 })
 
-var _ = When("a virtual mode cluster scales down servers", Label("e2e"), Label(updateTestsLabel), Label(slowTestsLabel), func() {
+var _ = When("a virtual mode cluster scales down servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
 		nginxPod       *v1.Pod

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -113,22 +113,16 @@ func DeleteNamespaces(names ...string) {
 			defer wg.Done()
 			defer GinkgoRecover()
 
-			deleteNamespace(name)
+			By(fmt.Sprintf("Deleting namespace %s", name))
+
+			err := k8s.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{
+				GracePeriodSeconds: ptr.To[int64](0),
+			})
+			Expect(err).To(Not(HaveOccurred()))
 		}()
 	}
 
 	wg.Wait()
-}
-
-func deleteNamespace(name string) {
-	GinkgoHelper()
-
-	By(fmt.Sprintf("Deleting namespace %s", name))
-
-	err := k8s.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{
-		GracePeriodSeconds: ptr.To[int64](0),
-	})
-	Expect(err).To(Not(HaveOccurred()))
 }
 
 func NewCluster(namespace string) *v1beta1.Cluster {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -42,6 +42,7 @@ import (
 const (
 	k3kNamespace = "k3k-system"
 
+	e2eTestLabel           = "e2e"
 	slowTestsLabel         = "slow"
 	updateTestsLabel       = "update"
 	persistenceTestsLabel  = "persistence"


### PR DESCRIPTION
#441 fixed an issue about a `CreateContainerConfigError` coming from an invalid VolumeMount.
Creating a Pod that is erroring and then trying to fix it updating the annotation was not working.

This PR just adds a test to avoid regressions, while trying to fix #495.