### PR TITLE
change ControllerReferences over to OwnerReferences

### DIFF
--- a/k3k-kubelet/controller/syncer/configmap.go
+++ b/k3k-kubelet/controller/syncer/configmap.go
@@ -100,7 +100,7 @@ func (c *ConfigMapSyncer) Reconcile(ctx context.Context, req reconcile.Request) 
 
 	syncedConfigMap := c.translateConfigMap(&virtualConfigMap)
 
-	if err := controllerutil.SetControllerReference(&cluster, syncedConfigMap, c.HostClient.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(&cluster, syncedConfigMap, c.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/k3k-kubelet/controller/syncer/ingress.go
+++ b/k3k-kubelet/controller/syncer/ingress.go
@@ -98,7 +98,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	syncedIngress := r.ingress(&virtIngress)
 
-	if err := controllerutil.SetControllerReference(&cluster, syncedIngress, r.HostClient.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(&cluster, syncedIngress, r.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/k3k-kubelet/controller/syncer/persistentvolumeclaims.go
+++ b/k3k-kubelet/controller/syncer/persistentvolumeclaims.go
@@ -98,7 +98,7 @@ func (r *PVCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 
 	syncedPVC := r.pvc(&virtPVC)
-	if err := controllerutil.SetControllerReference(&cluster, syncedPVC, r.HostClient.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(&cluster, syncedPVC, r.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/k3k-kubelet/controller/syncer/priorityclass.go
+++ b/k3k-kubelet/controller/syncer/priorityclass.go
@@ -117,7 +117,7 @@ func (r *PriorityClassSyncer) Reconcile(ctx context.Context, req reconcile.Reque
 
 	hostPriorityClass := r.translatePriorityClass(priorityClass)
 
-	if err := controllerutil.SetControllerReference(&cluster, hostPriorityClass, r.HostClient.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(&cluster, hostPriorityClass, r.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/k3k-kubelet/controller/syncer/secret.go
+++ b/k3k-kubelet/controller/syncer/secret.go
@@ -100,7 +100,7 @@ func (s *SecretSyncer) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 	syncedSecret := s.translateSecret(&virtualSecret)
 
-	if err := controllerutil.SetControllerReference(&cluster, syncedSecret, s.HostClient.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(&cluster, syncedSecret, s.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/k3k-kubelet/controller/syncer/service.go
+++ b/k3k-kubelet/controller/syncer/service.go
@@ -76,7 +76,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	syncedService := r.service(&virtService)
 
-	if err := controllerutil.SetControllerReference(&cluster, syncedService, r.HostClient.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(&cluster, syncedService, r.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
Issue #541 

Changed all uses of `SetControllerReference` in the syncer over to `SetOwnerReference`.
