### PR TITLE
Cleanup tests and small fixes

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install helm
       run: |
         curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | sha256sum --check
         tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -6,6 +6,10 @@ on:
 permissions:
     contents: write
 
+env:
+  HELM_VERSION: v4.1.3
+  HELM_BIN_HASH_AMD64: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
+
 jobs:
   chart-release:
     runs-on: ubuntu-latest
@@ -19,11 +23,13 @@ jobs:
       run: |
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-    
-    - name: Install Helm
-      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Install helm
+      run: |
+        curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | sha256sum -a 256 --check
+        sudo mv /tmp/helm /usr/local/bin
+        sudo chmod +x /usr/local/bin/helm
 
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install helm
       run: |
         curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | sha256sum -a 256 --check
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | shasum -a 256 --check
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
 

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -26,8 +26,9 @@ jobs:
 
     - name: Install helm
       run: |
-        curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | shasum -a 256 --check
+        curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
+        tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
 

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Install helm
       run: |
         curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | sha256sum -a 256 --check
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | shasum -a 256 --check
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
 

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -11,6 +11,10 @@ permissions:
 env:
   ARCH: amd64
   KUBERNETES_VERSION: v1.35.3
+  HELM_VERSION: v4.1.3
+  HELM_BIN_HASH_AMD64: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
+  K3D_VERSION: v5.8.3
+  K3D_BIN_HASH_AMD64: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
 
 jobs:
   conformance:
@@ -22,9 +26,7 @@ jobs:
         type:
         - parallel
         - serial
-    env:
-      K3D_VERSION: v5.8.3
-      K3D_BIN_HASH_AMD64: "dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e"
+      
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -37,15 +39,19 @@ jobs:
         go-version-file: go.mod
 
     - name: Install helm
-      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
-    
+      run: |
+        curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | sha256sum -a 256 --check
+        sudo mv /tmp/helm /usr/local/bin
+        sudo chmod +x /usr/local/bin/helm
+
     - name: Install hydrophone
       run: go install sigs.k8s.io/hydrophone@3de3e886a2f6f09635d8b981c195490af1584d97 #v0.7.0
 
     - name: Install k3d # taken from github.com/rancher/rancher/.github/workflows/integration-tests.yaml
       run: |
-        curl -sSfL -o k3d "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-${ARCH}"
-        echo "${K3D_BIN_HASH_AMD64}  k3d" | shasum -a 256 --check
+        curl -sSfL -o k3d "https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-${ARCH}"
+        echo "${{ env.K3D_BIN_HASH_AMD64 }}  k3d" | shasum -a 256 --check
         sudo mv k3d /usr/local/bin
         sudo chmod +x /usr/local/bin/k3d
 
@@ -63,7 +69,7 @@ jobs:
         k3d registry create ${REPO_NAME} --port ${REPO_PORT}
         
         k3d cluster create k3k --servers 2 \
-          --image ${{ env.KUBERNETES_VERSION }}-k3s1 \
+          --image rancher/k3s:${{ env.KUBERNETES_VERSION }}-k3s1 \
           -p "30000-30010:30000-30010@server:0" \
           --registry-use k3d-${REPO_NAME}:${REPO_PORT}
         

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -40,8 +40,9 @@ jobs:
 
     - name: Install helm
       run: |
-        curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | shasum -a 256 --check
+        curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
+        tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
 

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -10,7 +10,6 @@ permissions:
 
 env:
   ARCH: amd64
-  KUBERNETES_VERSION: v1.35.3
   HELM_VERSION: v4.1.3
   HELM_BIN_HASH_AMD64: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
   K3D_VERSION: v5.8.3
@@ -19,10 +18,15 @@ env:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    env:
+      KUBERNETES_VERSION: ${{ matrix.k8s_version }}
 
     strategy:
       fail-fast: false
       matrix:
+        k8s_version:
+        - v1.34.6
+        - v1.35.3
         type:
         - parallel
         - serial
@@ -152,13 +156,13 @@ jobs:
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: conformance-${{ matrix.type }}-logs
+        name: conformance-${{ matrix.k8s_version }}-${{ matrix.type }}-logs
         path: /tmp/e2e.log
 
     - name: Job Summary
       if: always()
       run: |
-        echo '## 📊 Conformance Tests Results (${{ matrix.type }})' >> $GITHUB_STEP_SUMMARY
+        echo '## 📊 Conformance Tests Results (${{ matrix.k8s_version }} - ${{ matrix.type }})' >> $GITHUB_STEP_SUMMARY
         echo '| Passed | Failed | Pending | Skipped |'              >> $GITHUB_STEP_SUMMARY
         echo '|---|---|---|---|'                                    >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   ARCH: amd64
