### PR TITLE
Fix tests `BeforeSuite` setup with `K3K_DOCKER_INSTALL` flag

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -78,7 +78,6 @@ var (
 	k8s              *kubernetes.Clientset
 	k8sClient        client.Client
 	kubeconfigPath   string
-	repo             string
 	helmActionConfig *action.Configuration
 )
 
@@ -87,17 +86,17 @@ var _ = BeforeSuite(func() {
 
 	GinkgoWriter.Println("GOCOVERDIR:", os.Getenv("GOCOVERDIR"))
 
-	repo = os.Getenv("REPO")
-	if repo == "" {
-		repo = "rancher"
-	}
-
 	_, dockerInstallEnabled := os.LookupEnv("K3K_DOCKER_INSTALL")
 
 	if dockerInstallEnabled {
-		installK3SDocker(ctx)
+		repo := os.Getenv("REPO")
+		if repo == "" {
+			repo = "rancher"
+		}
+
+		installK3SDocker(ctx, repo+"/k3k", repo+"/k3k-kubelet")
 		initKubernetesClient(ctx)
-		installK3kChart()
+		installK3kChart(repo+"/k3k", repo+"/k3k-kubelet")
 	} else {
 		initKubernetesClient(ctx)
 	}
@@ -110,6 +109,11 @@ func initKubernetesClient(ctx context.Context) {
 		err        error
 		kubeconfig []byte
 	)
+
+	logger, err := zap.NewDevelopment()
+	Expect(err).NotTo(HaveOccurred())
+
+	log.SetLogger(zapr.NewLogger(logger))
 
 	kubeconfigPath := os.Getenv("KUBECONFIG")
 	Expect(kubeconfigPath).To(Not(BeEmpty()))
@@ -129,11 +133,6 @@ func initKubernetesClient(ctx context.Context) {
 	scheme := buildScheme()
 	k8sClient, err = client.New(restcfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
-
-	logger, err := zap.NewDevelopment()
-	Expect(err).NotTo(HaveOccurred())
-
-	log.SetLogger(zapr.NewLogger(logger))
 }
 
 func buildScheme() *runtime.Scheme {
@@ -147,7 +146,7 @@ func buildScheme() *runtime.Scheme {
 	return scheme
 }
 
-func installK3SDocker(ctx context.Context) {
+func installK3SDocker(ctx context.Context, controllerImage, kubeletImage string) {
 	var (
 		err        error
 		kubeconfig []byte
@@ -179,16 +178,15 @@ func installK3SDocker(ctx context.Context) {
 	Expect(tmpFile.Close()).To(Succeed())
 	kubeconfigPath = tmpFile.Name()
 
-	err = k3sContainer.LoadImages(ctx, repo+"/k3k:dev", repo+"/k3k-kubelet:dev")
+	err = k3sContainer.LoadImages(ctx, controllerImage+":dev", kubeletImage+":dev")
 	Expect(err).To(Not(HaveOccurred()))
 	DeferCleanup(os.Remove, kubeconfigPath)
 
 	Expect(os.Setenv("KUBECONFIG", kubeconfigPath)).To(Succeed())
-	GinkgoWriter.Print(kubeconfigPath)
-	GinkgoWriter.Print(string(kubeconfig))
+	GinkgoWriter.Printf("KUBECONFIG set to: %s\n", kubeconfigPath)
 }
 
-func installK3kChart() {
+func installK3kChart(controllerImage, kubeletImage string) {
 	pwd, err := os.Getwd()
 	Expect(err).To(Not(HaveOccurred()))
 
@@ -204,7 +202,7 @@ func installK3kChart() {
 	Expect(err).To(Not(HaveOccurred()))
 
 	err = helmActionConfig.Init(restClientGetter, k3kNamespace, os.Getenv("HELM_DRIVER"), func(format string, v ...any) {
-		GinkgoWriter.Printf("helm debug: "+format+"\n", v...)
+		GinkgoWriter.Printf("[Helm] "+format+"\n", v...)
 	})
 	Expect(err).To(Not(HaveOccurred()))
 
@@ -216,9 +214,17 @@ func installK3kChart() {
 	iCli.Wait = true
 
 	controllerMap, _ := k3kChart.Values["controller"].(map[string]any)
+
+	extraEnvArray, _ := controllerMap["extraEnv"].([]map[string]any)
+	extraEnvArray = append(extraEnvArray, map[string]any{
+		"name":  "DEBUG",
+		"value": "true",
+	})
+	controllerMap["extraEnv"] = extraEnvArray
+
 	imageMap, _ := controllerMap["image"].(map[string]any)
 	maps.Copy(imageMap, map[string]any{
-		"repository": repo + "/k3k",
+		"repository": controllerImage,
 		"tag":        "dev",
 		"pullPolicy": "IfNotPresent",
 	})
@@ -227,14 +233,14 @@ func installK3kChart() {
 	sharedAgentMap, _ := agentMap["shared"].(map[string]any)
 	sharedAgentImageMap, _ := sharedAgentMap["image"].(map[string]any)
 	maps.Copy(sharedAgentImageMap, map[string]any{
-		"repository": repo + "/k3k-kubelet",
+		"repository": kubeletImage,
 		"tag":        "dev",
 	})
 
 	release, err := iCli.Run(k3kChart, k3kChart.Values)
 	Expect(err).To(Not(HaveOccurred()))
 
-	GinkgoWriter.Printf("Release %s installed in %s namespace\n", release.Name, release.Namespace)
+	GinkgoWriter.Printf("Helm release '%s' installed in '%s' namespace\n", release.Name, release.Namespace)
 }
 
 func patchPVC(ctx context.Context, clientset *kubernetes.Clientset) {
@@ -297,36 +303,28 @@ func patchPVC(ctx context.Context, clientset *kubernetes.Clientset) {
 	_, err = clientset.AppsV1().Deployments(k3kNamespace).Update(ctx, k3kDeployment, metav1.UpdateOptions{})
 	Expect(err).To(Not(HaveOccurred()))
 
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
 		GinkgoWriter.Println("Checking K3k deployment status")
 
 		dep, err := clientset.AppsV1().Deployments(k3kNamespace).Get(ctx, k3kDeployment.Name, metav1.GetOptions{})
-		Expect(err).To(Not(HaveOccurred()))
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(dep.Generation).To(Equal(dep.Status.ObservedGeneration))
 
-		// 1. Check if the controller has observed the latest generation
-		if dep.Generation > dep.Status.ObservedGeneration {
-			GinkgoWriter.Printf("K3k deployment generation: %d, observed generation: %d\n", dep.Generation, dep.Status.ObservedGeneration)
-			return false
+		var availableCond appsv1.DeploymentCondition
+
+		for _, cond := range dep.Status.Conditions {
+			if cond.Type == appsv1.DeploymentAvailable {
+				availableCond = cond
+				break
+			}
 		}
 
-		// 2. Check if all replicas have been updated
-		if dep.Spec.Replicas != nil && dep.Status.UpdatedReplicas < *dep.Spec.Replicas {
-			GinkgoWriter.Printf("K3k deployment replicas: %d, updated replicas: %d\n", *dep.Spec.Replicas, dep.Status.UpdatedReplicas)
-			return false
-		}
-
-		// 3. Check if all updated replicas are available
-		if dep.Status.AvailableReplicas < dep.Status.UpdatedReplicas {
-			GinkgoWriter.Printf("K3k deployment available replicas: %d, updated replicas: %d\n", dep.Status.AvailableReplicas, dep.Status.UpdatedReplicas)
-			return false
-		}
-
-		return true
+		g.Expect(availableCond.Type).To(Equal(appsv1.DeploymentAvailable))
+		g.Expect(availableCond.Status).To(Equal(v1.ConditionTrue))
 	}).
-		MustPassRepeatedly(5).
 		WithPolling(time.Second).
 		WithTimeout(time.Second * 30).
-		Should(BeTrue())
+		Should(Succeed())
 }
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Running tests with the `K3K_DOCKER_INSTALL` was causing an error because of the logger not being properly set.

This PR moves the initialization of the logger, enables the DEBUG logging during the K3k Helm installation and cleanup the logs. It also moves the `REPO` flag from being a global to a more scoped variable.

<details>
<summary>Before</summary>

```
➜ K3K_DOCKER_INSTALL=true make test-e2e
go run github.com/onsi/ginkgo/v2/ginkgo@v2.21.0 -v -r --coverprofile=cover.out --coverpkg=./... --label-filter="e2e" tests
Running Suite: Tests Suite - /home/enrico/Development/enrichman/k3k/tests
=========================================================================
Random Seed: 1773248053

Will run 37 of 49 specs
------------------------------
[BeforeSuite] 
/home/enrico/Development/enrichman/k3k/tests/tests_suite_test.go:85
  GOCOVERDIR: 
  K3s containerIP: 172.17.0.5
  /tmp/kubeconfig-1376155225apiVersion: v1
  kind: Config
  clusters:
      - name: default
        cluster:
          server: https://localhost:32769
          certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJkakNDQVIyZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQWpNU0V3SHdZRFZRUUREQmhyTTNNdGMyVnkKZG1WeUxXTmhRREUzTnpNeU5EZ3dOakl3SGhjTk1qWXdNekV4TVRZMU5ESXlXaGNOTXpZd016QTRNVFkxTkRJeQpXakFqTVNFd0h3WURWUVFEREJock0zTXRjMlZ5ZG1WeUxXTmhRREUzTnpNeU5EZ3dOakl3V1RBVEJnY3Foa2pPClBRSUJCZ2dxaGtqT1BRTUJCd05DQUFUVXpPblhLcEFmR050TW9xUHJVUnJFdXAvbWgyZWdobStWbTI3eG9jbDkKWk9BamJ0UVZRc05KelpBS0NsRUFVcEtTY0J4SFV3NURDS2hDamdpUUdtd0xvMEl3UURBT0JnTlZIUThCQWY4RQpCQU1DQXFRd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFRmdRVXUvSHJhNnZmY3ZtVTc3Y28xaGpUCllpdmt1NHd3Q2dZSUtvWkl6ajBFQXdJRFJ3QXdSQUlnV3VlRWRORWRJWjNnZzFhenBqaHdlOC9SN2liYkhrVVoKTEFwaTBEZG9uaTBDSUJzUTQ0bUsxeGpRSG84MUxRVm5vQVh5RGRSMjJjMUlGaUlidnpRYU9OdXMKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
          certificate-authority: ""
  users:
      - name: default
        user:
          client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FUR.......FLS0tLS0K
          client-key-data: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0......FJJVkFURSBLRVktLS0tLQo=
  contexts:
      - name: default
        context:
          cluster: default
          user: default
  current-context: default
  preferences: {}
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 31 [running]:
        >  runtime/debug.Stack()
        >       /home/enrico/.asdf/installs/golang/1.25.6/go/src/runtime/debug/stack.go:26 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc000444980, {0x3eeec90, 0x14})
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/log/deleg.go:147 +0x3e
        >  github.com/go-logr/logr.Logger.WithName({{0x4322868, 0xc000444980}, 0x0}, {0x3eeec90?, 0xc0005b9180?})
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/github.com/go-logr/logr@v1.4.3/logr.go:345 +0x36
        >  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x0?, {0x0, 0xc00054ebd0, {0x0, 0x0}, 0x0, 0x0})
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/client/client.go:118 +0xdb
        >  sigs.k8s.io/controller-runtime/pkg/client.New(0xc00089ddc0?, {0x0, 0xc00054ebd0, {0x0, 0x0}, 0x0, 0x0})
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/client/client.go:98 +0x4d
        >  github.com/rancher/k3k/tests_test.initKubernetesClient({0x431ad68, 0x5d32760})
        >       /home/enrico/Development/enrichman/k3k/tests/tests_suite_test.go:130 +0x3a5
        >  github.com/rancher/k3k/tests_test.init.func23()
        >       /home/enrico/Development/enrichman/k3k/tests/tests_suite_test.go:99 +0x15a
        >  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0x0?, 0x0?})
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/github.com/onsi/ginkgo/v2@v2.21.0/internal/node.go:472 +0x13
        >  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/github.com/onsi/ginkgo/v2@v2.21.0/internal/suite.go:894 +0x7b
        >  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 69
        >       /home/enrico/.asdf/installs/golang/1.25.6/packages/pkg/mod/github.com/onsi/ginkgo/v2@v2.21.0/internal/suite.go:881 +0xd50
  helm debug: creating 1 resource(s)
  helm debug: creating 10 resource(s)
  helm debug: beginning wait for 10 resources with timeout of 1m0s
  helm debug: Deployment is not ready: k3k-system/k3k. 0 out of 1 expected pods are ready
  helm debug: wait for resources succeeded within 2s
  Release k3k installed in k3k-system namespace
  Checking K3k deployment status
  K3k deployment generation: 2, observed generation: 1
  Checking K3k deployment status
  Checking K3k deployment status
  Checking K3k deployment status
  Checking K3k deployment status
  Checking K3k deployment status
[BeforeSuite] PASSED [40.039 seconds]
```

</details>

<details>
<summary>After</summary>

```
➜ K3K_DOCKER_INSTALL=true make test-e2e
go run github.com/onsi/ginkgo/v2/ginkgo@v2.21.0 -v -r --coverprofile=cover.out --coverpkg=./... --label-filter="e2e" tests
Running Suite: Tests Suite - /home/enrico/Development/enrichman/k3k/tests
=========================================================================
Random Seed: 1773248358

Will run 37 of 49 specs
------------------------------
[BeforeSuite] 
/home/enrico/Development/enrichman/k3k/tests/tests_suite_test.go:84
  GOCOVERDIR: 
  K3s containerIP: 172.17.0.5
  KUBECONFIG set to: /tmp/kubeconfig-320149498
  [Helm] creating 1 resource(s)
  [Helm] creating 10 resource(s)
  [Helm] beginning wait for 10 resources with timeout of 1m0s
  [Helm] Deployment is not ready: k3k-system/k3k. 0 out of 1 expected pods are ready
  [Helm] wait for resources succeeded within 2s
  Helm release 'k3k' installed in 'k3k-system' namespace
  Checking K3k deployment status
  Checking K3k deployment status
[BeforeSuite] PASSED [32.771 seconds]
```

</details>