### PR TITLE
Fix allocatable resources in shared mode and Pod scheduling

### DIFF
--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -265,7 +265,7 @@ func (k *kubelet) start(ctx context.Context) {
 
 func (k *kubelet) newProviderFunc(cfg config) nodeutil.NewProviderFunc {
 	return func(pc nodeutil.ProviderConfig) (nodeutil.Provider, node.NodeProvider, error) {
-		utilProvider, err := provider.New(*k.hostConfig, k.hostMgr, k.virtualMgr, k.logger, cfg.ClusterNamespace, cfg.ClusterName, cfg.ServerIP, k.dnsIP)
+		utilProvider, err := provider.New(*k.hostConfig, k.hostMgr, k.virtualMgr, k.logger, cfg.ClusterNamespace, cfg.ClusterName, cfg.ServerIP, k.dnsIP, cfg.AgentHostname)
 		if err != nil {
 			return nil, nil, errors.New("unable to make nodeutil provider: " + err.Error())
 		}


### PR DESCRIPTION
The Virtual Kubelet component is deployed as a DaemonSet. This means there will be one pod per node.

Each Virtual Kubelet was reporting as allocatable resources the **sum** of all the nodes. This means that in a 3 nodes cluster the result will be multipled by 3. See:

<img width="1252" height="346" alt="Image" src="https://github.com/user-attachments/assets/dcaa1b41-d766-4467-8311-33d7c2dc072f" />

To fix this now we are getting the resources only from the node where the kubelet is running on, identified by the `AGENT_HOSTNAME` var.

**Important:** this PR also will schedule the pods on the same node where the virtual cluster scheduler opted for. This now works because of the 1-1 relationship with the host nodes.

```go
// Schedule the host pod in the same host node of the virtual kubelet
hostPod.Spec.NodeName = p.agentHostname
```