### PR TITLE
Don't start the metrics server.

### DIFF
--- a/pkg/controller/cluster/cluster_suite_test.go
+++ b/pkg/controller/cluster/cluster_suite_test.go
@@ -16,6 +16,7 @@ import (
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller/cluster"
@@ -61,7 +62,7 @@ var _ = BeforeSuite(func() {
 
 	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme, Metrics: metricsserver.Options{BindAddress: "0"}})
 	Expect(err).NotTo(HaveOccurred())
 
 	portAllocator, err := agent.NewPortAllocator(ctx, mgr.GetClient())

--- a/pkg/controller/policy/policy_suite_test.go
+++ b/pkg/controller/policy/policy_suite_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller/policy"
@@ -49,7 +50,7 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme, Metrics: metricsserver.Options{BindAddress: "0"}})
 	Expect(err).NotTo(HaveOccurred())
 
 	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))


### PR DESCRIPTION
This prevents the metrics server from starting when testing.

None of the tests check the metrics server.