### PR TITLE
Bump Go (`v1.25.9`) and golanci-lint to (`2.11.4`)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.3
+          version: v2.11.4
           args: -v
           only-new-issues: true
           skip-cache: false

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION ?= $(shell git describe --tags --always --dirty --match="v[0-9]*")
 
 ## Dependencies
 
-GOLANGCI_LINT_VERSION := v2.11.3
+GOLANGCI_LINT_VERSION := v2.11.4
 GINKGO_VERSION ?= v2.28.1
 GINKGO_FLAGS ?= -v -r --coverprofile=cover.out --coverpkg=./...
 ENVTEST_VERSION ?= v0.0.0-20250505003155-b6c5897febe5

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/k3k
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
This PR bumps Go and golanci-lint to the latest patch.