### PR TITLE
Only reconcile the server resource on the StatefullSet Controller

### DIFF
--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -54,6 +54,7 @@ func AddStatefulSetController(ctx context.Context, mgr manager.Manager, maxConcu
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apps.StatefulSet{}).
+		WithEventFilter(newClusterPredicate()).
 		Owns(&v1.Pod{}).
 		Named(statefulsetController).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).


### PR DESCRIPTION
Fix issue #591 

@galal-hussein do you think we should also filter by label `role: server` ? 
The current filter only respond to statefulset that are owned by a cluster kind and match the cluster name. Which is always the server. 
And it leaves out any other statefullset. 