### PR TITLE
fix: reject negative storageRequestSize in CLI and CRD validation

### DIFF
--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -48,8 +48,10 @@ func validateCreateConfig(cfg *CreateConfig) error {
 		}
 	}
 
-	if _, err := resource.ParseQuantity(cfg.storageRequestSize); err != nil {
+	if qty, err := resource.ParseQuantity(cfg.storageRequestSize); err != nil {
 		return errors.New(`invalid storage size, should be a valid resource quantity e.g "10Gi"`)
+	} else if qty.Cmp(resource.MustParse("0")) <= 0 {
+		return errors.New("storage size must be a positive value")
 	}
 
 	if cfg.mode != "" {

--- a/pkg/apis/k3k.io/v1beta1/types.go
+++ b/pkg/apis/k3k.io/v1beta1/types.go
@@ -427,6 +427,7 @@ type PersistenceConfig struct {
 	//
 	// +kubebuilder:default="2G"
 	// +kubebuilder:validation:XValidation:message="storageRequestSize is immutable",rule="self == oldSelf"
+	// +kubebuilder:validation:XValidation:message="storageRequestSize must be a positive value",rule="self > quantity('0')"
 	// +optional
 	StorageRequestSize *resource.Quantity `json:"storageRequestSize,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds validation to reject negative or zero `storageRequestSize` values in both the CLI and the CRD.

## Why this matters

Creating a cluster with a negative storage size (e.g. `-1G`) passes CLI and CRD validation but fails at StatefulSet creation time with an unhelpful Kubernetes error. Catching this early gives users a clear message.

## Changes

- `cli/cmds/cluster_create_flags.go`: After parsing the quantity, added a check that rejects values <= 0 with "storage size must be a positive value"
- `pkg/apis/k3k.io/v1beta1/types.go`: Added a CEL validation rule (`self > quantity('0')`) on the `StorageRequestSize` field so the Kubernetes API rejects negative values at admission time

## Testing

- CLI validation: `k3kcli cluster create --storage-request-size "-1G"` now returns "storage size must be a positive value"
- CRD validation: Negative values rejected by the API server before the StatefulSet is created

Fixes #729

This contribution was developed with AI assistance (Claude Code).

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)