-  KUBECTL_VERSION: v1.35.3
+  KUBERNETES_VERSION: v1.35.3
 
 jobs:
   conformance:
@@ -51,7 +51,7 @@ jobs:
 
     - name: Install k3d and kubectl
       run: |
-        curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+        curl -LO "https://dl.k8s.io/release/${{ env.KUBERNETES_VERSION }}/bin/linux/amd64/kubectl"
 
     - name: Setup Kubernetes (k3d)
       env:
@@ -63,6 +63,7 @@ jobs:
         k3d registry create ${REPO_NAME} --port ${REPO_PORT}
         
         k3d cluster create k3k --servers 2 \
+          --image ${{ env.KUBERNETES_VERSION }}-k3s1 \
           -p "30000-30010:30000-30010@server:0" \
           --registry-use k3d-${REPO_NAME}:${REPO_PORT}
         

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Install helm
       run: |
         curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | sha256sum --check
         tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
@@ -56,13 +56,15 @@ jobs:
     - name: Install k3d # taken from github.com/rancher/rancher/.github/workflows/integration-tests.yaml
       run: |
         curl -sSfL -o k3d "https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}/k3d-linux-${ARCH}"
-        echo "${{ env.K3D_BIN_HASH_AMD64 }}  k3d" | shasum -a 256 --check
+        echo "${{ env.K3D_BIN_HASH_AMD64 }}  k3d" | sha256sum --check
         sudo mv k3d /usr/local/bin
         sudo chmod +x /usr/local/bin/k3d
 
     - name: Install k3d and kubectl
       run: |
         curl -LO "https://dl.k8s.io/release/${{ env.KUBERNETES_VERSION }}/bin/linux/amd64/kubectl"
+        curl -LO "https://dl.k8s.io/release/${{ env.KUBERNETES_VERSION }}/bin/linux/amd64/kubectl.sha256"
+        echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 
     - name: Setup Kubernetes (k3d)
       env:
@@ -150,7 +152,7 @@ jobs:
         # Run serial conformance tests
         hydrophone --focus='\[Serial\].*\[Conformance\]' \
           --kubeconfig ${{ github.workspace }}/k3k-mycluster-mycluster-kubeconfig.yaml \
-          --output-dir /tmp 
+          --output-dir /tmp
 
     - name: Archive conformance logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Install helm
       run: |
         curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | sha256sum --check
         tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Install helm
       run: |
         curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | sha256sum -a 256 --check
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | shasum -a 256 --check
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
     

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   KUBERNETES_VERSION: v1.35.3
+  HELM_VERSION: v4.1.3
+  HELM_BIN_HASH_AMD64: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
 
 jobs:
   conformance:
@@ -34,7 +36,11 @@ jobs:
         go-version-file: go.mod
 
     - name: Install helm
-      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      run: |
+        curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | sha256sum -a 256 --check
+        sudo mv /tmp/helm /usr/local/bin
+        sudo chmod +x /usr/local/bin/helm
     
     - name: Install hydrophone
       run: go install sigs.k8s.io/hydrophone@3de3e886a2f6f09635d8b981c195490af1584d97 #v0.7.0

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -8,6 +8,9 @@ on:
 permissions:
     contents: read
 
+env:
+  KUBERNETES_VERSION: v1.35.3
+
 jobs:
   conformance:
     runs-on: ubuntu-latest
@@ -39,7 +42,7 @@ jobs:
     - name: Install k3s
       env:
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        K3S_HOST_VERSION: v1.35.2+k3s1
+        K3S_HOST_VERSION: ${{ env.KUBERNETES_VERSION }}+k3s1
       run: |
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_HOST_VERSION} INSTALL_K3S_EXEC="--write-kubeconfig-mode=777" sh -s -
 

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -9,17 +9,21 @@ permissions:
     contents: read
 
 env:
-  KUBERNETES_VERSION: v1.35.3
   HELM_VERSION: v4.1.3
   HELM_BIN_HASH_AMD64: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
 
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    env:
+      KUBERNETES_VERSION: ${{ matrix.k8s_version }}
 
     strategy:
       fail-fast: false
       matrix:
+        k8s_version:
+        - v1.34.6
+        - v1.35.3
         type:
         - parallel
         - serial
@@ -117,27 +121,27 @@ jobs:
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: k3s-${{ matrix.type }}-logs
+        name: k3s-${{ matrix.k8s_version }}-${{ matrix.type }}-logs
         path: /tmp/k3s.log
 
     - name: Archive K3k logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: k3k-${{ matrix.type }}-logs
