### PR TITLE
chore(ci): bump aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         REGISTRY: ""
 
     - name: Run Trivy vulnerability scanner (k3kcli)
-      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         ignore-unfixed: true
         severity: 'MEDIUM,HIGH,CRITICAL'
@@ -56,7 +56,7 @@ jobs:
         category: k3kcli
 
     - name: Run Trivy vulnerability scanner (k3k)
-      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         ignore-unfixed: true
         severity: 'MEDIUM,HIGH,CRITICAL'
@@ -72,7 +72,7 @@ jobs:
         category: k3k
 
     - name: Run Trivy vulnerability scanner (k3k-kubelet)
-      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         ignore-unfixed: true
         severity: 'MEDIUM,HIGH,CRITICAL'


### PR DESCRIPTION
Updates GitHub Actions workflows to pin aquasecurity/trivy-action to v0.35.0.

CC @macedogm