### PR TITLE
[v1.0 backport] chore(deps): update dependency go to v1.25.8 (#664)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/k3k
 
 go 1.25
 
-toolchain go1.25.6
+toolchain go1.25.8
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Backport of #664 