+        name: k3k-${{ matrix.k8s_version }}-${{ matrix.type }}-logs
         path: /tmp/k3k.log
 
     - name: Archive conformance logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: conformance-${{ matrix.type }}-logs
+        name: conformance-${{ matrix.k8s_version }}-${{ matrix.type }}-logs
         path: /tmp/e2e.log
 
     - name: Job Summary
       if: always()
       run: |
-        echo '## 📊 Conformance Tests Results (${{ matrix.type }})' >> $GITHUB_STEP_SUMMARY
+        echo '## 📊 Conformance Tests Results (${{ matrix.k8s_version }} - ${{ matrix.type }})' >> $GITHUB_STEP_SUMMARY
         echo '| Passed | Failed | Pending | Skipped |'              >> $GITHUB_STEP_SUMMARY
         echo '|---|---|---|---|'                                    >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -37,8 +37,9 @@ jobs:
 
     - name: Install helm
       run: |
-        curl https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-        echo "${{ env.HELM_BIN_HASH_AMD64 }}  /tmp/helm" | shasum -a 256 --check
+        curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
+        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
+        tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
         sudo mv /tmp/helm /usr/local/bin
         sudo chmod +x /usr/local/bin/helm
     

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -80,6 +80,14 @@ jobs:
         files: ./cover.out
         flags: e2e
 
+    - name: Export logs
+      if: always()
+      env:
+        KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      run: |
+        journalctl -u k3s -o cat --no-pager > /tmp/k3s.log
+        kubectl logs -n k3k-system -l "app.kubernetes.io/name=k3k" --tail=-1 > /tmp/k3k.log
+
     - name: Archive k3s logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
@@ -159,16 +167,24 @@ jobs:
         files: ./cover.out
         flags: e2e
 
+    - name: Export logs
+      if: always()
+      env:
+        KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      run: |
+        journalctl -u k3s -o cat --no-pager > /tmp/k3s.log
+        kubectl logs -n k3k-system -l "app.kubernetes.io/name=k3k" --tail=-1 > /tmp/k3k.log
+
     - name: Archive k3s logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: e2e-k3s-logs
+        name: e2e-slow-k3s-logs
         path: /tmp/k3s.log
 
     - name: Archive k3k logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: e2e-k3k-logs
+        name: e2e-slow-k3k-logs
         path: /tmp/k3k.log

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -10,6 +10,9 @@ on:
 permissions:
     contents: read
 
+env:
+  KUBERNETES_VERSION: v1.35.3
+
 jobs:
   tests-e2e:
     runs-on: ubuntu-latest
@@ -36,11 +39,11 @@ jobs:
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
         echo "REPO=ttl.sh/$(uuidgen)" >> $GITHUB_ENV
         echo "VERSION=1h" >> $GITHUB_ENV
-        echo "K3S_HOST_VERSION=v1.32.1+k3s1 >> $GITHUB_ENV"
+        echo "K3S_HOST_VERSION=${{ env.KUBERNETES_VERSION }}+k3s1" >> $GITHUB_ENV
 
     - name: Install k3s
       run: |
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${{ env.K3S_HOST_VERSION }} INSTALL_K3S_EXEC="--write-kubeconfig-mode=777" sh -s - 
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_HOST_VERSION} INSTALL_K3S_EXEC="--write-kubeconfig-mode=777" sh -s - 
 
     - name: Build and package and push dev images
       env:
@@ -115,11 +118,11 @@ jobs:
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
         echo "REPO=ttl.sh/$(uuidgen)" >> $GITHUB_ENV
         echo "VERSION=1h" >> $GITHUB_ENV
-        echo "K3S_HOST_VERSION=v1.32.1+k3s1 >> $GITHUB_ENV"
+        echo "K3S_HOST_VERSION=${{ env.KUBERNETES_VERSION }}+k3s1" >> $GITHUB_ENV
 
     - name: Install k3s
       run: |
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${{ env.K3S_HOST_VERSION }} INSTALL_K3S_EXEC="--write-kubeconfig-mode=777" sh -s - 
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_HOST_VERSION} INSTALL_K3S_EXEC="--write-kubeconfig-mode=777" sh -s - 
 
     - name: Build and package and push dev images
       env:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -67,14 +67,14 @@ jobs:
       run: go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out
     
     - name: Upload coverage reports to Codecov (controller)
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${GOCOVERDIR}/cover.out
         flags: controller
 
     - name: Upload coverage reports to Codecov (e2e)
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./cover.out
@@ -146,14 +146,14 @@ jobs:
       run: go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out
     
     - name: Upload coverage reports to Codecov (controller)
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${GOCOVERDIR}/cover.out
         flags: controller
 
     - name: Upload coverage reports to Codecov (e2e)
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./cover.out

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       run: make test-unit
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./cover.out
@@ -81,7 +81,7 @@ jobs:
       run: go tool covdata textfmt -i=${{ github.workspace }}/covdata -o ${{ github.workspace }}/covdata/cover.out
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/covdata/cover.out

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
 permissions:
     contents: read
 
