### PR TITLE
Fix for missing label update with `--namespace` flag in `k3kcli policy create` command

### DIFF
--- a/cli/cmds/policy_create.go
+++ b/cli/cmds/policy_create.go
@@ -150,6 +150,8 @@ func bindPolicyToNamespaces(ctx context.Context, client client.Client, config *V
 
 		// no old policy, safe to update
 		if oldPolicy == "" {
+			ns.Labels[policy.PolicyNameLabelKey] = policyName
+
 			if err := client.Update(ctx, &ns); err != nil {
 				errs = append(errs, err)
 			} else {


### PR DESCRIPTION
#379 was not completely implemented.

This PR fixes the binding for unbound namespaces, and added some tests around the feature.