### PR TITLE
minor fix to translated ingress tls secrets in ingress object

### DIFF
--- a/charts/k3k/templates/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/templates/crds/k3k.io_clusters.yaml
@@ -2511,6 +2511,12 @@ spec:
                       enabled: false
                     description: Ingresses resources sync configuration.
                     properties:
+                      disableTLSSecretTranslation:
+                        default: false
+                        description: |-
+                          DisableTLSSecretTranslation is an on/off switch for translating TLS secrets
+                          from virtual cluster to host cluster
+                        type: boolean
                       enabled:
                         default: false
                         description: Enabled is an on/off switch for syncing resources.
@@ -2522,12 +2528,6 @@ spec:
                           Selector specifies set of labels of the resources that will be synced, if empty
                           then all resources of the given type will be synced.
                         type: object
-                      syncTLSSecrets:
-                        default: true
-                        description: |-
-                          Enabled is an on/off switch for translating TLS secret
-                          from virtual cluster to host cluster
-                        type: boolean
                     required:
                     - enabled
                     type: object
@@ -4536,6 +4536,12 @@ spec:
                           enabled: false
                         description: Ingresses resources sync configuration.
                         properties:
+                          disableTLSSecretTranslation:
+                            default: false
+                            description: |-
+                              DisableTLSSecretTranslation is an on/off switch for translating TLS secrets
+                              from virtual cluster to host cluster
+                            type: boolean
                           enabled:
                             default: false
                             description: Enabled is an on/off switch for syncing resources.

--- a/charts/k3k/templates/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/templates/crds/k3k.io_clusters.yaml
@@ -2522,6 +2522,12 @@ spec:
                           Selector specifies set of labels of the resources that will be synced, if empty
                           then all resources of the given type will be synced.
                         type: object
+                      syncTLSSecrets:
+                        default: true
+                        description: |-
+                          Enabled is an on/off switch for translating TLS secret
+                          from virtual cluster to host cluster
+                        type: boolean
                     required:
                     - enabled
                     type: object

--- a/charts/k3k/templates/crds/k3k.io_virtualclusterpolicies.yaml
+++ b/charts/k3k/templates/crds/k3k.io_virtualclusterpolicies.yaml
@@ -1984,6 +1984,12 @@ spec:
                       enabled: false
                     description: Ingresses resources sync configuration.
                     properties:
+                      disableTLSSecretTranslation:
+                        default: false
+                        description: |-
+                          DisableTLSSecretTranslation is an on/off switch for translating TLS secrets
+                          from virtual cluster to host cluster
+                        type: boolean
                       enabled:
                         default: false
                         description: Enabled is an on/off switch for syncing resources.
@@ -1995,12 +2001,6 @@ spec:
                           Selector specifies set of labels of the resources that will be synced, if empty
                           then all resources of the given type will be synced.
                         type: object
-                      syncTLSSecrets:
-                        default: true
-                        description: |-
-                          Enabled is an on/off switch for translating TLS secret
-                          from virtual cluster to host cluster
-                        type: boolean
                     required:
                     - enabled
                     type: object

--- a/charts/k3k/templates/crds/k3k.io_virtualclusterpolicies.yaml
+++ b/charts/k3k/templates/crds/k3k.io_virtualclusterpolicies.yaml
@@ -1995,6 +1995,12 @@ spec:
                           Selector specifies set of labels of the resources that will be synced, if empty
                           then all resources of the given type will be synced.
                         type: object
+                      syncTLSSecrets:
+                        default: true
+                        description: |-
+                          Enabled is an on/off switch for translating TLS secret
+                          from virtual cluster to host cluster
+                        type: boolean
                     required:
                     - enabled
                     type: object

--- a/docs/crds/crds.adoc
+++ b/docs/crds/crds.adoc
@@ -405,8 +405,8 @@ _Appears In:_
 | *`enabled`* __boolean__ | Enabled is an on/off switch for syncing resources. + | false | 
 | *`selector`* __object (keys:string, values:string)__ | Selector specifies set of labels of the resources that will be synced, if empty +
 then all resources of the given type will be synced. + |  | 
-| *`syncTLSSecrets`* __boolean__ | Enabled is an on/off switch for translating TLS secret +
-from virtual cluster to host cluster + | true | 
+| *`disableTLSSecretTranslation`* __boolean__ | DisableTLSSecretTranslation is an on/off switch for translating TLS secrets +
+from virtual cluster to host cluster + | false | 
 |===
 
 