+env:
+  KUBERNETES_VERSION: v1.35.3
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -55,7 +58,7 @@ jobs:
         
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
-        echo "K3S_HOST_VERSION=v1.35.2+k3s1" >> $GITHUB_ENV
+        echo "K3S_HOST_VERSION=${{ env.KUBERNETES_VERSION }}+k3s1" >> $GITHUB_ENV
     
     - name: Build and package
       run: |

--- a/tests/cli/tests_suite_test.go
+++ b/tests/cli/tests_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	v1 "k8s.io/api/core/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
@@ -216,9 +217,27 @@ var _ = AfterSuite(func() {
 		Expect(err).To(Not(HaveOccurred()))
 		writeLogs("k3s.log", k3sLogs)
 
+		// dump k3k controller logs
+		k3kLogs := getK3kLogs(ctx)
+		writeLogs("k3k.log", k3kLogs)
+
 		testcontainers.CleanupContainer(GinkgoTB(), k3sContainer)
 	}
 })
+
+func getK3kLogs(ctx context.Context) io.ReadCloser {
+	var podList v1.PodList
+
+	err := k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: k3kNamespace})
+	Expect(err).To(Not(HaveOccurred()))
+
+	k3kPod := podList.Items[0]
+	req := k8s.CoreV1().Pods(k3kPod.Namespace).GetLogs(k3kPod.Name, &v1.PodLogOptions{})
+	podLogs, err := req.Stream(ctx)
+	Expect(err).To(Not(HaveOccurred()))
+
+	return podLogs
+}
 
 func writeLogs(filename string, logs io.ReadCloser) {
 	logsStr, err := io.ReadAll(logs)

--- a/tests/cli/tests_suite_test.go
+++ b/tests/cli/tests_suite_test.go
@@ -230,6 +230,7 @@ func getK3kLogs(ctx context.Context) io.ReadCloser {
 
 	err := k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: k3kNamespace})
 	Expect(err).To(Not(HaveOccurred()))
+	Expect(podList.Items).NotTo(BeEmpty())
 
 	k3kPod := podList.Items[0]
 	req := k8s.CoreV1().Pods(k3kPod.Namespace).GetLogs(k3kPod.Name, &v1.PodLogOptions{})

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -362,6 +362,7 @@ func dumpK3kCoverageData(ctx context.Context, folder string) {
 
 	err := k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: k3kNamespace})
 	Expect(err).To(Not(HaveOccurred()))
+	Expect(podList.Items).NotTo(BeEmpty())
 
 	k3kPod := podList.Items[0]
 	k3kContainerName := k3kPod.Spec.Containers[0].Name
@@ -455,6 +456,7 @@ func getK3kLogs(ctx context.Context) io.ReadCloser {
 
 	err := k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: k3kNamespace})
 	Expect(err).To(Not(HaveOccurred()))
+	Expect(podList.Items).NotTo(BeEmpty())
 
 	k3kPod := podList.Items[0]
 	req := k8s.CoreV1().Pods(k3kPod.Namespace).GetLogs(k3kPod.Name, &v1.PodLogOptions{Previous: true})


### PR DESCRIPTION
This PR address few fixes in our tests, and cleanup.

### Fix for wrong exported var

This was just echoing the whole line:
```
echo "K3S_HOST_VERSION=v1.32.1+k3s1 >> $GITHUB_ENV"
```

### Common `KUBERNETES_VERSION` var

With a common `KUBERNETES_VERSION` var it will be easier to upgrade the version everywhere, and possibly automate this. This is now also used to create the k3d cluster for the conformance tests with the correct version.

### Missing k3k logs dump

Cli tests were missing the k3k server logs dump, so the archive was failing, and it was not possible to check them on the CI.

### Helm installation

We are now using directly the helm releases to install Helm, instead of the `azure/setup-helm` action.

```yaml
env:
  HELM_VERSION: v4.1.3
  HELM_BIN_HASH_AMD64: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700

...

    - name: Install helm
      run: |
        curl -sSfL -o helm.tar.gz https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
        echo "${{ env.HELM_BIN_HASH_AMD64 }}  helm.tar.gz" | shasum -a 256 --check
        tar -xvzf helm.tar.gz --strip-components=1 -C /tmp/
        sudo mv /tmp/helm /usr/local/bin
        sudo chmod +x /usr/local/bin/helm
```
