### PR TITLE
Fix nil error handling in webhook removal

### DIFF
--- a/k3k-kubelet/controller/webhook/pod.go
+++ b/k3k-kubelet/controller/webhook/pod.go
@@ -26,8 +26,10 @@ func RemovePodMutatingWebhook(ctx context.Context, virtualClient, hostClient ctr
 		},
 	}
 
-	if err := hostClient.Delete(ctx, webhookSecret); !apierrors.IsNotFound(err) {
-		return err
+	if err := hostClient.Delete(ctx, webhookSecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	webhook := &admissionregistrationv1.MutatingWebhookConfiguration{
@@ -40,8 +42,10 @@ func RemovePodMutatingWebhook(ctx context.Context, virtualClient, hostClient ctr
 		},
 	}
 
-	if err := virtualClient.Delete(ctx, webhook); !apierrors.IsNotFound(err) {
-		return err
+	if err := virtualClient.Delete(ctx, webhook); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes a bug regarding Webhook removal and cleanup.

Previously, the logic only checked if the error was not a `NotFound` error. This meant the code entered the error-handling branch even when the error was nil. While a restart would eventually resolve the state (as the error would no longer be nil), adding an explicit check for nil fixes the root cause immediately.