--- a/docs/crds/crds.adoc
+++ b/docs/crds/crds.adoc
@@ -405,6 +405,8 @@ _Appears In:_
 | *`enabled`* __boolean__ | Enabled is an on/off switch for syncing resources. + | false | 
 | *`selector`* __object (keys:string, values:string)__ | Selector specifies set of labels of the resources that will be synced, if empty +
 then all resources of the given type will be synced. + |  | 
+| *`syncTLSSecrets`* __boolean__ | Enabled is an on/off switch for translating TLS secret +
+from virtual cluster to host cluster + | true | 
 |===
 
 

--- a/docs/crds/crds.md
+++ b/docs/crds/crds.md
@@ -310,6 +310,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled is an on/off switch for syncing resources. | false |  |
 | `selector` _object (keys:string, values:string)_ | Selector specifies set of labels of the resources that will be synced, if empty<br />then all resources of the given type will be synced. |  |  |
+| `syncTLSSecrets` _boolean_ | Enabled is an on/off switch for translating TLS secret<br />from virtual cluster to host cluster | true |  |
 
 
 #### LoadBalancerConfig

--- a/docs/crds/crds.md
+++ b/docs/crds/crds.md
@@ -310,7 +310,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled is an on/off switch for syncing resources. | false |  |
 | `selector` _object (keys:string, values:string)_ | Selector specifies set of labels of the resources that will be synced, if empty<br />then all resources of the given type will be synced. |  |  |
-| `syncTLSSecrets` _boolean_ | Enabled is an on/off switch for translating TLS secret<br />from virtual cluster to host cluster | true |  |
+| `disableTLSSecretTranslation` _boolean_ | DisableTLSSecretTranslation is an on/off switch for translating TLS secrets<br />from virtual cluster to host cluster | false |  |
 
 
 #### LoadBalancerConfig

--- a/k3k-kubelet/controller/syncer/ingress.go
+++ b/k3k-kubelet/controller/syncer/ingress.go
@@ -92,12 +92,20 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, err
 	}
 
-	syncConfig := cluster.Spec.Sync.Ingresses
+	appliedSync := cluster.Spec.Sync.DeepCopy()
+
+	// If a policy is applied to the virtual cluster we need to use its SyncConfig, if available
+	if cluster.Status.Policy != nil && cluster.Status.Policy.Sync != nil {
+		appliedSync = cluster.Status.Policy.Sync
+	}
+
+	syncConfig := appliedSync.Ingresses
+
 	if err := r.VirtualClient.Get(ctx, req.NamespacedName, &virtIngress); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
-	syncedIngress := r.ingress(&virtIngress, syncConfig.SyncTLSSecrets)
+	syncedIngress := r.ingress(&virtIngress, syncConfig.DisableTLSSecretTranslation)
 
 	if err := controllerutil.SetOwnerReference(&cluster, syncedIngress, r.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
@@ -144,7 +152,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	return reconcile.Result{}, r.HostClient.Update(ctx, syncedIngress)
 }
 
