### PR TITLE
Pin QEMU and Docker Buildx versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,13 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      with:
+        image: tonistiigi/binfmt:qemu-v10.0.4-56
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.30.1
 
     - name: "Read secrets"
       uses: rancher-eio/read-vault-secrets@main


### PR DESCRIPTION
During the release of `1.0.2` we faced an issue related the usage of a too recent version of Docker Buildx plugin: https://github.com/rancher/k3k/actions/runs/22055395347/job/63723219990

The specific error was related to
```
docker manifests: failed to publish artifacts: failed to create rancher/k3k:v1.0.2: exit status 1: docker.io/rancher/k3k:v1.0.2-amd64@sha256:28b36d73138586fa63718cdc482bb2baf1da6533f2e9443f425f2da310c4aee7 is a manifest list
```

Checking the differences from the [last successfull release](https://github.com/rancher/k3k/actions/runs/21449017965/job/61772541170) we have seen the Buildx version being different:

### old

```
  Client: Docker Engine - Community
   Version:    28.0.4
   Context:    default
   Debug Mode: false
   Plugins:
    buildx: Docker Buildx (Docker Inc.)
      Version:  v0.30.1
      Path:     /usr/libexec/docker/cli-plugins/docker-buildx
    compose: Docker Compose (Docker Inc.)
      Version:  v2.38.2
      Path:     /usr/libexec/docker/cli-plugins/docker-compose
```

### new

```
  Client: Docker Engine - Community
   Version:    29.1.5
   Context:    default
   Debug Mode: false
   Plugins:
    buildx: Docker Buildx (Docker Inc.)
      Version:  v0.31.1
      Path:     /usr/libexec/docker/cli-plugins/docker-buildx
    compose: Docker Compose (Docker Inc.)
      Version:  v2.40.3
      Path:     /usr/libexec/docker/cli-plugins/docker-compose
```

Pinning the Docker Buildx version with the old `v0.30.1` fixed the issue ([release run](https://github.com/enrichman/k3k/actions/runs/22064118227/job/63751428879))

```
    - name: Set up Docker Buildx
      uses: docker/setup-buildx-action@v3
      with:
        version: v0.30.1
```

and to avoid other possible issues we have pinned also the image used by the QEMU action to the latest image `tonistiigi/binfmt:qemu-v10.0.4-56` ([Docker Hub](https://hub.docker.com/layers/tonistiigi/binfmt/qemu-v10.0.4-56)).