### PR TITLE
fix virtual pod NodeSelector #572

### DIFF
--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -130,6 +130,7 @@ func (v *VirtualAgent) podSpec(image, name string, args []string, affinitySelect
 	args = append([]string{"agent", "--config", "/opt/rancher/k3s/config.yaml"}, args...)
 
 	podSpec := v1.PodSpec{
+		NodeSelector: v.cluster.Spec.NodeSelector,
 		Volumes: []v1.Volume{
 			{
 				Name: "config",


### PR DESCRIPTION
Quick fix for #572 

## How to validate
1. Create the following `cluster` resource
```
apiVersion: k3k.io/v1beta1
kind: Cluster
metadata:
  name: k3kcluster-virtual
spec:
  mode: virtual
  servers: 1
  agents: 1
  nodeSelector: 
    disktype: ssd
```
2. Verify the agent pod
Run `kubectl describe po k3k-k3kcluster-virtual-agent-`
Verify the `Node-Selectors` value
```
...
Node-Selectors:              disktype=ssd
...
```