-func (s *IngressReconciler) ingress(obj *networkingv1.Ingress, syncTLSSecrets bool) *networkingv1.Ingress {
+func (s *IngressReconciler) ingress(obj *networkingv1.Ingress, disableTLSSecretTranslation bool) *networkingv1.Ingress {
 	hostIngress := obj.DeepCopy()
 	s.Translator.TranslateTo(hostIngress)
 
@@ -159,15 +167,16 @@ func (s *IngressReconciler) ingress(obj *networkingv1.Ingress, syncTLSSecrets bo
 		}
 	}
 
+	// TLS Secret translation disable, return early without translating TLS secrets in the ingress spec
+	if disableTLSSecretTranslation {
+		return hostIngress
+	}
 	// ensure tls secrets are also translated
-	if syncTLSSecrets {
-		for i := range hostIngress.Spec.TLS {
-			if hostIngress.Spec.TLS[i].SecretName != "" {
-				hostIngress.Spec.TLS[i].SecretName = s.Translator.TranslateName(obj.GetNamespace(), hostIngress.Spec.TLS[i].SecretName)
-			}
+	for i := range hostIngress.Spec.TLS {
+		if hostIngress.Spec.TLS[i].SecretName != "" {
+			hostIngress.Spec.TLS[i].SecretName = s.Translator.TranslateName(obj.GetNamespace(), hostIngress.Spec.TLS[i].SecretName)
 		}
 	}
 
-	// don't sync finalizers to the host
 	return hostIngress
 }

--- a/k3k-kubelet/controller/syncer/ingress.go
+++ b/k3k-kubelet/controller/syncer/ingress.go
@@ -92,11 +92,12 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, err
 	}
 
+	syncConfig := cluster.Spec.Sync.Ingresses
 	if err := r.VirtualClient.Get(ctx, req.NamespacedName, &virtIngress); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 
-	syncedIngress := r.ingress(&virtIngress)
+	syncedIngress := r.ingress(&virtIngress, syncConfig.SyncTLSSecrets)
 
 	if err := controllerutil.SetOwnerReference(&cluster, syncedIngress, r.HostClient.Scheme()); err != nil {
 		return reconcile.Result{}, err
@@ -143,7 +144,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	return reconcile.Result{}, r.HostClient.Update(ctx, syncedIngress)
 }
 
-func (s *IngressReconciler) ingress(obj *networkingv1.Ingress) *networkingv1.Ingress {
+func (s *IngressReconciler) ingress(obj *networkingv1.Ingress, syncTLSSecrets bool) *networkingv1.Ingress {
 	hostIngress := obj.DeepCopy()
 	s.Translator.TranslateTo(hostIngress)
 
@@ -157,6 +158,16 @@ func (s *IngressReconciler) ingress(obj *networkingv1.Ingress) *networkingv1.Ing
 			}
 		}
 	}
+
+	// ensure tls secrets are also translated
+	if syncTLSSecrets {
+		for i := range hostIngress.Spec.TLS {
+			if hostIngress.Spec.TLS[i].SecretName != "" {
+				hostIngress.Spec.TLS[i].SecretName = s.Translator.TranslateName(obj.GetNamespace(), hostIngress.Spec.TLS[i].SecretName)
+			}
+		}
+	}
+
 	// don't sync finalizers to the host
 	return hostIngress
 }

--- a/pkg/apis/k3k.io/v1beta1/types.go
+++ b/pkg/apis/k3k.io/v1beta1/types.go
@@ -326,6 +326,13 @@ type IngressSyncConfig struct {
 	//
 	// +optional
 	Selector map[string]string `json:"selector,omitempty"`
+
+	// Enabled is an on/off switch for translating TLS secret
+	// from virtual cluster to host cluster
+	//
+	// +kubebuilder:default=true
+	// +optional
+	SyncTLSSecrets bool `json:"syncTLSSecrets,omitempty"`
 }
 
 // PersistentVolumeClaimSyncConfig specifies the sync options for PersistentVolumeClaims.

--- a/pkg/apis/k3k.io/v1beta1/types.go
+++ b/pkg/apis/k3k.io/v1beta1/types.go
@@ -327,12 +327,12 @@ type IngressSyncConfig struct {
 	// +optional
 	Selector map[string]string `json:"selector,omitempty"`
 
-	// Enabled is an on/off switch for translating TLS secret
+	// DisableTLSSecretTranslation is an on/off switch for translating TLS secrets
 	// from virtual cluster to host cluster
 	//
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	// +optional
-	SyncTLSSecrets bool `json:"syncTLSSecrets,omitempty"`
+	DisableTLSSecretTranslation bool `json:"disableTLSSecretTranslation,omitempty"`
 }
 
 // PersistentVolumeClaimSyncConfig specifies the sync options for PersistentVolumeClaims.

--- a/tests/integration/k3k-kubelet/ingress_test.go
+++ b/tests/integration/k3k-kubelet/ingress_test.go
@@ -47,6 +47,9 @@ var IngressTests = func() {
 					Ingresses: v1beta1.IngressSyncConfig{
 						Enabled: true,
 					},
+					Secrets: v1beta1.SecretSyncConfig{
+						Enabled: true,
+					},
 				},
 			},
 		}
