### PR TITLE
Fix for `K3S_HOST_VERSION` in cli tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
         
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
-        echo "K3S_HOST_VERSION=v1.32.1+k3s1 >> $GITHUB_ENV"
+        echo "K3S_HOST_VERSION=v1.35.2+k3s1" >> $GITHUB_ENV
     
     - name: Build and package
       run: |

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -100,7 +100,7 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				DeleteNamespaces(clusterNamespace)
 			})
 
-			_, stderr, err = K3kcli("cluster", "create", "--version", "v1.35.2-k3s1", clusterName)
+			_, stderr, err = K3kcli("cluster", "create", "--version", k3sVersion, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
 		})


### PR DESCRIPTION
The cli tests were not using the right Kubernetes version, because the environment variable was not set, due to a wrong quoting.