@@ -54,6 +57,8 @@ var IngressTests = func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		err = syncer.AddIngressSyncer(ctx, virtManager, hostManager, cluster.Name, cluster.Namespace)
+		Expect(err).NotTo(HaveOccurred())
+		err = syncer.AddSecretSyncer(ctx, virtManager, hostManager, cluster.Name, cluster.Namespace)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -290,6 +295,194 @@ var IngressTests = func() {
 			WithPolling(time.Millisecond * 300).
 			WithTimeout(time.Second * 10).
 			Should(BeTrue())
+	})
+
+	It("will sync an Ingress with a TLS secret", func() {
+		ctx := context.Background()
+		ingressSecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ingress-secret-",
+				Namespace:    "default",
+			},
+			Data: map[string][]byte{
+				"ca.crt":  []byte("value"),
+				"tls.crt": []byte("value"),
+				"tls.key": []byte("value"),
+			},
+		}
+
+		err := virtTestEnv.k8sClient.Create(ctx, ingressSecret)
+		Expect(err).NotTo(HaveOccurred())
+
+		ingress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ingress-",
+				Namespace:    "default",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "test.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: ptr.To(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name: "test-port",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: []networkingv1.IngressTLS{
+					{
+						Hosts:      []string{"test.com"},
+						SecretName: ingressSecret.Name,
+					},
+				},
+			},
+		}
+
+		err = virtTestEnv.k8sClient.Create(ctx, ingress)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Created Ingress %s in virtual cluster", ingress.Name))
+
+		var hostIngress networkingv1.Ingress
+
+		var hostSecret v1.Secret
+
+		hostIngressName := translateName(cluster, ingress.Namespace, ingress.Name)
+
+		hostSecretName := translateName(cluster, ingress.Namespace, ingressSecret.Name)
+
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostIngressName, Namespace: namespace}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostIngress)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostSecretName, Namespace: namespace}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostSecret)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		// Verify Ingress in host cluster does reference the translated secret since TLS secret translation is enabled
+		Expect(hostIngress.Spec.TLS[0].SecretName).To(Equal(hostSecretName))
+	})
+
+	It("will not sync an Ingress with a TLS secret", func() {
+		ctx := context.Background()
+
+		cluster.Spec.Sync.Ingresses.DisableTLSSecretTranslation = true
+		err := hostTestEnv.k8sClient.Update(ctx, &cluster)
+		Expect(err).NotTo(HaveOccurred())
+
+		ingressSecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ingress-secret-",
+				Namespace:    "default",
+			},
+			Data: map[string][]byte{
+				"ca.crt":  []byte("value"),
+				"tls.crt": []byte("value"),
+				"tls.key": []byte("value"),
+			},
+		}
+
+		err = virtTestEnv.k8sClient.Create(ctx, ingressSecret)
+		Expect(err).NotTo(HaveOccurred())
+
+		ingress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ingress-",
+				Namespace:    "default",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "test.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: ptr.To(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test-service",
+												Port: networkingv1.ServiceBackendPort{
+													Name: "test-port",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: []networkingv1.IngressTLS{
+					{
+						Hosts:      []string{"test.com"},
+						SecretName: ingressSecret.Name,
+					},
+				},
+			},
+		}
+
+		err = virtTestEnv.k8sClient.Create(ctx, ingress)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Created Ingress %s in virtual cluster", ingress.Name))
+
+		var hostIngress networkingv1.Ingress
+
+		var hostSecret v1.Secret
+
+		hostIngressName := translateName(cluster, ingress.Namespace, ingress.Name)
+
+		hostSecretName := translateName(cluster, ingress.Namespace, ingressSecret.Name)
+
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostIngressName, Namespace: namespace}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostIngress)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		// Secret will be translated to host cluster but the Ingress will not reference it since TLS secret translation is disabled
+		Eventually(func() error {
+			key := client.ObjectKey{Name: hostSecretName, Namespace: namespace}
+			return hostTestEnv.k8sClient.Get(ctx, key, &hostSecret)
+		}).
+			WithPolling(time.Millisecond * 300).
+			WithTimeout(time.Second * 10).
+			Should(BeNil())
+
+		// Verify Ingress in host cluster has guest cluster secret reference as translation has not been performed
+		Expect(hostIngress.Spec.TLS[0].SecretName).To(Equal(ingressSecret.Name))
 	})
 
 	It("will not sync an Ingress if disabled", func() {


### PR DESCRIPTION
PR ensures TLS secret's are translated to host ingress object.

Addresses: https://github.com/rancher/k3k/issues/671

To validate install rancher on a shared k3k cluster with ingress sync enabled.

Please refer to issue to find manifest used for deploying rancher on k3k.

Post this change the synced ingress on host cluster references the correct tls secret, and rancher ingress leverages the correct secret for.
