### PR TITLE
Add `importas` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   enable:
   - misspell
   - wsl_v5
+  - importas
   exclusions:
     rules:
     # Allow dot imports for Ginkgo/Gomega in test framework
@@ -11,6 +12,20 @@ linters:
       text: "dot imports"
       linters:
       - staticcheck
+  settings:
+    importas:
+      # Enforce import aliases for k8s packages
+      alias:
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
+      - pkg: k8s.io/api/networking/v1
+        alias: networkingv1
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ endif
 lint:	## Find any linting issues in the project
 	$(GOLANGCI_LINT) run --timeout=5m
 
+.PHONY: lint-fix
+lint-fix:	## Fix any linting issues in the project
+	$(GOLANGCI_LINT) run --fix --timeout=5m
+
 .PHONY: fmt
 fmt:	## Format source files in the project
 ifndef CI

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,7 +67,7 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 			matchingLabels.ApplyToList(&listOpts)
 			deleteOpts := &ctrlclient.DeleteAllOfOptions{ListOptions: listOpts}
 
-			if err := client.DeleteAllOf(ctx, &v1.PersistentVolumeClaim{}, deleteOpts); err != nil {
+			if err := client.DeleteAllOf(ctx, &corev1.PersistentVolumeClaim{}, deleteOpts); err != nil {
 				return ctrlclient.IgnoreNotFound(err)
 			}
 		}
@@ -81,7 +81,7 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 }
 
 func RemoveOwnerReferenceFromSecret(ctx context.Context, name string, cl ctrlclient.Client, cluster v1beta1.Cluster) error {
-	var secret v1.Secret
+	var secret corev1.Secret
 
 	key := types.NamespacedName{
 		Name:      name,

--- a/cli/cmds/policy_create.go
+++ b/cli/cmds/policy_create.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -69,7 +69,7 @@ func policyCreateAction(appCtx *AppContext, config *VirtualClusterPolicyCreateCo
 }
 
 func createNamespace(ctx context.Context, client client.Client, name, policyName string) error {
-	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 
 	if policyName != "" {
 		ns.Labels = map[string]string{
@@ -125,7 +125,7 @@ func bindPolicyToNamespaces(ctx context.Context, client client.Client, config *V
 	var errs []error
 
 	for _, namespace := range config.namespaces {
-		var ns v1.Namespace
+		var ns corev1.Namespace
 		if err := client.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
 			if apierrors.IsNotFound(err) {
 				logrus.Warnf(`Namespace '%s' not found, skipping`, namespace)

--- a/k3k-kubelet/controller/syncer/persistentvolumeclaims.go
+++ b/k3k-kubelet/controller/syncer/persistentvolumeclaims.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,7 +50,7 @@ func AddPVCSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, cluster
 
 	return ctrl.NewControllerManagedBy(virtMgr).
 		Named(name).
-		For(&v1.PersistentVolumeClaim{}).
+		For(&corev1.PersistentVolumeClaim{}).
 		WithEventFilter(predicate.NewPredicateFuncs(reconciler.filterResources)).
 		Complete(&reconciler)
 }
@@ -85,7 +85,7 @@ func (r *PVCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	var (
-		virtPVC v1.PersistentVolumeClaim
+		virtPVC corev1.PersistentVolumeClaim
 		cluster v1beta1.Cluster
 	)
 
@@ -131,7 +131,7 @@ func (r *PVCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		}
 	}
 
-	var currentHostPVC v1.PersistentVolumeClaim
+	var currentHostPVC corev1.PersistentVolumeClaim
 
 	err := r.HostClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(syncedPVC), &currentHostPVC)
 	if err == nil {
@@ -156,14 +156,14 @@ func (r *PVCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	return reconcile.Result{}, r.createVirtualPersistentVolume(ctx, virtPVC)
 }
 
-func (r *PVCReconciler) pvc(obj *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
+func (r *PVCReconciler) pvc(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
 	hostPVC := obj.DeepCopy()
 	r.Translator.TranslateTo(hostPVC)
 
 	return hostPVC
 }
 
-func (r *PVCReconciler) createVirtualPersistentVolume(ctx context.Context, pvc v1.PersistentVolumeClaim) error {
+func (r *PVCReconciler) createVirtualPersistentVolume(ctx context.Context, pvc corev1.PersistentVolumeClaim) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Creating virtual PersistentVolume")
 
@@ -174,8 +174,8 @@ func (r *PVCReconciler) createVirtualPersistentVolume(ctx context.Context, pvc v
 	}
 
 	orig := pv.DeepCopy()
-	pv.Status = v1.PersistentVolumeStatus{
-		Phase: v1.VolumeBound,
+	pv.Status = corev1.PersistentVolumeStatus{
+		Phase: corev1.VolumeBound,
 	}
 
 	if err := r.VirtualClient.Status().Patch(ctx, pv, ctrlruntimeclient.MergeFrom(orig)); err != nil {
@@ -191,20 +191,20 @@ func (r *PVCReconciler) createVirtualPersistentVolume(ctx context.Context, pvc v
 
 	pvcPatch.Annotations[volume.AnnBoundByController] = "yes"
 	pvcPatch.Annotations[volume.AnnBindCompleted] = "yes"
-	pvcPatch.Status.Phase = v1.ClaimBound
+	pvcPatch.Status.Phase = corev1.ClaimBound
 	pvcPatch.Status.AccessModes = pvcPatch.Spec.AccessModes
 
 	return r.VirtualClient.Status().Update(ctx, pvcPatch)
 }
 
-func newPersistentVolume(obj *v1.PersistentVolumeClaim) *v1.PersistentVolume {
+func newPersistentVolume(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolume {
 	var storageClass string
 
 	if obj.Spec.StorageClassName != nil {
 		storageClass = *obj.Spec.StorageClassName
 	}
 
-	return &v1.PersistentVolume{
+	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: obj.Name,
 			Labels: map[string]string{
@@ -219,18 +219,18 @@ func newPersistentVolume(obj *v1.PersistentVolumeClaim) *v1.PersistentVolume {
 			Kind:       "PersistentVolume",
 			APIVersion: "v1",
 		},
-		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeSource: v1.PersistentVolumeSource{
-				FlexVolume: &v1.FlexPersistentVolumeSource{
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				FlexVolume: &corev1.FlexPersistentVolumeSource{
 					Driver: "pseudopv",
 				},
 			},
 			StorageClassName:              storageClass,
 			VolumeMode:                    obj.Spec.VolumeMode,
-			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
 			AccessModes:                   obj.Spec.AccessModes,
 			Capacity:                      obj.Spec.Resources.Requests,
-			ClaimRef: &v1.ObjectReference{
+			ClaimRef: &corev1.ObjectReference{
 				APIVersion:      obj.APIVersion,
 				UID:             obj.UID,
 				ResourceVersion: obj.ResourceVersion,

--- a/k3k-kubelet/controller/syncer/secret.go
+++ b/k3k-kubelet/controller/syncer/secret.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -52,7 +52,7 @@ func AddSecretSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clus
 
 	return ctrl.NewControllerManagedBy(virtMgr).
 		Named(name).
-		For(&v1.Secret{}).WithEventFilter(predicate.NewPredicateFuncs(reconciler.filterResources)).
+		For(&corev1.Secret{}).WithEventFilter(predicate.NewPredicateFuncs(reconciler.filterResources)).
 		Complete(&reconciler)
 }
 
@@ -92,7 +92,7 @@ func (s *SecretSyncer) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, err
 	}
 
-	var virtualSecret v1.Secret
+	var virtualSecret corev1.Secret
 
 	if err := s.VirtualClient.Get(ctx, req.NamespacedName, &virtualSecret); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
@@ -128,7 +128,7 @@ func (s *SecretSyncer) Reconcile(ctx context.Context, req reconcile.Request) (re
 		}
 	}
 
-	var hostSecret v1.Secret
+	var hostSecret corev1.Secret
 	if err := s.HostClient.Get(ctx, types.NamespacedName{Name: syncedSecret.Name, Namespace: syncedSecret.Namespace}, &hostSecret); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("creating the Secret for the first time on the host cluster")
@@ -146,11 +146,11 @@ func (s *SecretSyncer) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 // translateSecret will translate a given secret created in the virtual cluster and
 // translates it to host cluster object
-func (s *SecretSyncer) translateSecret(secret *v1.Secret) *v1.Secret {
+func (s *SecretSyncer) translateSecret(secret *corev1.Secret) *corev1.Secret {
 	hostSecret := secret.DeepCopy()
 
-	if hostSecret.Type == v1.SecretTypeServiceAccountToken {
-		hostSecret.Type = v1.SecretTypeOpaque
+	if hostSecret.Type == corev1.SecretTypeServiceAccountToken {
+		hostSecret.Type = corev1.SecretTypeOpaque
 	}
 
 	s.Translator.TranslateTo(hostSecret)

--- a/k3k-kubelet/controller/syncer/service.go
+++ b/k3k-kubelet/controller/syncer/service.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +49,7 @@ func AddServiceSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clu
 
 	return ctrl.NewControllerManagedBy(virtMgr).
 		Named(name).
-		For(&v1.Service{}).WithEventFilter(predicate.NewPredicateFuncs(reconciler.filterResources)).
+		For(&corev1.Service{}).WithEventFilter(predicate.NewPredicateFuncs(reconciler.filterResources)).
 		Complete(&reconciler)
 }
 
@@ -62,7 +62,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	var (
-		virtService v1.Service
+		virtService corev1.Service
 		cluster     v1beta1.Cluster
 	)
 
@@ -105,7 +105,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	// create or update the service on host
-	var hostService v1.Service
+	var hostService corev1.Service
 	if err := r.HostClient.Get(ctx, types.NamespacedName{Name: syncedService.Name, Namespace: r.ClusterNamespace}, &hostService); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("creating the service for the first time on the host cluster")
@@ -145,7 +145,7 @@ func (r *ServiceReconciler) filterResources(object ctrlruntimeclient.Object) boo
 	return labelSelector.Matches(labels.Set(object.GetLabels()))
 }
 
-func (s *ServiceReconciler) service(obj *v1.Service) *v1.Service {
+func (s *ServiceReconciler) service(obj *corev1.Service) *corev1.Service {
 	hostService := obj.DeepCopy()
 	s.Translator.TranslateTo(hostService)
 	// don't sync finalizers to the host

--- a/k3k-kubelet/controller/webhook/pod.go
+++ b/k3k-kubelet/controller/webhook/pod.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,7 +15,7 @@ import (
 const webhookName = "podmutating.k3k.io"
 
 func RemovePodMutatingWebhook(ctx context.Context, virtualClient, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace string) error {
-	webhookSecret := &v1.Secret{
+	webhookSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -148,7 +148,7 @@ func newKubelet(ctx context.Context, c *config) (*kubelet, error) {
 	}
 
 	// get the cluster's DNS IP to be injected to pods
-	var dnsService v1.Service
+	var dnsService corev1.Service
 
 	dnsName := controller.SafeConcatNameWithPrefix(c.ClusterName, "kube-dns")
 	if err := hostClient.Get(ctx, types.NamespacedName{Name: dnsName, Namespace: c.ClusterNamespace}, &dnsService); err != nil {
@@ -179,7 +179,7 @@ func newKubelet(ctx context.Context, c *config) (*kubelet, error) {
 }
 
 func clusterIP(ctx context.Context, serviceName, clusterNamespace string, hostClient ctrlruntimeclient.Client) (string, error) {
-	var service v1.Service
+	var service corev1.Service
 
 	serviceKey := types.NamespacedName{
 		Namespace: clusterNamespace,

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -152,9 +152,9 @@ func run(cmd *cobra.Command, args []string) error {
 
 func validate() error {
 	if config.SharedAgentImagePullPolicy != "" {
-		if config.SharedAgentImagePullPolicy != string(v1.PullAlways) &&
-			config.SharedAgentImagePullPolicy != string(v1.PullIfNotPresent) &&
-			config.SharedAgentImagePullPolicy != string(v1.PullNever) {
+		if config.SharedAgentImagePullPolicy != string(corev1.PullAlways) &&
+			config.SharedAgentImagePullPolicy != string(corev1.PullIfNotPresent) &&
+			config.SharedAgentImagePullPolicy != string(corev1.PullNever) {
 			return errors.New("invalid value for shared agent image policy")
 		}
 	}

--- a/pkg/controller/cluster/agent/ports.go
+++ b/pkg/controller/cluster/agent/ports.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,7 +28,7 @@ const (
 type PortAllocator struct {
 	ctrlruntimeclient.Client
 
-	KubeletCM *v1.ConfigMap
+	KubeletCM *corev1.ConfigMap
 }
 
 func NewPortAllocator(ctx context.Context, client ctrlruntimeclient.Client) (*PortAllocator, error) {
@@ -40,7 +40,7 @@ func NewPortAllocator(ctx context.Context, client ctrlruntimeclient.Client) (*Po
 		return nil, fmt.Errorf("failed to find k3k controller namespace")
 	}
 
-	var kubeletPortRangeCM v1.ConfigMap
+	var kubeletPortRangeCM corev1.ConfigMap
 
 	kubeletPortRangeCM.Name = kubeletPortRangeConfigMapName
 	kubeletPortRangeCM.Namespace = portRangeConfigMapNamespace
@@ -57,7 +57,7 @@ func (a *PortAllocator) InitPortAllocatorConfig(ctx context.Context, client ctrl
 	})
 }
 
-func (a *PortAllocator) getOrCreate(ctx context.Context, configmap *v1.ConfigMap, portRange string) error {
+func (a *PortAllocator) getOrCreate(ctx context.Context, configmap *corev1.ConfigMap, portRange string) error {
 	nn := types.NamespacedName{
 		Name:      configmap.Name,
 		Namespace: configmap.Namespace,
@@ -94,7 +94,7 @@ func (a *PortAllocator) DeallocateKubeletPort(ctx context.Context, clusterName, 
 }
 
 // allocatePort will assign port to the cluster from a port Range configured for k3k
-func (a *PortAllocator) allocatePort(ctx context.Context, clusterName, clusterNamespace string, configMap *v1.ConfigMap) (int, error) {
+func (a *PortAllocator) allocatePort(ctx context.Context, clusterName, clusterNamespace string, configMap *corev1.ConfigMap) (int, error) {
 	portRange, ok := configMap.Data[rangeKey]
 	if !ok {
 		return 0, fmt.Errorf("port range is not initialized")
@@ -145,7 +145,7 @@ func (a *PortAllocator) allocatePort(ctx context.Context, clusterName, clusterNa
 }
 
 // deallocatePort will remove the port used by the cluster from the port range
-func (a *PortAllocator) deallocatePort(ctx context.Context, clusterName, clusterNamespace string, configMap *v1.ConfigMap, port int) error {
+func (a *PortAllocator) deallocatePort(ctx context.Context, clusterName, clusterNamespace string, configMap *corev1.ConfigMap, port int) error {
 	portRange, ok := configMap.Data[rangeKey]
 	if !ok {
 		return fmt.Errorf("port range is not initialized")
@@ -211,7 +211,7 @@ func serializePortMap(m map[string]int) (string, error) {
 	return string(out), nil
 }
 
-func saveSnapshot(portAllocator *portallocator.PortAllocator, snapshot *core.RangeAllocation, configMap *v1.ConfigMap, portsMap map[string]int) error {
+func saveSnapshot(portAllocator *portallocator.PortAllocator, snapshot *core.RangeAllocation, configMap *corev1.ConfigMap, portsMap map[string]int) error {
 	// save the new snapshot
 	if err := portAllocator.Snapshot(snapshot); err != nil {
 		return err

--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -7,8 +7,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -74,7 +74,7 @@ func (s *SharedAgent) ensureObject(ctx context.Context, obj ctrlruntimeclient.Ob
 func (s *SharedAgent) config(ctx context.Context) error {
 	config := sharedAgentData(s.cluster, s.Name(), s.token, s.serviceIP, s.kubeletPort)
 
-	configSecret := &v1.Secret{
+	configSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -115,7 +115,7 @@ func (s *SharedAgent) daemonset(ctx context.Context) error {
 		"mode":    "shared",
 	}
 
-	deploy := &apps.DaemonSet{
+	deploy := &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
 			APIVersion: "apps/v1",
@@ -125,11 +125,11 @@ func (s *SharedAgent) daemonset(ctx context.Context) error {
 			Namespace: s.cluster.Namespace,
 			Labels:    labels,
 		},
-		Spec: apps.DaemonSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
 				},
@@ -141,15 +141,15 @@ func (s *SharedAgent) daemonset(ctx context.Context) error {
 	return s.ensureObject(ctx, deploy)
 }
 
-func (s *SharedAgent) podSpec(ctx context.Context) v1.PodSpec {
+func (s *SharedAgent) podSpec(ctx context.Context) corev1.PodSpec {
 	log := ctrl.LoggerFrom(ctx)
 
 	hostNetwork := false
-	dnsPolicy := v1.DNSClusterFirst
+	dnsPolicy := corev1.DNSClusterFirst
 
 	if s.cluster.Spec.MirrorHostNodes {
 		hostNetwork = true
-		dnsPolicy = v1.DNSClusterFirstWithHostNet
+		dnsPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	image := s.image
@@ -165,19 +165,19 @@ func (s *SharedAgent) podSpec(ctx context.Context) v1.PodSpec {
 		agentAffinity = s.cluster.Status.Policy.AgentAffinity
 	}
 
-	podSpec := v1.PodSpec{
+	podSpec := corev1.PodSpec{
 		Affinity:           agentAffinity,
 		HostNetwork:        hostNetwork,
 		DNSPolicy:          dnsPolicy,
 		ServiceAccountName: s.Name(),
 		NodeSelector:       s.cluster.Spec.NodeSelector,
-		Volumes: []v1.Volume{
+		Volumes: []corev1.Volume{
 			{
 				Name: "config",
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: configSecretName(s.cluster.Name),
-						Items: []v1.KeyToPath{
+						Items: []corev1.KeyToPath{
 							{
 								Key:  "config.yaml",
 								Path: "config.yaml",
@@ -187,19 +187,19 @@ func (s *SharedAgent) podSpec(ctx context.Context) v1.PodSpec {
 				},
 			},
 		},
-		Containers: []v1.Container{
+		Containers: []corev1.Container{
 			{
 				Name:            s.Name(),
 				Image:           image,
-				ImagePullPolicy: v1.PullPolicy(s.imagePullPolicy),
-				Resources: v1.ResourceRequirements{
-					Limits: v1.ResourceList{},
+				ImagePullPolicy: corev1.PullPolicy(s.imagePullPolicy),
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{},
 				},
-				Env: append([]v1.EnvVar{
+				Env: append([]corev1.EnvVar{
 					{
 						Name: "AGENT_HOSTNAME",
-						ValueFrom: &v1.EnvVarSource{
-							FieldRef: &v1.ObjectFieldSelector{
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
 								APIVersion: "v1",
 								FieldPath:  "spec.nodeName",
 							},
@@ -207,25 +207,25 @@ func (s *SharedAgent) podSpec(ctx context.Context) v1.PodSpec {
 					},
 					{
 						Name: "POD_IP",
-						ValueFrom: &v1.EnvVarSource{
-							FieldRef: &v1.ObjectFieldSelector{
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
 								APIVersion: "v1",
 								FieldPath:  "status.podIP",
 							},
 						},
 					},
 				}, s.cluster.Spec.AgentEnvs...),
-				VolumeMounts: []v1.VolumeMount{
+				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "config",
 						MountPath: "/opt/rancher/k3k/",
 						ReadOnly:  false,
 					},
 				},
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "kubelet-port",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: int32(s.kubeletPort),
 					},
 				},
@@ -233,7 +233,7 @@ func (s *SharedAgent) podSpec(ctx context.Context) v1.PodSpec {
 		},
 	}
 	for _, imagePullSecret := range s.imagePullSecrets {
-		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, v1.LocalObjectReference{Name: imagePullSecret})
+		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{Name: imagePullSecret})
 	}
 
 	securityContext := s.cluster.Spec.SecurityContext
@@ -258,7 +258,7 @@ func (s *SharedAgent) podSpec(ctx context.Context) v1.PodSpec {
 }
 
 func (s *SharedAgent) service(ctx context.Context) error {
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
@@ -267,17 +267,17 @@ func (s *SharedAgent) service(ctx context.Context) error {
 			Name:      s.Name(),
 			Namespace: s.cluster.Namespace,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				"cluster": s.cluster.Name,
 				"type":    "agent",
 				"mode":    "shared",
 			},
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:     "k3s-kubelet-port",
-					Protocol: v1.ProtocolTCP,
+					Protocol: corev1.ProtocolTCP,
 					Port:     int32(s.kubeletPort),
 				},
 			},
@@ -290,7 +290,7 @@ func (s *SharedAgent) service(ctx context.Context) error {
 func (s *SharedAgent) dnsService(ctx context.Context) error {
 	dnsServiceName := controller.SafeConcatNameWithPrefix(s.cluster.Name, "kube-dns")
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
@@ -299,28 +299,28 @@ func (s *SharedAgent) dnsService(ctx context.Context) error {
 			Name:      dnsServiceName,
 			Namespace: s.cluster.Namespace,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				translate.ClusterNameLabel: s.cluster.Name,
 				"k8s-app":                  "kube-dns",
 			},
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "dns",
-					Protocol:   v1.ProtocolUDP,
+					Protocol:   corev1.ProtocolUDP,
 					Port:       53,
 					TargetPort: intstr.FromInt32(53),
 				},
 				{
 					Name:       "dns-tcp",
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 					Port:       53,
 					TargetPort: intstr.FromInt32(53),
 				},
 				{
 					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 					Port:       9153,
 					TargetPort: intstr.FromInt32(9153),
 				},
@@ -332,7 +332,7 @@ func (s *SharedAgent) dnsService(ctx context.Context) error {
 }
 
 func (s *SharedAgent) serviceAccount(ctx context.Context) error {
-	svcAccount := &v1.ServiceAccount{
+	svcAccount := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceAccount",
 			APIVersion: "v1",

--- a/pkg/controller/cluster/agent/shared_test.go
+++ b/pkg/controller/cluster/agent/shared_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
@@ -29,7 +29,7 @@ func Test_sharedAgentData(t *testing.T) {
 			name: "simple config",
 			args: args{
 				cluster: &v1beta1.Cluster{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mycluster",
 						Namespace: "ns-1",
 					},
@@ -57,7 +57,7 @@ func Test_sharedAgentData(t *testing.T) {
 			name: "version in status",
 			args: args{
 				cluster: &v1beta1.Cluster{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mycluster",
 						Namespace: "ns-1",
 					},
@@ -88,7 +88,7 @@ func Test_sharedAgentData(t *testing.T) {
 			name: "missing version in spec",
 			args: args{
 				cluster: &v1beta1.Cluster{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mycluster",
 						Namespace: "ns-1",
 					},

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -7,8 +7,8 @@ import (
 
 	"k8s.io/utils/ptr"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,7 +65,7 @@ func (v *VirtualAgent) ensureObject(ctx context.Context, obj ctrlruntimeclient.O
 func (v *VirtualAgent) config(ctx context.Context) error {
 	config := virtualAgentData(v.serviceIP, v.token)
 
-	configSecret := &v1.Secret{
+	configSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -110,7 +110,7 @@ func (v *VirtualAgent) deployment(ctx context.Context) error {
 		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, volMounts...)
 	}
 
-	deployment := &apps.Deployment{
+	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
@@ -120,10 +120,10 @@ func (v *VirtualAgent) deployment(ctx context.Context) error {
 			Namespace: v.cluster.Namespace,
 			Labels:    selector.MatchLabels,
 		},
-		Spec: apps.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: v.cluster.Spec.Agents,
 			Selector: &selector,
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: selector.MatchLabels,
 				},
@@ -135,10 +135,10 @@ func (v *VirtualAgent) deployment(ctx context.Context) error {
 	return v.ensureObject(ctx, deployment)
 }
 
-func (v *VirtualAgent) podSpec(ctx context.Context, image, name string) v1.PodSpec {
+func (v *VirtualAgent) podSpec(ctx context.Context, image, name string) corev1.PodSpec {
 	log := ctrl.LoggerFrom(ctx)
 
-	var limit v1.ResourceList
+	var limit corev1.ResourceList
 
 	args := v.cluster.Spec.AgentArgs
 	args = append([]string{"agent", "--config", "/opt/rancher/k3s/config.yaml"}, args...)
@@ -150,16 +150,16 @@ func (v *VirtualAgent) podSpec(ctx context.Context, image, name string) v1.PodSp
 		agentAffinity = v.cluster.Status.Policy.AgentAffinity
 	}
 
-	podSpec := v1.PodSpec{
+	podSpec := corev1.PodSpec{
 		Affinity:     agentAffinity,
 		NodeSelector: v.cluster.Spec.NodeSelector,
-		Volumes: []v1.Volume{
+		Volumes: []corev1.Volume{
 			{
 				Name: "config",
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: configSecretName(v.cluster.Name),
-						Items: []v1.KeyToPath{
+						Items: []corev1.KeyToPath{
 							{
 								Key:  "config.yaml",
 								Path: "config.yaml",
@@ -170,58 +170,58 @@ func (v *VirtualAgent) podSpec(ctx context.Context, image, name string) v1.PodSp
 			},
 			{
 				Name: "run",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varrun",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlibcni",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlog",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlibkubelet",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlibrancherk3s",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 		},
-		Containers: []v1.Container{
+		Containers: []corev1.Container{
 			{
 				Name:            name,
 				Image:           image,
-				ImagePullPolicy: v1.PullPolicy(v.ImagePullPolicy),
-				SecurityContext: &v1.SecurityContext{
+				ImagePullPolicy: corev1.PullPolicy(v.ImagePullPolicy),
+				SecurityContext: &corev1.SecurityContext{
 					Privileged: ptr.To(true),
 				},
 				Args: args,
 				Command: []string{
 					"/bin/k3s",
 				},
-				Resources: v1.ResourceRequirements{
+				Resources: corev1.ResourceRequirements{
 					Limits: limit,
 				},
 				Env: v.cluster.Spec.AgentEnvs,
-				VolumeMounts: []v1.VolumeMount{
+				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "config",
 						MountPath: "/opt/rancher/k3s/",
@@ -264,13 +264,13 @@ func (v *VirtualAgent) podSpec(ctx context.Context, image, name string) v1.PodSp
 
 	// specify resource limits if specified for the servers.
 	if v.cluster.Spec.WorkerLimit != nil {
-		podSpec.Containers[0].Resources = v1.ResourceRequirements{
+		podSpec.Containers[0].Resources = corev1.ResourceRequirements{
 			Limits: v.cluster.Spec.WorkerLimit,
 		}
 	}
 
 	for _, imagePullSecret := range v.imagePullSecrets {
-		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, v1.LocalObjectReference{Name: imagePullSecret})
+		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{Name: imagePullSecret})
 	}
 
 	securityContext := v.cluster.Spec.SecurityContext

--- a/pkg/controller/cluster/client.go
+++ b/pkg/controller/cluster/client.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rancher/k3k/pkg/controller"
@@ -15,7 +15,7 @@ import (
 
 // newVirtualClient creates a new Client that can be used to interact with the virtual cluster
 func newVirtualClient(ctx context.Context, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace string) (ctrlruntimeclient.Client, error) {
-	var clusterKubeConfig v1.Secret
+	var clusterKubeConfig corev1.Secret
 
 	kubeconfigSecretName := types.NamespacedName{
 		Name:      controller.SafeConcatNameWithPrefix(clusterName, "kubeconfig"),

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -154,12 +154,12 @@ func Add(ctx context.Context, mgr manager.Manager, config *Config, maxConcurrent
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.Cluster{}).
-		Watches(&v1.Namespace{}, namespaceEventHandler(&reconciler)).
+		Watches(&corev1.Namespace{}, namespaceEventHandler(&reconciler)).
 		Watches(&storagev1.StorageClass{},
 			handler.EnqueueRequestsFromMapFunc(reconciler.mapStorageClassToCluster),
 		).
-		Owns(&apps.StatefulSet{}).
-		Owns(&v1.Service{}).
+		Owns(&appsv1.StatefulSet{}).
+		Owns(&corev1.Service{}).
 		WithOptions(ctrlcontroller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(&reconciler)
 }
@@ -207,8 +207,8 @@ func namespaceEventHandler(r *ClusterReconciler) handler.Funcs {
 		DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {},
 		// When a Namespace is updated, if it has the "policy.k3k.io/policy-name" label
 		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			oldNs, okOld := e.ObjectOld.(*v1.Namespace)
-			newNs, okNew := e.ObjectNew.(*v1.Namespace)
+			oldNs, okOld := e.ObjectOld.(*corev1.Namespace)
+			newNs, okNew := e.ObjectNew.(*corev1.Namespace)
 
 			if !okOld || !okNew {
 				return
@@ -323,7 +323,7 @@ func (c *ClusterReconciler) reconcileCluster(ctx context.Context, cluster *v1bet
 func (c *ClusterReconciler) reconcile(ctx context.Context, cluster *v1beta1.Cluster) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	var ns v1.Namespace
+	var ns corev1.Namespace
 	if err := c.Client.Get(ctx, client.ObjectKey{Name: cluster.Namespace}, &ns); err != nil {
 		return err
 	}
@@ -454,7 +454,7 @@ func (c *ClusterReconciler) ensureBootstrapSecret(ctx context.Context, cluster *
 		return err
 	}
 
-	bootstrapSecret := &v1.Secret{
+	bootstrapSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controller.SafeConcatNameWithPrefix(cluster.Name, "bootstrap"),
 			Namespace: cluster.Namespace,
@@ -493,7 +493,7 @@ func (c *ClusterReconciler) ensureKubeconfigSecret(ctx context.Context, cluster 
 		return err
 	}
 
-	kubeconfigSecret := &v1.Secret{
+	kubeconfigSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controller.SafeConcatNameWithPrefix(cluster.Name, "kubeconfig"),
 			Namespace: cluster.Namespace,
@@ -651,7 +651,7 @@ func (c *ClusterReconciler) ensureNetworkPolicy(ctx context.Context, cluster *v1
 	return nil
 }
 
-func (c *ClusterReconciler) ensureClusterService(ctx context.Context, cluster *v1beta1.Cluster) (*v1.Service, error) {
+func (c *ClusterReconciler) ensureClusterService(ctx context.Context, cluster *v1beta1.Cluster) (*corev1.Service, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Ensuring Cluster Service")
 
@@ -957,9 +957,9 @@ func (c *ClusterReconciler) lookupServiceCIDR(ctx context.Context) (string, erro
 
 	log.V(1).Info("Looking up Service CIDR from a failing service creation")
 
-	failingSvc := v1.Service{
+	failingSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "fail", Namespace: "default"},
-		Spec:       v1.ServiceSpec{ClusterIP: "1.1.1.1"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "1.1.1.1"},
 	}
 
 	if err := c.Client.Create(ctx, &failingSvc); err != nil {
@@ -990,7 +990,7 @@ func (c *ClusterReconciler) lookupServiceCIDR(ctx context.Context) (string, erro
 	listOpts := &client.ListOptions{Namespace: "kube-system"}
 	matchingLabels.ApplyToList(listOpts)
 
-	var podList v1.PodList
+	var podList corev1.PodList
 	if err := c.Client.List(ctx, &podList, listOpts); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return "", err

--- a/pkg/controller/cluster/mounts/mounts.go
+++ b/pkg/controller/cluster/mounts/mounts.go
@@ -1,15 +1,15 @@
 package mounts
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
 
-func BuildSecretsMountsVolumes(secretMounts []v1beta1.SecretMount, role string) ([]v1.Volume, []v1.VolumeMount) {
+func BuildSecretsMountsVolumes(secretMounts []v1beta1.SecretMount, role string) ([]corev1.Volume, []corev1.VolumeMount) {
 	var (
-		vols      []v1.Volume
-		volMounts []v1.VolumeMount
+		vols      []corev1.Volume
+		volMounts []corev1.VolumeMount
 	)
 
 	for _, secretMount := range secretMounts {
@@ -28,11 +28,11 @@ func BuildSecretsMountsVolumes(secretMounts []v1beta1.SecretMount, role string) 
 	return vols, volMounts
 }
 
-func buildSecretMountVolume(secretMount v1beta1.SecretMount) (v1.Volume, v1.VolumeMount) {
-	projectedVolSources := []v1.VolumeProjection{
+func buildSecretMountVolume(secretMount v1beta1.SecretMount) (corev1.Volume, corev1.VolumeMount) {
+	projectedVolSources := []corev1.VolumeProjection{
 		{
-			Secret: &v1.SecretProjection{
-				LocalObjectReference: v1.LocalObjectReference{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretMount.SecretName,
 				},
 				Items:    secretMount.Items,
@@ -41,16 +41,16 @@ func buildSecretMountVolume(secretMount v1beta1.SecretMount) (v1.Volume, v1.Volu
 		},
 	}
 
-	vol := v1.Volume{
+	vol := corev1.Volume{
 		Name: secretMount.SecretName,
-		VolumeSource: v1.VolumeSource{
-			Projected: &v1.ProjectedVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
 				Sources: projectedVolSources,
 			},
 		},
 	}
 
-	volMount := v1.VolumeMount{
+	volMount := corev1.VolumeMount{
 		Name:      secretMount.SecretName,
 		MountPath: secretMount.MountPath,
 		SubPath:   secretMount.SubPath,

--- a/pkg/controller/cluster/mounts/mounts_test.go
+++ b/pkg/controller/cluster/mounts/mounts_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
@@ -17,8 +17,8 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 	}
 
 	type expectedVolumes struct {
-		vols      []v1.Volume
-		volMounts []v1.VolumeMount
+		vols      []corev1.Volume
+		volMounts []corev1.VolumeMount
 	}
 
 	tests := []struct {
@@ -53,7 +53,7 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
 						},
 						MountPath: "/mount-dir-1",
@@ -62,10 +62,10 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("secret-1", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-1", "/mount-dir-1", ""),
 				},
 			},
@@ -75,13 +75,13 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
 						},
 						MountPath: "/mount-dir-1",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-2",
 						},
 						MountPath: "/mount-dir-2",
@@ -90,11 +90,11 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("secret-1", nil),
 					expectedVolume("secret-2", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-1", "/mount-dir-1", ""),
 					expectedVolumeMount("secret-2", "/mount-dir-2", ""),
 				},
@@ -105,9 +105,9 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
-							Items: []v1.KeyToPath{
+							Items: []corev1.KeyToPath{
 								{
 									Key:  "key-1",
 									Path: "path-1",
@@ -120,10 +120,10 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
-					expectedVolume("secret-1", []v1.KeyToPath{{Key: "key-1", Path: "path-1"}}),
+				vols: []corev1.Volume{
+					expectedVolume("secret-1", []corev1.KeyToPath{{Key: "key-1", Path: "path-1"}}),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-1", "/mount-dir-1", ""),
 				},
 			},
@@ -133,9 +133,9 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
-							Items: []v1.KeyToPath{
+							Items: []corev1.KeyToPath{
 								{
 									Key:  "key-1",
 									Path: "path-1",
@@ -145,9 +145,9 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 						MountPath: "/mount-dir-1",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-2",
-							Items: []v1.KeyToPath{
+							Items: []corev1.KeyToPath{
 								{
 									Key:  "key-2",
 									Path: "path-2",
@@ -160,11 +160,11 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
-					expectedVolume("secret-1", []v1.KeyToPath{{Key: "key-1", Path: "path-1"}}),
-					expectedVolume("secret-2", []v1.KeyToPath{{Key: "key-2", Path: "path-2"}}),
+				vols: []corev1.Volume{
+					expectedVolume("secret-1", []corev1.KeyToPath{{Key: "key-1", Path: "path-1"}}),
+					expectedVolume("secret-2", []corev1.KeyToPath{{Key: "key-2", Path: "path-2"}}),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-1", "/mount-dir-1", ""),
 					expectedVolumeMount("secret-2", "/mount-dir-2", ""),
 				},
@@ -175,19 +175,19 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "z-secret",
 						},
 						MountPath: "/z",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "a-secret",
 						},
 						MountPath: "/a",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "m-secret",
 						},
 						MountPath: "/m",
@@ -196,12 +196,12 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("z-secret", nil),
 					expectedVolume("a-secret", nil),
 					expectedVolume("m-secret", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("z-secret", "/z", ""),
 					expectedVolumeMount("a-secret", "/a", ""),
 					expectedVolumeMount("m-secret", "/m", ""),
@@ -216,7 +216,7 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 						MountPath: "/mount-dir-1",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-2",
 						},
 						MountPath: "/mount-dir-2",
@@ -225,10 +225,10 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("secret-2", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-2", "/mount-dir-2", ""),
 				},
 			},
@@ -238,13 +238,13 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
 						},
 						MountPath: "",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-2",
 						},
 						MountPath: "/mount-dir-2",
@@ -253,10 +253,10 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("secret-2", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-2", "/mount-dir-2", ""),
 				},
 			},
@@ -266,7 +266,7 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
 						},
 						MountPath: "/etc/rancher/k3s/registries.yaml",
@@ -276,10 +276,10 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("secret-1", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-1", "/etc/rancher/k3s/registries.yaml", "registries.yaml"),
 				},
 			},
@@ -290,21 +290,21 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "server-secret",
 						},
 						MountPath: "/server",
 						Role:      "server",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "agent-secret",
 						},
 						MountPath: "/agent",
 						Role:      "agent",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "all-secret",
 						},
 						MountPath: "/all",
@@ -314,11 +314,11 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("server-secret", nil),
 					expectedVolume("all-secret", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("server-secret", "/server", ""),
 					expectedVolumeMount("all-secret", "/all", ""),
 				},
@@ -329,21 +329,21 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "server-secret",
 						},
 						MountPath: "/server",
 						Role:      "server",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "agent-secret",
 						},
 						MountPath: "/agent",
 						Role:      "agent",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "all-secret",
 						},
 						MountPath: "/all",
@@ -353,11 +353,11 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "agent",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("agent-secret", nil),
 					expectedVolume("all-secret", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("agent-secret", "/agent", ""),
 					expectedVolumeMount("all-secret", "/all", ""),
 				},
@@ -368,14 +368,14 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "no-role-secret",
 						},
 						MountPath: "/no-role",
 						Role:      "",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "server-secret",
 						},
 						MountPath: "/server",
@@ -385,10 +385,10 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "agent",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("no-role-secret", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("no-role-secret", "/no-role", ""),
 				},
 			},
@@ -398,7 +398,7 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "registry-config",
 						},
 						MountPath: "/etc/rancher/k3s/registries.yaml",
@@ -406,14 +406,14 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 						Role:      "all",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "server-config",
 						},
 						MountPath: "/etc/server",
 						Role:      "server",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "agent-config",
 						},
 						MountPath: "/etc/agent",
@@ -423,11 +423,11 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("registry-config", nil),
 					expectedVolume("server-config", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("registry-config", "/etc/rancher/k3s/registries.yaml", "registries.yaml"),
 					expectedVolumeMount("server-config", "/etc/server", ""),
 				},
@@ -438,14 +438,14 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-1",
 						},
 						MountPath: "/secret-1",
 						Role:      "all",
 					},
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "secret-2",
 						},
 						MountPath: "/secret-2",
@@ -455,11 +455,11 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 				role: "server",
 			},
 			expectedData: expectedVolumes{
-				vols: []v1.Volume{
+				vols: []corev1.Volume{
 					expectedVolume("secret-1", nil),
 					expectedVolume("secret-2", nil),
 				},
-				volMounts: []v1.VolumeMount{
+				volMounts: []corev1.VolumeMount{
 					expectedVolumeMount("secret-1", "/secret-1", ""),
 					expectedVolumeMount("secret-2", "/secret-2", ""),
 				},
@@ -470,7 +470,7 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 			args: args{
 				secretMounts: []v1beta1.SecretMount{
 					{
-						SecretVolumeSource: v1.SecretVolumeSource{
+						SecretVolumeSource: corev1.SecretVolumeSource{
 							SecretName: "server-only",
 						},
 						MountPath: "/server-only",
@@ -496,14 +496,14 @@ func Test_BuildSecretMountsVolume(t *testing.T) {
 	}
 }
 
-func expectedVolume(name string, items []v1.KeyToPath) v1.Volume {
-	return v1.Volume{
+func expectedVolume(name string, items []corev1.KeyToPath) corev1.Volume {
+	return corev1.Volume{
 		Name: name,
-		VolumeSource: v1.VolumeSource{
-			Projected: &v1.ProjectedVolumeSource{
-				Sources: []v1.VolumeProjection{
-					{Secret: &v1.SecretProjection{
-						LocalObjectReference: v1.LocalObjectReference{
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: name,
 						},
 						Items: items,
@@ -514,8 +514,8 @@ func expectedVolume(name string, items []v1.KeyToPath) v1.Volume {
 	}
 }
 
-func expectedVolumeMount(name, mountPath, subPath string) v1.VolumeMount {
-	return v1.VolumeMount{
+func expectedVolumeMount(name, mountPath, subPath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
 		Name:      name,
 		MountPath: mountPath,
 		SubPath:   subPath,

--- a/pkg/controller/cluster/pod.go
+++ b/pkg/controller/cluster/pod.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +34,7 @@ func AddPodController(ctx context.Context, mgr manager.Manager, maxConcurrentRec
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1.Pod{}).
+		For(&corev1.Pod{}).
 		Named(podController).
 		WithEventFilter(newClusterPredicate()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
@@ -45,7 +45,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling Pod")
 
-	var pod v1.Pod
+	var pod corev1.Pod
 	if err := r.Client.Get(ctx, req.NamespacedName, &pod); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
@@ -62,7 +62,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		virtName := pod.GetAnnotations()[translate.ResourceNameAnnotation]
 		virtNamespace := pod.GetAnnotations()[translate.ResourceNamespaceAnnotation]
 
-		virtPod := v1.Pod{
+		virtPod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      virtName,
 				Namespace: virtNamespace,

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
@@ -168,7 +168,7 @@ func GetFromSecret(ctx context.Context, client client.Client, cluster *v1beta1.C
 		Namespace: cluster.Namespace,
 	}
 
-	var bootstrapSecret v1.Secret
+	var bootstrapSecret corev1.Secret
 	if err := client.Get(ctx, key, &bootstrapSecret); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/cluster/server/config.go
+++ b/pkg/controller/cluster/server/config.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
@@ -13,7 +13,7 @@ import (
 	"github.com/rancher/k3k/pkg/controller/cluster/agent"
 )
 
-func (s *Server) Config(init bool, serviceIP string) (*v1.Secret, error) {
+func (s *Server) Config(init bool, serviceIP string) (*corev1.Secret, error) {
 	name := configSecretName(s.cluster.Name, init)
 
 	sans := sets.NewString(s.cluster.Spec.TLSSANs...)
@@ -30,7 +30,7 @@ func (s *Server) Config(init bool, serviceIP string) (*v1.Secret, error) {
 		config = initConfigData(s.cluster, s.token)
 	}
 
-	return &v1.Secret{
+	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -54,7 +54,7 @@ func New(cluster *v1beta1.Cluster, client client.Client, token, image, imagePull
 	}
 }
 
-func (s *Server) podSpec(ctx context.Context, image, name string, persistent bool, startupCmd string) v1.PodSpec {
+func (s *Server) podSpec(ctx context.Context, image, name string, persistent bool, startupCmd string) corev1.PodSpec {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Use the server affinity from the policy status if it exists, otherwise fall back to the spec.
@@ -64,17 +64,17 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 		serverAffinity = s.cluster.Status.Policy.ServerAffinity
 	}
 
-	podSpec := v1.PodSpec{
+	podSpec := corev1.PodSpec{
 		Affinity:          serverAffinity,
 		NodeSelector:      s.cluster.Spec.NodeSelector,
 		PriorityClassName: s.cluster.Spec.PriorityClass,
-		Volumes: []v1.Volume{
+		Volumes: []corev1.Volume{
 			{
 				Name: "initconfig",
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: configSecretName(s.cluster.Name, true),
-						Items: []v1.KeyToPath{
+						Items: []corev1.KeyToPath{
 							{
 								Key:  "config.yaml",
 								Path: "config.yaml",
@@ -85,10 +85,10 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 			},
 			{
 				Name: "config",
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: configSecretName(s.cluster.Name, false),
-						Items: []v1.KeyToPath{
+						Items: []corev1.KeyToPath{
 							{
 								Key:  "config.yaml",
 								Path: "config.yaml",
@@ -99,59 +99,59 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 			},
 			{
 				Name: "run",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varrun",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlibcni",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlog",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 			{
 				Name: "varlibkubelet",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 		},
-		Containers: []v1.Container{
+		Containers: []corev1.Container{
 			{
 				Name:            name,
 				Image:           image,
-				ImagePullPolicy: v1.PullPolicy(s.imagePullPolicy),
-				Env: []v1.EnvVar{
+				ImagePullPolicy: corev1.PullPolicy(s.imagePullPolicy),
+				Env: []corev1.EnvVar{
 					{
 						Name: "POD_NAME",
-						ValueFrom: &v1.EnvVarSource{
-							FieldRef: &v1.ObjectFieldSelector{
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
 								FieldPath: "metadata.name",
 							},
 						},
 					},
 					{
 						Name: "POD_IP",
-						ValueFrom: &v1.EnvVarSource{
-							FieldRef: &v1.ObjectFieldSelector{
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
 								FieldPath: "status.podIP",
 							},
 						},
 					},
 				},
-				VolumeMounts: []v1.VolumeMount{
+				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "config",
 						MountPath: "/opt/rancher/k3s/server",
@@ -205,32 +205,32 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 
 	podSpec.Containers[0].Command = cmd
 	if !persistent {
-		podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: "varlibrancherk3s",
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 		)
 	}
 
 	// Adding readiness probes to statefulset
-	podSpec.Containers[0].ReadinessProbe = &v1.Probe{
+	podSpec.Containers[0].ReadinessProbe = &corev1.Probe{
 		InitialDelaySeconds: 60,
 		FailureThreshold:    5,
 		TimeoutSeconds:      10,
-		ProbeHandler: v1.ProbeHandler{
-			TCPSocket: &v1.TCPSocketAction{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
 				Port: intstr.FromInt(6443),
 			},
 		},
 	}
-	podSpec.Containers[0].LivenessProbe = &v1.Probe{
+	podSpec.Containers[0].LivenessProbe = &corev1.Probe{
 		InitialDelaySeconds: 10,
 		FailureThreshold:    3,
 		PeriodSeconds:       3,
-		ProbeHandler: v1.ProbeHandler{
-			Exec: &v1.ExecAction{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
 				Command: []string{
 					"sh",
 					"-c",
@@ -241,7 +241,7 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 	}
 	// start the pod unprivileged in shared mode
 	if s.mode == agent.VirtualNodeMode {
-		podSpec.Containers[0].SecurityContext = &v1.SecurityContext{
+		podSpec.Containers[0].SecurityContext = &corev1.SecurityContext{
 			Privileged: ptr.To(true),
 		}
 	}
@@ -266,7 +266,7 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 
 	// specify resource limits if specified for the servers.
 	if s.cluster.Spec.ServerLimit != nil {
-		podSpec.Containers[0].Resources = v1.ResourceRequirements{
+		podSpec.Containers[0].Resources = corev1.ResourceRequirements{
 			Limits: s.cluster.Spec.ServerLimit,
 		}
 	}
@@ -275,16 +275,16 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 
 	// add image pull secrets
 	for _, imagePullSecret := range s.imagePullSecrets {
-		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, v1.LocalObjectReference{Name: imagePullSecret})
+		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{Name: imagePullSecret})
 	}
 
 	return podSpec
 }
 
-func (s *Server) StatefulServer(ctx context.Context) (*apps.StatefulSet, error) {
+func (s *Server) StatefulServer(ctx context.Context) (*appsv1.StatefulSet, error) {
 	var (
 		replicas   int32
-		pvClaim    v1.PersistentVolumeClaim
+		pvClaim    corev1.PersistentVolumeClaim
 		err        error
 		persistent bool
 	)
@@ -304,8 +304,8 @@ func (s *Server) StatefulServer(ctx context.Context) (*apps.StatefulSet, error) 
 	}
 
 	var (
-		volumes      []v1.Volume
-		volumeMounts []v1.VolumeMount
+		volumes      []corev1.Volume
+		volumeMounts []corev1.VolumeMount
 	)
 
 	if len(s.cluster.Spec.Addons) > 0 {
@@ -354,7 +354,7 @@ func (s *Server) StatefulServer(ctx context.Context) (*apps.StatefulSet, error) 
 	podSpec.Volumes = append(podSpec.Volumes, volumes...)
 	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, volumeMounts...)
 
-	ss := &apps.StatefulSet{
+	ss := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
 			APIVersion: "apps/v1",
@@ -364,11 +364,11 @@ func (s *Server) StatefulServer(ctx context.Context) (*apps.StatefulSet, error) 
 			Namespace: s.cluster.Namespace,
 			Labels:    selector.MatchLabels,
 		},
-		Spec: apps.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas:    &replicas,
 			ServiceName: headlessServiceName(s.cluster.Name),
 			Selector:    &selector,
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: selector.MatchLabels,
 				},
@@ -377,14 +377,14 @@ func (s *Server) StatefulServer(ctx context.Context) (*apps.StatefulSet, error) 
 		},
 	}
 	if s.cluster.Spec.Persistence.Type == v1beta1.DynamicPersistenceMode {
-		ss.Spec.VolumeClaimTemplates = []v1.PersistentVolumeClaim{pvClaim}
+		ss.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{pvClaim}
 	}
 
 	return ss, nil
 }
 
-func (s *Server) setupDynamicPersistence() v1.PersistentVolumeClaim {
-	return v1.PersistentVolumeClaim{
+func (s *Server) setupDynamicPersistence() corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
 			APIVersion: "v1",
@@ -393,11 +393,11 @@ func (s *Server) setupDynamicPersistence() v1.PersistentVolumeClaim {
 			Name:      "varlibrancherk3s",
 			Namespace: s.cluster.Namespace,
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			StorageClassName: s.cluster.Spec.Persistence.StorageClassName,
-			Resources: v1.VolumeResourceRequirements{
-				Requests: v1.ResourceList{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
 					"storage": *s.cluster.Spec.Persistence.StorageRequestSize,
 				},
 			},
@@ -434,7 +434,7 @@ func (s *Server) setupStartCommand() (string, error) {
 	return output.String(), nil
 }
 
-func (s *Server) buildCABundleVolumes(ctx context.Context) ([]v1.Volume, []v1.VolumeMount, error) {
+func (s *Server) buildCABundleVolumes(ctx context.Context) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	if s.cluster.Spec.CustomCAs == nil {
 		return nil, nil, fmt.Errorf("customCAs not found")
 	}
@@ -450,13 +450,13 @@ func (s *Server) buildCABundleVolumes(ctx context.Context) ([]v1.Volume, []v1.Vo
 	}
 
 	var (
-		volumes       []v1.Volume
-		mounts        []v1.VolumeMount
+		volumes       []corev1.Volume
+		mounts        []corev1.VolumeMount
 		sortedCertIDs = sortedKeys(caCertMap)
 	)
 
 	for _, certName := range sortedCertIDs {
-		var certSecret v1.Secret
+		var certSecret corev1.Secret
 
 		secretName := string(caCertMap[certName])
 		key := types.NamespacedName{Name: secretName, Namespace: s.cluster.Namespace}
@@ -483,18 +483,18 @@ func (s *Server) buildCABundleVolumes(ctx context.Context) ([]v1.Volume, []v1.Vo
 	return volumes, mounts, nil
 }
 
-func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMount string) (*v1.Volume, []v1.VolumeMount) {
+func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMount string) (*corev1.Volume, []corev1.VolumeMount) {
 	var (
-		volume *v1.Volume
-		mounts []v1.VolumeMount
+		volume *corev1.Volume
+		mounts []corev1.VolumeMount
 	)
 
 	// avoid re-adding secretName in case of combined secret
 
-	volume = &v1.Volume{
+	volume = &corev1.Volume{
 		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{SecretName: secretName},
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: secretName},
 		},
 	}
 
@@ -509,7 +509,7 @@ func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMou
 
 	// add the mount for the cert except for the service account token
 	if certName != "service" {
-		mounts = append(mounts, v1.VolumeMount{
+		mounts = append(mounts, corev1.VolumeMount{
 			Name:      volumeName,
 			MountPath: fmt.Sprintf("/var/lib/rancher/k3s/server/tls%s/%s.crt", etcdPrefix, mountFile),
 			SubPath:   subPathMount + ".crt",
@@ -517,7 +517,7 @@ func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMou
 	}
 
 	// add the mount for the key
-	mounts = append(mounts, v1.VolumeMount{
+	mounts = append(mounts, corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: fmt.Sprintf("/var/lib/rancher/k3s/server/tls%s/%s.key", etcdPrefix, mountFile),
 		SubPath:   subPathMount + ".key",
@@ -526,10 +526,10 @@ func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMou
 	return volume, mounts
 }
 
-func (s *Server) buildAddonsVolumes(ctx context.Context) ([]v1.Volume, []v1.VolumeMount, error) {
+func (s *Server) buildAddonsVolumes(ctx context.Context) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	var (
-		volumes []v1.Volume
-		mounts  []v1.VolumeMount
+		volumes []corev1.Volume
+		mounts  []corev1.VolumeMount
 	)
 
 	for _, addon := range s.cluster.Spec.Addons {
@@ -543,14 +543,14 @@ func (s *Server) buildAddonsVolumes(ctx context.Context) ([]v1.Volume, []v1.Volu
 			Namespace: namespace,
 		}
 
-		var addons v1.Secret
+		var addons corev1.Secret
 		if err := s.client.Get(ctx, nn, &addons); err != nil {
 			return nil, nil, err
 		}
 
 		// skip creating the addon secret if it already exists and in the same namespace as the cluster
 		if namespace != s.cluster.Namespace {
-			clusterAddons := v1.Secret{
+			clusterAddons := corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Secret",
 					APIVersion: "v1",
@@ -570,17 +570,17 @@ func (s *Server) buildAddonsVolumes(ctx context.Context) ([]v1.Volume, []v1.Volu
 		}
 
 		name := "addon-" + addon.SecretRef
-		volume := v1.Volume{
+		volume := corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: addon.SecretRef,
 				},
 			},
 		}
 		volumes = append(volumes, volume)
 
-		volumeMount := v1.VolumeMount{
+		volumeMount := corev1.VolumeMount{
 			Name:      name,
 			MountPath: "/var/lib/rancher/k3s/server/manifests/" + addon.SecretRef,
 			ReadOnly:  true,

--- a/pkg/controller/cluster/server/service.go
+++ b/pkg/controller/cluster/server/service.go
@@ -3,15 +3,15 @@ package server
 import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
 )
 
-func Service(cluster *v1beta1.Cluster) *v1.Service {
-	service := &v1.Service{
+func Service(cluster *v1beta1.Cluster) *corev1.Service {
+	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
@@ -20,7 +20,7 @@ func Service(cluster *v1beta1.Cluster) *v1.Service {
 			Name:      ServiceName(cluster.Name),
 			Namespace: cluster.Namespace,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				"cluster": cluster.Name,
 				"role":    "server",
@@ -28,22 +28,22 @@ func Service(cluster *v1beta1.Cluster) *v1.Service {
 		},
 	}
 
-	k3sServerPort := v1.ServicePort{
+	k3sServerPort := corev1.ServicePort{
 		Name:       "k3s-server-port",
-		Protocol:   v1.ProtocolTCP,
+		Protocol:   corev1.ProtocolTCP,
 		Port:       httpsPort,
 		TargetPort: intstr.FromInt(k3sServerPort),
 	}
 
-	etcdPort := v1.ServicePort{
+	etcdPort := corev1.ServicePort{
 		Name:     "k3s-etcd-port",
-		Protocol: v1.ProtocolTCP,
+		Protocol: corev1.ProtocolTCP,
 		Port:     etcdPort,
 	}
 
 	// If no expose is specified, default to ClusterIP
 	if cluster.Spec.Expose == nil {
-		service.Spec.Type = v1.ServiceTypeClusterIP
+		service.Spec.Type = corev1.ServiceTypeClusterIP
 		service.Spec.Ports = append(service.Spec.Ports, k3sServerPort, etcdPort)
 	}
 
@@ -53,14 +53,14 @@ func Service(cluster *v1beta1.Cluster) *v1.Service {
 
 		switch {
 		case expose.LoadBalancer != nil:
-			service.Spec.Type = v1.ServiceTypeLoadBalancer
+			service.Spec.Type = corev1.ServiceTypeLoadBalancer
 			addLoadBalancerPorts(service, *expose.LoadBalancer, k3sServerPort, etcdPort)
 		case expose.NodePort != nil:
-			service.Spec.Type = v1.ServiceTypeNodePort
+			service.Spec.Type = corev1.ServiceTypeNodePort
 			addNodePortPorts(service, *expose.NodePort, k3sServerPort, etcdPort)
 		default:
 			// default to clusterIP for ingress or empty expose config
-			service.Spec.Type = v1.ServiceTypeClusterIP
+			service.Spec.Type = corev1.ServiceTypeClusterIP
 			service.Spec.Ports = append(service.Spec.Ports, k3sServerPort, etcdPort)
 		}
 	}
@@ -69,7 +69,7 @@ func Service(cluster *v1beta1.Cluster) *v1.Service {
 }
 
 // addLoadBalancerPorts adds the load balancer ports to the service
-func addLoadBalancerPorts(service *v1.Service, loadbalancerConfig v1beta1.LoadBalancerConfig, k3sServerPort, etcdPort v1.ServicePort) {
+func addLoadBalancerPorts(service *corev1.Service, loadbalancerConfig v1beta1.LoadBalancerConfig, k3sServerPort, etcdPort corev1.ServicePort) {
 	// If the server port is not specified, use the default port
 	if loadbalancerConfig.ServerPort == nil {
 		service.Spec.Ports = append(service.Spec.Ports, k3sServerPort)
@@ -90,7 +90,7 @@ func addLoadBalancerPorts(service *v1.Service, loadbalancerConfig v1beta1.LoadBa
 }
 
 // addNodePortPorts adds the node port ports to the service
-func addNodePortPorts(service *v1.Service, nodePortConfig v1beta1.NodePortConfig, k3sServerPort, etcdPort v1.ServicePort) {
+func addNodePortPorts(service *corev1.Service, nodePortConfig v1beta1.NodePortConfig, k3sServerPort, etcdPort corev1.ServicePort) {
 	// If the server port is not specified Kubernetes will set the node port to a random port between 30000-32767
 	if nodePortConfig.ServerPort == nil {
 		service.Spec.Ports = append(service.Spec.Ports, k3sServerPort)
@@ -120,8 +120,8 @@ func addNodePortPorts(service *v1.Service, nodePortConfig v1beta1.NodePortConfig
 	}
 }
 
-func (s *Server) StatefulServerService() *v1.Service {
-	return &v1.Service{
+func (s *Server) StatefulServerService() *corev1.Service {
+	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
@@ -130,23 +130,23 @@ func (s *Server) StatefulServerService() *v1.Service {
 			Name:      headlessServiceName(s.cluster.Name),
 			Namespace: s.cluster.Namespace,
 		},
-		Spec: v1.ServiceSpec{
-			Type:      v1.ServiceTypeClusterIP,
-			ClusterIP: v1.ClusterIPNone,
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
 			Selector: map[string]string{
 				"cluster": s.cluster.Name,
 				"role":    "server",
 			},
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "k3s-server-port",
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 					Port:       httpsPort,
 					TargetPort: intstr.FromInt(k3sServerPort),
 				},
 				{
 					Name:     "k3s-etcd-port",
-					Protocol: v1.ProtocolTCP,
+					Protocol: corev1.ProtocolTCP,
 					Port:     etcdPort,
 				},
 			},

--- a/pkg/controller/cluster/service.go
+++ b/pkg/controller/cluster/service.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,7 +32,7 @@ func AddServiceController(ctx context.Context, mgr manager.Manager, maxConcurren
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(serviceController).
-		For(&v1.Service{}).
+		For(&corev1.Service{}).
 		WithEventFilter(newClusterPredicate()).
 		Complete(&reconciler)
 }
@@ -41,7 +41,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling Service")
 
-	var hostService v1.Service
+	var hostService corev1.Service
 	if err := r.HostClient.Get(ctx, req.NamespacedName, &hostService); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
 	}
@@ -74,7 +74,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		Namespace: virtualServiceNamespace,
 	}
 
-	var virtualService v1.Service
+	var virtualService corev1.Service
 	if err := virtualClient.Get(ctx, virtualServiceKey, &virtualService); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get virtual service: %v", err)
 	}

--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -20,8 +20,8 @@ import (
 
 	certutil "github.com/rancher/dynamiclistener/cert"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,9 +53,9 @@ func AddStatefulSetController(ctx context.Context, mgr manager.Manager, maxConcu
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&apps.StatefulSet{}).
+		For(&appsv1.StatefulSet{}).
 		WithEventFilter(newClusterPredicate()).
-		Owns(&v1.Pod{}).
+		Owns(&corev1.Pod{}).
 		Named(statefulsetController).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(&reconciler)
@@ -65,7 +65,7 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Reconciling StatefulSet")
 
-	var sts apps.StatefulSet
+	var sts appsv1.StatefulSet
 	if err := p.Client.Get(ctx, req.NamespacedName, &sts); err != nil {
 		// we can ignore the IsNotFound error
 		// if the stateful set was deleted we have already cleaned up the pods
@@ -115,7 +115,7 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	return reconcile.Result{}, nil
 }
 
-func (p *StatefulSetReconciler) handleServerPod(ctx context.Context, cluster v1beta1.Cluster, pod *v1.Pod) error {
+func (p *StatefulSetReconciler) handleServerPod(ctx context.Context, cluster v1beta1.Cluster, pod *corev1.Pod) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Handling Server Pod")
 
@@ -266,7 +266,7 @@ func removePeer(ctx context.Context, client *clientv3.Client, name, address stri
 }
 
 func (p *StatefulSetReconciler) clusterToken(ctx context.Context, cluster *v1beta1.Cluster) (string, error) {
-	var tokenSecret v1.Secret
+	var tokenSecret corev1.Secret
 
 	nn := types.NamespacedName{
 		Name:      TokenSecretName(cluster.Name),
@@ -288,7 +288,7 @@ func (p *StatefulSetReconciler) clusterToken(ctx context.Context, cluster *v1bet
 	return string(tokenSecret.Data["token"]), nil
 }
 
-func (p *StatefulSetReconciler) handleDeletion(ctx context.Context, sts *apps.StatefulSet) (ctrl.Result, error) {
+func (p *StatefulSetReconciler) handleDeletion(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	podList, err := p.listPods(ctx, sts)
@@ -313,7 +313,7 @@ func (p *StatefulSetReconciler) handleDeletion(ctx context.Context, sts *apps.St
 	return reconcile.Result{}, nil
 }
 
-func (p *StatefulSetReconciler) listPods(ctx context.Context, sts *apps.StatefulSet) (*v1.PodList, error) {
+func (p *StatefulSetReconciler) listPods(ctx context.Context, sts *appsv1.StatefulSet) (*corev1.PodList, error) {
 	selector, err := metav1.LabelSelectorAsSelector(sts.Spec.Selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create selector from statefulset: %w", err)
@@ -324,7 +324,7 @@ func (p *StatefulSetReconciler) listPods(ctx context.Context, sts *apps.Stateful
 		LabelSelector: selector,
 	}
 
-	var podList v1.PodList
+	var podList corev1.PodList
 	if err := p.Client.List(ctx, &podList, listOpts); err != nil {
 		return nil, ctrlruntimeclient.IgnoreNotFound(err)
 	}

--- a/pkg/controller/cluster/status.go
+++ b/pkg/controller/cluster/status.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -52,7 +52,7 @@ func (c *ClusterReconciler) updateStatus(ctx context.Context, cluster *v1beta1.C
 			Message: reconcileErr.Error(),
 		})
 
-		c.Eventf(cluster, v1.EventTypeWarning, ReasonValidationFailed, reconcileErr.Error())
+		c.Eventf(cluster, corev1.EventTypeWarning, ReasonValidationFailed, reconcileErr.Error())
 
 		return
 	}
@@ -79,7 +79,7 @@ func (c *ClusterReconciler) updateStatus(ctx context.Context, cluster *v1beta1.C
 			Message: reconcileErr.Error(),
 		})
 
-		c.Eventf(cluster, v1.EventTypeWarning, ReasonProvisioningFailed, reconcileErr.Error())
+		c.Eventf(cluster, corev1.EventTypeWarning, ReasonProvisioningFailed, reconcileErr.Error())
 
 		return
 	}
@@ -95,7 +95,7 @@ func (c *ClusterReconciler) updateStatus(ctx context.Context, cluster *v1beta1.C
 
 	// Only emit event on transition to Ready
 	if !meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, ConditionReady, metav1.ConditionTrue) {
-		c.Eventf(cluster, v1.EventTypeNormal, ReasonProvisioned, newCondition.Message)
+		c.Eventf(cluster, corev1.EventTypeNormal, ReasonProvisioned, newCondition.Message)
 	}
 
 	meta.SetStatusCondition(&cluster.Status.Conditions, newCondition)

--- a/pkg/controller/cluster/token.go
+++ b/pkg/controller/cluster/token.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,7 +29,7 @@ func (c *ClusterReconciler) token(ctx context.Context, cluster *v1beta1.Cluster)
 		Namespace: cluster.Spec.TokenSecretRef.Namespace,
 	}
 
-	var tokenSecret v1.Secret
+	var tokenSecret corev1.Secret
 
 	if err := c.Client.Get(ctx, nn, &tokenSecret); err != nil {
 		return "", err
@@ -51,7 +51,7 @@ func (c *ClusterReconciler) ensureTokenSecret(ctx context.Context, cluster *v1be
 		Namespace: cluster.Namespace,
 	}
 
-	var tokenSecret v1.Secret
+	var tokenSecret corev1.Secret
 	if err := c.Client.Get(ctx, key, &tokenSecret); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return "", err
@@ -94,8 +94,8 @@ func random(size int) (string, error) {
 	return hex.EncodeToString(token), err
 }
 
-func TokenSecretObj(token, name, namespace string) v1.Secret {
-	return v1.Secret{
+func TokenSecretObj(token, name, namespace string) corev1.Secret {
+	return corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
@@ -26,7 +26,7 @@ func Test_K3S_Image(t *testing.T) {
 			args: args{
 				k3sImage: "rancher/k3s",
 				cluster: &v1beta1.Cluster{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mycluster",
 						Namespace: "ns-1",
 					},
@@ -42,7 +42,7 @@ func Test_K3S_Image(t *testing.T) {
 			args: args{
 				k3sImage: "rancher/k3s",
 				cluster: &v1beta1.Cluster{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mycluster",
 						Namespace: "ns-1",
 					},
@@ -58,7 +58,7 @@ func Test_K3S_Image(t *testing.T) {
 			args: args{
 				k3sImage: "rancher/k3s",
 				cluster: &v1beta1.Cluster{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mycluster",
 						Namespace: "ns-1",
 					},

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	certutil "github.com/rancher/dynamiclistener/cert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -100,7 +100,7 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1bet
 		Namespace: cluster.Namespace,
 	}
 
-	var k3kService v1.Service
+	var k3kService corev1.Service
 	if err := client.Get(ctx, key, &k3kService); err != nil {
 		return "", err
 	}
@@ -113,13 +113,13 @@ func getURLFromService(ctx context.Context, client client.Client, cluster *v1bet
 	}
 
 	switch k3kService.Spec.Type {
-	case v1.ServiceTypeNodePort:
+	case corev1.ServiceTypeNodePort:
 		ip = hostServerIP
 
 		if len(k3kService.Spec.Ports) > 0 {
 			port = k3kService.Spec.Ports[0].NodePort
 		}
-	case v1.ServiceTypeLoadBalancer:
+	case corev1.ServiceTypeLoadBalancer:
 		if len(k3kService.Status.LoadBalancer.Ingress) > 0 {
 			ip = k3kService.Status.LoadBalancer.Ingress[0].IP
 		} else {

--- a/pkg/controller/policy/namespace.go
+++ b/pkg/controller/policy/namespace.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,7 +19,7 @@ import (
 )
 
 // reconcileNamespacePodSecurityLabels will update the labels of the namespace to reconcile the PSA level specified in the VirtualClusterPolicy
-func (c *VirtualClusterPolicyReconciler) reconcileNamespacePodSecurityLabels(ctx context.Context, namespace *v1.Namespace, policy *v1beta1.VirtualClusterPolicy) {
+func (c *VirtualClusterPolicyReconciler) reconcileNamespacePodSecurityLabels(ctx context.Context, namespace *corev1.Namespace, policy *v1beta1.VirtualClusterPolicy) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling PSA labels")
 
@@ -50,7 +50,7 @@ func (c *VirtualClusterPolicyReconciler) cleanupNamespaces(ctx context.Context) 
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Cleanup Namespace resources")
 
-	var namespaces v1.NamespaceList
+	var namespaces corev1.NamespaceList
 	if err := c.Client.List(ctx, &namespaces); err != nil {
 		return err
 	}
@@ -104,11 +104,11 @@ func (c *VirtualClusterPolicyReconciler) cleanupNamespaces(ctx context.Context) 
 			return err
 		}
 
-		if err := c.Client.DeleteAllOf(ctx, &v1.ResourceQuota{}, deleteOpts...); err != nil {
+		if err := c.Client.DeleteAllOf(ctx, &corev1.ResourceQuota{}, deleteOpts...); err != nil {
 			return err
 		}
 
-		if err := c.Client.DeleteAllOf(ctx, &v1.LimitRange{}, deleteOpts...); err != nil {
+		if err := c.Client.DeleteAllOf(ctx, &corev1.LimitRange{}, deleteOpts...); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/policy/networkpolicy.go
+++ b/pkg/controller/policy/networkpolicy.go
@@ -5,7 +5,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +24,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileNetworkPolicy(ctx context.Cont
 	if c.ClusterCIDR != "" {
 		cidrList = []string{c.ClusterCIDR}
 	} else {
-		var nodeList v1.NodeList
+		var nodeList corev1.NodeList
 		if err := c.Client.List(ctx, &nodeList); err != nil {
 			return err
 		}

--- a/pkg/controller/policy/policy.go
+++ b/pkg/controller/policy/policy.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,12 +47,12 @@ func Add(mgr manager.Manager, clusterCIDR string, maxConcurrentReconciles int) e
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.VirtualClusterPolicy{}).
-		Watches(&v1.Namespace{}, namespaceEventHandler()).
-		Watches(&v1.Node{}, nodeEventHandler(&reconciler)).
+		Watches(&corev1.Namespace{}, namespaceEventHandler()).
+		Watches(&corev1.Node{}, nodeEventHandler(&reconciler)).
 		Watches(&v1beta1.Cluster{}, clusterEventHandler(&reconciler)).
 		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&v1.ResourceQuota{}).
-		Owns(&v1.LimitRange{}).
+		Owns(&corev1.ResourceQuota{}).
+		Owns(&corev1.LimitRange{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(&reconciler)
 }
@@ -62,7 +62,7 @@ func namespaceEventHandler() handler.Funcs {
 	return handler.Funcs{
 		// When a Namespace is created, if it has the "policy.k3k.io/policy-name" label
 		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			ns, ok := e.Object.(*v1.Namespace)
+			ns, ok := e.Object.(*corev1.Namespace)
 			if !ok {
 				return
 			}
@@ -73,8 +73,8 @@ func namespaceEventHandler() handler.Funcs {
 		},
 		// When a Namespace is updated, if it has the "policy.k3k.io/policy-name" label
 		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			oldNs, okOld := e.ObjectOld.(*v1.Namespace)
-			newNs, okNew := e.ObjectNew.(*v1.Namespace)
+			oldNs, okOld := e.ObjectOld.(*corev1.Namespace)
+			newNs, okNew := e.ObjectNew.(*corev1.Namespace)
 
 			if !okOld || !okNew {
 				return
@@ -112,7 +112,7 @@ func namespaceEventHandler() handler.Funcs {
 		// When a namespace is deleted all the resources in the namespace are deleted
 		// but we trigger the reconciliation to eventually perform some cluster-wide cleanup if necessary
 		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			ns, ok := e.Object.(*v1.Namespace)
+			ns, ok := e.Object.(*corev1.Namespace)
 			if !ok {
 				return
 			}
@@ -152,8 +152,8 @@ func nodeEventHandler(r *VirtualClusterPolicyReconciler) handler.Funcs {
 				return
 			}
 
-			oldNode, okOld := e.ObjectOld.(*v1.Node)
-			newNode, okNew := e.ObjectNew.(*v1.Node)
+			oldNode, okOld := e.ObjectOld.(*corev1.Node)
+			newNode, okNew := e.ObjectNew.(*corev1.Node)
 
 			if !okOld || !okNew {
 				return
@@ -199,7 +199,7 @@ func clusterEventHandler(r *VirtualClusterPolicyReconciler) handler.Funcs {
 				return
 			}
 
-			var ns v1.Namespace
+			var ns corev1.Namespace
 			if err := r.Client.Get(ctx, types.NamespacedName{Name: cluster.Namespace}, &ns); err != nil {
 				return
 			}
@@ -218,7 +218,7 @@ func clusterEventHandler(r *VirtualClusterPolicyReconciler) handler.Funcs {
 				return
 			}
 
-			var ns v1.Namespace
+			var ns corev1.Namespace
 			if err := r.Client.Get(ctx, types.NamespacedName{Name: oldCluster.Namespace}, &ns); err != nil {
 				return
 			}
@@ -306,7 +306,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileMatchingNamespaces(ctx context
 		PolicyNameLabelKey: policy.Name,
 	}
 
-	var namespaces v1.NamespaceList
+	var namespaces corev1.NamespaceList
 	if err := c.Client.List(ctx, &namespaces, listOpts); err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileQuota(ctx context.Context, nam
 
 	if policy.Spec.Quota == nil {
 		// check if resourceQuota object exists and deletes it.
-		var toDeleteResourceQuota v1.ResourceQuota
+		var toDeleteResourceQuota corev1.ResourceQuota
 
 		key := types.NamespacedName{
 			Name:      k3kcontroller.SafeConcatNameWithPrefix(policy.Name),
@@ -372,7 +372,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileQuota(ctx context.Context, nam
 	}
 
 	// create/update resource Quota
-	resourceQuota := &v1.ResourceQuota{
+	resourceQuota := &corev1.ResourceQuota{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ResourceQuota",
 			APIVersion: "v1",
@@ -410,7 +410,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileLimit(ctx context.Context, nam
 
 	// delete limitrange if spec.limits isnt specified.
 	if policy.Spec.Limit == nil {
-		var toDeleteLimitRange v1.LimitRange
+		var toDeleteLimitRange corev1.LimitRange
 
 		key := types.NamespacedName{
 			Name:      k3kcontroller.SafeConcatNameWithPrefix(policy.Name),
@@ -426,7 +426,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileLimit(ctx context.Context, nam
 		return c.Client.Delete(ctx, &toDeleteLimitRange)
 	}
 
-	limitRange := &v1.LimitRange{
+	limitRange := &corev1.LimitRange{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "LimitRange",
 			APIVersion: "v1",
@@ -458,7 +458,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileLimit(ctx context.Context, nam
 	return err
 }
 
-func (c *VirtualClusterPolicyReconciler) reconcileClusters(ctx context.Context, namespace *v1.Namespace, policy *v1beta1.VirtualClusterPolicy) error {
+func (c *VirtualClusterPolicyReconciler) reconcileClusters(ctx context.Context, namespace *corev1.Namespace, policy *v1beta1.VirtualClusterPolicy) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling Clusters")
 

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller/policy"
@@ -165,7 +165,7 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				Expect(stderr).To(ContainSubstring(`Policy '%s' deleted`, policy1Name))
 			})
 
-			var ns v1.Namespace
+			var ns corev1.Namespace
 
 			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: namespaceName}, &ns)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))

--- a/tests/e2e/cluster_addons_test.go
+++ b/tests/e2e/cluster_addons_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
@@ -42,7 +42,7 @@ var _ = When("a cluster with secretMounts configuration is used to load addons",
 
 		cluster.Spec.SecretMounts = []v1beta1.SecretMount{
 			{
-				SecretVolumeSource: v1.SecretVolumeSource{
+				SecretVolumeSource: corev1.SecretVolumeSource{
 					SecretName: addonsSecretName,
 				},
 				MountPath: secretMountManifestMountPath,
@@ -83,7 +83,7 @@ var _ = When("a cluster with secretMounts configuration is used to load addons",
 		Eventually(func(g Gomega) {
 			nginxPod, err := virtualCluster.Client.CoreV1().Pods("default").Get(ctx, "nginx-addon", metav1.GetOptions{})
 			g.Expect(err).To(Not(HaveOccurred()))
-			g.Expect(nginxPod.Status.Phase).To(Equal(v1.PodRunning))
+			g.Expect(nginxPod.Status.Phase).To(Equal(corev1.PodRunning))
 		}).
 			WithTimeout(time.Minute * 3).
 			WithPolling(time.Second * 5).
@@ -141,7 +141,7 @@ var _ = When("a cluster with addon configuration is used with addons secret in t
 		Eventually(func(g Gomega) {
 			nginxPod, err := virtualCluster.Client.CoreV1().Pods("default").Get(ctx, "nginx-addon", metav1.GetOptions{})
 			g.Expect(err).To(Not(HaveOccurred()))
-			g.Expect(nginxPod.Status.Phase).To(Equal(v1.PodRunning))
+			g.Expect(nginxPod.Status.Phase).To(Equal(corev1.PodRunning))
 		}).
 			WithTimeout(time.Minute * 3).
 			WithPolling(time.Second * 5).
@@ -204,7 +204,7 @@ var _ = When("a cluster with addon configuration is used with addons secret in t
 		Eventually(func(g Gomega) {
 			nginxPod, err := virtualCluster.Client.CoreV1().Pods("default").Get(ctx, "nginx-addon", metav1.GetOptions{})
 			g.Expect(err).To(Not(HaveOccurred()))
-			g.Expect(nginxPod.Status.Phase).To(Equal(v1.PodRunning))
+			g.Expect(nginxPod.Status.Phase).To(Equal(corev1.PodRunning))
 		}).
 			WithTimeout(time.Minute * 3).
 			WithPolling(time.Second * 5).
@@ -218,7 +218,7 @@ func createAddonSecret(ctx context.Context, namespace string) error {
 		return err
 	}
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",

--- a/tests/e2e/cluster_app_test.go
+++ b/tests/e2e/cluster_app_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/k3k-kubelet/translate"
@@ -36,7 +36,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 	When("creating a Deployment with a PVC", func() {
 		var (
 			deployment *appsv1.Deployment
-			pvc        *v1.PersistentVolumeClaim
+			pvc        *corev1.PersistentVolumeClaim
 
 			namespace = "default"
 			labels    = map[string]string{
@@ -51,16 +51,16 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 			By("Creating the PVC")
 
-			pvc = &v1.PersistentVolumeClaim{
+			pvc = &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "k3k-test-app-",
 					Namespace:    namespace,
 				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-					Resources: v1.VolumeResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceStorage: resource.MustParse("1Gi"),
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
 						},
 					},
 				},
@@ -81,25 +81,25 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: labels,
 					},
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labels,
 						},
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
-									VolumeMounts: []v1.VolumeMount{{
+									VolumeMounts: []corev1.VolumeMount{{
 										Name:      "data-volume",
 										MountPath: "/data",
 									}},
 								},
 							},
-							Volumes: []v1.Volume{{
+							Volumes: []corev1.Volume{{
 								Name: "data-volume",
-								VolumeSource: v1.VolumeSource{
-									PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 										ClaimName: pvc.Name,
 									},
 								},
@@ -119,7 +119,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 			Eventually(func(g Gomega) {
 				virtualPVC, err := virtualCluster.Client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(virtualPVC.Status.Phase).To(Equal(v1.ClaimBound))
+				g.Expect(virtualPVC.Status.Phase).To(Equal(corev1.ClaimBound))
 			}).
 				WithPolling(time.Second * 3).
 				WithTimeout(time.Minute * 3).
@@ -134,7 +134,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 				hostPVC, err := k8s.CoreV1().PersistentVolumeClaims(hostPVCName.Namespace).Get(ctx, hostPVCName.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(hostPVC.Status.Phase).To(Equal(v1.ClaimBound))
+				g.Expect(hostPVC.Status.Phase).To(Equal(corev1.ClaimBound))
 			}).
 				WithPolling(time.Second * 3).
 				WithTimeout(time.Minute * 3).
@@ -153,7 +153,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				g.Expect(pods.Items).Should(HaveLen(int(*deployment.Spec.Replicas)))
 
 				for _, pod := range pods.Items {
-					g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+					g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 				}
 			}).
 				WithPolling(time.Second * 3).
@@ -177,7 +177,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 					pod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
 					g.Expect(err).NotTo(HaveOccurred())
-					g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+					g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 				}
 			}).
 				WithPolling(time.Second * 3).
@@ -215,16 +215,16 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: labels,
 					},
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labels,
 						},
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
-									VolumeMounts: []v1.VolumeMount{{
+									VolumeMounts: []corev1.VolumeMount{{
 										Name:      "www",
 										MountPath: "/usr/share/nginx/html",
 									}},
@@ -232,16 +232,16 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 							},
 						},
 					},
-					VolumeClaimTemplates: []v1.PersistentVolumeClaim{{
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   "www",
 							Labels: labels,
 						},
-						Spec: v1.PersistentVolumeClaimSpec{
-							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-							Resources: v1.VolumeResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceStorage: resource.MustParse("1Gi"),
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("1Gi"),
 								},
 							},
 						},
@@ -264,7 +264,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				for _, pvc := range pvcs.Items {
-					g.Expect(pvc.Status.Phase).To(Equal(v1.ClaimBound))
+					g.Expect(pvc.Status.Phase).To(Equal(corev1.ClaimBound))
 				}
 			}).
 				WithPolling(time.Second * 3).
@@ -287,7 +287,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 					hostPVC, err := k8s.CoreV1().PersistentVolumeClaims(hostPVCName.Namespace).Get(ctx, hostPVCName.Name, metav1.GetOptions{})
 					g.Expect(err).NotTo(HaveOccurred())
-					g.Expect(hostPVC.Status.Phase).To(Equal(v1.ClaimBound))
+					g.Expect(hostPVC.Status.Phase).To(Equal(corev1.ClaimBound))
 				}
 			}).
 				WithPolling(time.Second * 3).
@@ -307,7 +307,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				g.Expect(pods.Items).Should(HaveLen(int(*statefulSet.Spec.Replicas)))
 
 				for _, pod := range pods.Items {
-					g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+					g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 				}
 			}).
 				WithPolling(time.Second * 3).
@@ -331,7 +331,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 					pod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
 					g.Expect(err).NotTo(HaveOccurred())
-					g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+					g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 				}
 			}).
 				WithPolling(time.Second * 3).

--- a/tests/e2e/cluster_persistence_test.go
+++ b/tests/e2e/cluster_persistence_test.go
@@ -10,7 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/k3k-kubelet/translate"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
@@ -42,11 +42,11 @@ var _ = When("an ephemeral cluster is installed", Label(e2eTestLabel), Label(per
 		hostTranslator := translate.NewHostTranslator(virtualCluster.Cluster)
 		namespacedName := hostTranslator.NamespacedName(pod)
 
-		err := k8s.CoreV1().Pods(namespacedName.Namespace).Delete(ctx, namespacedName.Name, v1.DeleteOptions{})
+		err := k8s.CoreV1().Pods(namespacedName.Namespace).Delete(ctx, namespacedName.Name, metav1.DeleteOptions{})
 		Expect(err).To(Not(HaveOccurred()))
 
 		Eventually(func() bool {
-			_, err := virtualCluster.Client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, v1.GetOptions{})
+			_, err := virtualCluster.Client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
 		}).
 			WithPolling(time.Second * 5).
@@ -67,7 +67,7 @@ var _ = When("an ephemeral cluster is installed", Label(e2eTestLabel), Label(per
 
 		GinkgoWriter.Printf("deleting pod %s/%s\n", serverPod.Namespace, serverPod.Name)
 
-		err = k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).Delete(ctx, serverPod.Name, v1.DeleteOptions{})
+		err = k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).Delete(ctx, serverPod.Name, metav1.DeleteOptions{})
 		Expect(err).To(Not(HaveOccurred()))
 
 		By("Deleting server pod")
@@ -138,7 +138,7 @@ var _ = When("a dynamic cluster is installed", Label(e2eTestLabel), Label(persis
 		Eventually(func() []corev1.Pod {
 			By("listing the pods in the namespace")
 
-			podList, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).List(ctx, v1.ListOptions{})
+			podList, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).List(ctx, metav1.ListOptions{})
 			Expect(err).To(Not(HaveOccurred()))
 
 			GinkgoLogr.Info("podlist", "len", len(podList.Items))
@@ -181,7 +181,7 @@ var _ = When("a dynamic cluster is installed", Label(e2eTestLabel), Label(persis
 		Eventually(func() []corev1.Pod {
 			By("listing the pods in the namespace")
 
-			podList, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).List(ctx, v1.ListOptions{})
+			podList, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).List(ctx, metav1.ListOptions{})
 			Expect(err).To(Not(HaveOccurred()))
 
 			GinkgoLogr.Info("podlist", "len", len(podList.Items))

--- a/tests/e2e/cluster_pod_test.go
+++ b/tests/e2e/cluster_pod_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/api/v1/pod"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/k3k-kubelet/translate"
@@ -36,20 +36,20 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 	})
 
 	When("creating a Pod without any Affinity", func() {
-		var pod *v1.Pod
+		var pod *corev1.Pod
 
 		BeforeAll(func() {
 			var err error
 
 			ctx := context.Background()
 
-			pod = &v1.Pod{
+			pod = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "nginx-",
 					Namespace:    "default",
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
 						Name:  "nginx",
 						Image: "nginx",
 					}},
@@ -85,30 +85,30 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 	})
 
 	When("creating a Pod with an Affinity", func() {
-		var pod *v1.Pod
+		var pod *corev1.Pod
 
 		BeforeAll(func() {
 			var err error
 
 			ctx := context.Background()
 
-			pod = &v1.Pod{
+			pod = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "nginx-",
 					Namespace:    "default",
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
 						Name:  "nginx",
 						Image: "nginx",
 					}},
-					Affinity: &v1.Affinity{
-						NodeAffinity: &v1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-								NodeSelectorTerms: []v1.NodeSelectorTerm{{
-									MatchExpressions: []v1.NodeSelectorRequirement{{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+									MatchExpressions: []corev1.NodeSelectorRequirement{{
 										Key:      "kubernetes.io/hostname",
-										Operator: v1.NodeSelectorOpNotIn,
+										Operator: corev1.NodeSelectorOpNotIn,
 										Values:   []string{"fake"},
 									}},
 								}},
@@ -148,10 +148,10 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 	})
 
 	When("creating a Pod with an invalid configuration", func() {
-		var virtualPod *v1.Pod
+		var virtualPod *corev1.Pod
 
 		BeforeEach(func() {
-			p := &v1.Pod{
+			p := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "nginx-",
 					Namespace:    "default",
@@ -162,30 +162,30 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 						"notmysubpath": "mypath",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "nginx",
 							Image: "nginx",
-							Env: []v1.EnvVar{
+							Env: []corev1.EnvVar{
 								{
 									Name: "POD_NAME",
-									ValueFrom: &v1.EnvVarSource{
-										FieldRef: &v1.ObjectFieldSelector{
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.name",
 										},
 									},
 								},
 								{
 									Name: "ANNOTATION",
-									ValueFrom: &v1.EnvVarSource{
-										FieldRef: &v1.ObjectFieldSelector{
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.annotations['mysubpath']",
 										},
 									},
 								},
 							},
-							VolumeMounts: []v1.VolumeMount{
+							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "workdir",
 									MountPath: "/volume_mount",
@@ -198,9 +198,9 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 							},
 						},
 					},
-					Volumes: []v1.Volume{{
+					Volumes: []corev1.Volume{{
 						Name:         "workdir",
-						VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 					}},
 				},
 			}
@@ -222,7 +222,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				pod, err := virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Get(ctx, virtualPod.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(pod.Status.Phase).To(Equal(v1.PodPending))
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodPending))
 
 				envVars := pod.Spec.Containers[0].Env
 				g.Expect(envVars).NotTo(BeEmpty())
@@ -262,7 +262,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				pod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(pod.Status.Phase).To(Equal(v1.PodPending))
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodPending))
 
 				envVars := pod.Spec.Containers[0].Env
 				g.Expect(envVars).NotTo(BeEmpty())
@@ -312,7 +312,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				vPod, err := virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Get(ctx, virtualPod.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 
-				_, cond := pod.GetPodCondition(&vPod.Status, v1.PodReady)
+				_, cond := pod.GetPodCondition(&vPod.Status, corev1.PodReady)
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 			}).
@@ -328,7 +328,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				hPod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 
-				_, cond := pod.GetPodCondition(&hPod.Status, v1.PodReady)
+				_, cond := pod.GetPodCondition(&hPod.Status, corev1.PodReady)
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 			}).
@@ -339,36 +339,36 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 	})
 
 	When("creating a Pod with downward API variables in environment variable", func() {
-		var virtualPod *v1.Pod
+		var virtualPod *corev1.Pod
 
 		BeforeEach(func() {
 			ctx := context.Background()
 
 			var err error
 
-			p := &v1.Pod{
+			p := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "nginx-",
 					Namespace:    "default",
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "nginx",
 							Image: "nginx",
-							Env: []v1.EnvVar{
+							Env: []corev1.EnvVar{
 								{
 									Name: "POD_NAME",
-									ValueFrom: &v1.EnvVarSource{
-										FieldRef: &v1.ObjectFieldSelector{
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.name",
 										},
 									},
 								},
 								{
 									Name: "STATUS_POD_IP",
-									ValueFrom: &v1.EnvVarSource{
-										FieldRef: &v1.ObjectFieldSelector{
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "status.podIP",
 										},
 									},
@@ -389,7 +389,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 			Eventually(func(g Gomega) {
 				pod, err := virtualCluster.Client.CoreV1().Pods(virtualPod.Namespace).Get(ctx, virtualPod.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 				g.Expect(pod.Status.PodIP).NotTo(BeEmpty())
 			}).
 				WithPolling(time.Second).
@@ -406,7 +406,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 				pod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 			}).
 				WithPolling(time.Second).
 				WithTimeout(time.Minute).
@@ -438,7 +438,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(pods.Items).NotTo(BeEmpty())
 
-				g.Expect(pods.Items[0].Status.Phase).To(Equal(v1.PodSucceeded))
+				g.Expect(pods.Items[0].Status.Phase).To(Equal(corev1.PodSucceeded))
 			}).
 				WithPolling(time.Second).
 				WithTimeout(2 * time.Minute).

--- a/tests/e2e/cluster_registry_test.go
+++ b/tests/e2e/cluster_registry_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1/pod"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
@@ -60,14 +60,14 @@ var _ = When("a cluster with private registry configuration is used", Label("e2e
 		// Using subPath allows mounting individual files while keeping parent directories writable
 		cluster.Spec.SecretMounts = []v1beta1.SecretMount{
 			{
-				SecretVolumeSource: v1.SecretVolumeSource{
+				SecretVolumeSource: corev1.SecretVolumeSource{
 					SecretName: "k3s-registry-config",
 				},
 				MountPath: "/etc/rancher/k3s/registries.yaml",
 				SubPath:   "registries.yaml",
 			},
 			{
-				SecretVolumeSource: v1.SecretVolumeSource{
+				SecretVolumeSource: corev1.SecretVolumeSource{
 					SecretName: "private-registry-ca-cert",
 				},
 				MountPath: "/etc/rancher/k3s/tls/ca.crt",
@@ -126,13 +126,13 @@ var _ = When("a cluster with private registry configuration is used", Label("e2e
 
 		// creating a pod with image that uses any registry other than docker.io should fail
 		// for example public.ecr.aws/docker/library/alpine:latest
-		alpinePod := &v1.Pod{
+		alpinePod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "alpine-",
 				Namespace:    "default",
 			},
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
 					Name:  "alpine",
 					Image: "public.ecr.aws/docker/library/alpine:latest",
 				}},

--- a/tests/e2e/cluster_update_test.go
+++ b/tests/e2e/cluster_update_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/utils/ptr"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,7 +34,7 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 		cluster := NewCluster(namespace.Name)
 
 		// Add initial environment variables for server
-		cluster.Spec.ServerEnvs = []v1.EnvVar{
+		cluster.Spec.ServerEnvs = []corev1.EnvVar{
 			{
 				Name:  "TEST_SERVER_ENV_1",
 				Value: "not_upgraded",
@@ -45,7 +45,7 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 			},
 		}
 		// Add initial environment variables for agent
-		cluster.Spec.AgentEnvs = []v1.EnvVar{
+		cluster.Spec.AgentEnvs = []corev1.EnvVar{
 			{
 				Name:  "TEST_AGENT_ENV_1",
 				Value: "not_upgraded",
@@ -78,7 +78,7 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 		Expect(ok).To(BeTrue())
 		Expect(serverEnv2).To(Equal("toBeRemoved"))
 
-		var nodes v1.NodeList
+		var nodes corev1.NodeList
 		Expect(k8sClient.List(ctx, &nodes)).To(Succeed())
 
 		aPods := listAgentPods(ctx, virtualCluster)
@@ -102,7 +102,7 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// update both agent and server envs
-			cluster.Spec.ServerEnvs = []v1.EnvVar{
+			cluster.Spec.ServerEnvs = []corev1.EnvVar{
 				{
 					Name:  "TEST_SERVER_ENV_1",
 					Value: "upgraded",
@@ -112,7 +112,7 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 					Value: "new",
 				},
 			}
-			cluster.Spec.AgentEnvs = []v1.EnvVar{
+			cluster.Spec.AgentEnvs = []corev1.EnvVar{
 				{
 					Name:  "TEST_AGENT_ENV_1",
 					Value: "upgraded",
@@ -131,7 +131,7 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 			g.Expect(len(serverPods)).To(Equal(1))
 
 			serverPod := serverPods[0]
-			_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -147,14 +147,14 @@ var _ = When("a shared mode cluster update its envs", Label(e2eTestLabel), Label
 			g.Expect(serverEnv3).To(Equal("new"))
 
 			// agent pods
-			var nodes v1.NodeList
+			var nodes corev1.NodeList
 			g.Expect(k8sClient.List(ctx, &nodes)).To(Succeed())
 
 			aPods := listAgentPods(ctx, virtualCluster)
 			g.Expect(aPods).To(HaveLen(len(nodes.Items)))
 
 			agentPod := aPods[0]
-			_, cond = pod.GetPodCondition(&agentPod.Status, v1.PodReady)
+			_, cond = pod.GetPodCondition(&agentPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -229,7 +229,7 @@ var _ = When("a shared mode cluster update its server args", Label(e2eTestLabel)
 			g.Expect(len(sPods)).To(Equal(1))
 
 			serverPod := sPods[0]
-			_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -256,7 +256,7 @@ var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Labe
 		cluster := NewCluster(namespace.Name)
 
 		// Add initial environment variables for server
-		cluster.Spec.ServerEnvs = []v1.EnvVar{
+		cluster.Spec.ServerEnvs = []corev1.EnvVar{
 			{
 				Name:  "TEST_SERVER_ENV_1",
 				Value: "not_upgraded",
@@ -267,7 +267,7 @@ var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Labe
 			},
 		}
 		// Add initial environment variables for agent
-		cluster.Spec.AgentEnvs = []v1.EnvVar{
+		cluster.Spec.AgentEnvs = []corev1.EnvVar{
 			{
 				Name:  "TEST_AGENT_ENV_1",
 				Value: "not_upgraded",
@@ -324,7 +324,7 @@ var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Labe
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// update both agent and server envs
-			cluster.Spec.ServerEnvs = []v1.EnvVar{
+			cluster.Spec.ServerEnvs = []corev1.EnvVar{
 				{
 					Name:  "TEST_SERVER_ENV_1",
 					Value: "upgraded",
@@ -334,7 +334,7 @@ var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Labe
 					Value: "new",
 				},
 			}
-			cluster.Spec.AgentEnvs = []v1.EnvVar{
+			cluster.Spec.AgentEnvs = []corev1.EnvVar{
 				{
 					Name:  "TEST_AGENT_ENV_1",
 					Value: "upgraded",
@@ -353,7 +353,7 @@ var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Labe
 			g.Expect(len(serverPods)).To(Equal(1))
 
 			serverPod := serverPods[0]
-			_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -373,7 +373,7 @@ var _ = When("a virtual mode cluster update its envs", Label(e2eTestLabel), Labe
 			g.Expect(len(aPods)).To(Equal(1))
 
 			agentPod := aPods[0]
-			_, cond = pod.GetPodCondition(&agentPod.Status, v1.PodReady)
+			_, cond = pod.GetPodCondition(&agentPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -451,7 +451,7 @@ var _ = When("a virtual mode cluster update its server args", Label(e2eTestLabel
 			g.Expect(len(sPods)).To(Equal(1))
 
 			serverPod := sPods[0]
-			_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -466,7 +466,7 @@ var _ = When("a virtual mode cluster update its server args", Label(e2eTestLabel
 var _ = When("a shared mode cluster update its version", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
-		nginxPod       *v1.Pod
+		nginxPod       *corev1.Pod
 	)
 
 	BeforeEach(func() {
@@ -529,7 +529,7 @@ var _ = When("a shared mode cluster update its version", Label(e2eTestLabel), La
 			g.Expect(len(serverPods)).To(Equal(1))
 
 			serverPod := serverPods[0]
-			_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -542,7 +542,7 @@ var _ = When("a shared mode cluster update its version", Label(e2eTestLabel), La
 			nginxPod, err = virtualCluster.Client.CoreV1().Pods(nginxPod.Namespace).Get(ctx, nginxPod.Name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 
-			_, cond = pod.GetPodCondition(&nginxPod.Status, v1.PodReady)
+			_, cond = pod.GetPodCondition(&nginxPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 		}).
@@ -555,7 +555,7 @@ var _ = When("a shared mode cluster update its version", Label(e2eTestLabel), La
 var _ = When("a virtual mode cluster update its version", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
-		nginxPod       *v1.Pod
+		nginxPod       *corev1.Pod
 	)
 
 	BeforeEach(func() {
@@ -622,7 +622,7 @@ var _ = When("a virtual mode cluster update its version", Label(e2eTestLabel), L
 			g.Expect(len(serverPods)).To(Equal(1))
 
 			serverPod := serverPods[0]
-			_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -633,7 +633,7 @@ var _ = When("a virtual mode cluster update its version", Label(e2eTestLabel), L
 			g.Expect(len(agentPods)).To(Equal(1))
 
 			agentPod := agentPods[0]
-			_, cond = pod.GetPodCondition(&agentPod.Status, v1.PodReady)
+			_, cond = pod.GetPodCondition(&agentPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -646,7 +646,7 @@ var _ = When("a virtual mode cluster update its version", Label(e2eTestLabel), L
 			nginxPod, err = virtualCluster.Client.CoreV1().Pods(nginxPod.Namespace).Get(ctx, nginxPod.Name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 
-			_, cond = pod.GetPodCondition(&nginxPod.Status, v1.PodReady)
+			_, cond = pod.GetPodCondition(&nginxPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 		}).
@@ -659,7 +659,7 @@ var _ = When("a virtual mode cluster update its version", Label(e2eTestLabel), L
 var _ = When("a shared mode cluster scales up servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
-		nginxPod       *v1.Pod
+		nginxPod       *corev1.Pod
 	)
 
 	BeforeEach(func() {
@@ -722,7 +722,7 @@ var _ = When("a shared mode cluster scales up servers", Label(e2eTestLabel), Lab
 			g.Expect(len(serverPods)).To(Equal(3))
 
 			for _, serverPod := range serverPods {
-				_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+				_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 			}
@@ -734,7 +734,7 @@ var _ = When("a shared mode cluster scales up servers", Label(e2eTestLabel), Lab
 			nginxPod, err = virtualCluster.Client.CoreV1().Pods(nginxPod.Namespace).Get(ctx, nginxPod.Name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 
-			_, cond := pod.GetPodCondition(&nginxPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&nginxPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 		}).
@@ -747,7 +747,7 @@ var _ = When("a shared mode cluster scales up servers", Label(e2eTestLabel), Lab
 var _ = When("a shared mode cluster scales down servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
-		nginxPod       *v1.Pod
+		nginxPod       *corev1.Pod
 	)
 
 	BeforeEach(func() {
@@ -813,7 +813,7 @@ var _ = When("a shared mode cluster scales down servers", Label(e2eTestLabel), L
 			serverPods := listServerPods(ctx, virtualCluster)
 			g.Expect(len(serverPods)).To(Equal(1))
 
-			_, cond := pod.GetPodCondition(&serverPods[0].Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPods[0].Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -824,7 +824,7 @@ var _ = When("a shared mode cluster scales down servers", Label(e2eTestLabel), L
 			nginxPod, err = virtualCluster.Client.CoreV1().Pods(nginxPod.Namespace).Get(ctx, nginxPod.Name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 
-			_, cond = pod.GetPodCondition(&nginxPod.Status, v1.PodReady)
+			_, cond = pod.GetPodCondition(&nginxPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 		}).
@@ -837,7 +837,7 @@ var _ = When("a shared mode cluster scales down servers", Label(e2eTestLabel), L
 var _ = When("a virtual mode cluster scales up servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
-		nginxPod       *v1.Pod
+		nginxPod       *corev1.Pod
 	)
 
 	BeforeEach(func() {
@@ -900,7 +900,7 @@ var _ = When("a virtual mode cluster scales up servers", Label(e2eTestLabel), La
 			g.Expect(len(serverPods)).To(Equal(3))
 
 			for _, serverPod := range serverPods {
-				_, cond := pod.GetPodCondition(&serverPod.Status, v1.PodReady)
+				_, cond := pod.GetPodCondition(&serverPod.Status, corev1.PodReady)
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 			}
@@ -912,7 +912,7 @@ var _ = When("a virtual mode cluster scales up servers", Label(e2eTestLabel), La
 			nginxPod, err = virtualCluster.Client.CoreV1().Pods(nginxPod.Namespace).Get(ctx, nginxPod.Name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 
-			_, cond := pod.GetPodCondition(&nginxPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&nginxPod.Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 		}).
@@ -925,7 +925,7 @@ var _ = When("a virtual mode cluster scales up servers", Label(e2eTestLabel), La
 var _ = When("a virtual mode cluster scales down servers", Label(e2eTestLabel), Label(updateTestsLabel), Label(slowTestsLabel), func() {
 	var (
 		virtualCluster *VirtualCluster
-		nginxPod       *v1.Pod
+		nginxPod       *corev1.Pod
 	)
 
 	BeforeEach(func() {
@@ -1009,7 +1009,7 @@ var _ = When("a virtual mode cluster scales down servers", Label(e2eTestLabel), 
 			serverPods := listServerPods(ctx, virtualCluster)
 			g.Expect(len(serverPods)).To(Equal(1))
 
-			_, cond := pod.GetPodCondition(&serverPods[0].Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&serverPods[0].Status, corev1.PodReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
@@ -1035,7 +1035,7 @@ var _ = When("a virtual mode cluster scales down servers", Label(e2eTestLabel), 
 			// but this is probably to investigate.
 			// Related issue (?): https://github.com/kubernetes/kubernetes/issues/82346
 
-			_, cond := pod.GetPodCondition(&nginxPod.Status, v1.ContainersReady)
+			_, cond := pod.GetPodCondition(&nginxPod.Status, corev1.ContainersReady)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 		}).

--- a/tests/e2e/common_test.go
+++ b/tests/e2e/common_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubernetes/pkg/api/v1/pod"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -131,10 +131,10 @@ func CreateCluster(cluster *v1beta1.Cluster) {
 		var serversReady, agentsReady int
 
 		for _, k3sPod := range podList.Items {
-			_, cond := pod.GetPodCondition(&k3sPod.Status, v1.PodReady)
+			_, cond := pod.GetPodCondition(&k3sPod.Status, corev1.PodReady)
 
 			// pod not ready
-			if cond == nil || cond.Status != v1.ConditionTrue {
+			if cond == nil || cond.Status != corev1.ConditionTrue {
 				continue
 			}
 
@@ -244,20 +244,20 @@ func NewVirtualK8sClientAndKubeconfig(cluster *v1beta1.Cluster) (*kubernetes.Cli
 	return virtualK8sClient, restcfg, configData
 }
 
-func (c *VirtualCluster) NewNginxPod(namespace string) (*v1.Pod, string) {
+func (c *VirtualCluster) NewNginxPod(namespace string) (*corev1.Pod, string) {
 	GinkgoHelper()
 
 	if namespace == "" {
 		namespace = "default"
 	}
 
-	nginxPod := &v1.Pod{
+	nginxPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "nginx-",
 			Namespace:    namespace,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
 				Name:  "nginx",
 				Image: "nginx",
 			}},
@@ -278,7 +278,7 @@ func (c *VirtualCluster) NewNginxPod(namespace string) (*v1.Pod, string) {
 		nginxPod, err = c.Client.CoreV1().Pods(nginxPod.Namespace).Get(ctx, nginxPod.Name, metav1.GetOptions{})
 		g.Expect(err).To(Not(HaveOccurred()))
 
-		_, cond := pod.GetPodCondition(&nginxPod.Status, v1.PodReady)
+		_, cond := pod.GetPodCondition(&nginxPod.Status, corev1.PodReady)
 		g.Expect(cond).NotTo(BeNil())
 		g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 	}).
@@ -312,7 +312,7 @@ func (c *VirtualCluster) NewNginxPod(namespace string) (*v1.Pod, string) {
 					pod.Name, resourceNamespace, resourceName, pod.Status.Phase, podIP,
 				)
 
-				return pod.Status.Phase == v1.PodRunning && podIP != ""
+				return pod.Status.Phase == corev1.PodRunning && podIP != ""
 			}
 		}
 
@@ -326,8 +326,8 @@ func (c *VirtualCluster) NewNginxPod(namespace string) (*v1.Pod, string) {
 }
 
 // ExecCmd exec command on specific pod and wait the command's output.
-func (c *VirtualCluster) ExecCmd(pod *v1.Pod, command string) (string, string, error) {
-	option := &v1.PodExecOptions{
+func (c *VirtualCluster) ExecCmd(pod *corev1.Pod, command string) (string, string, error) {
+	option := &corev1.PodExecOptions{
 		Command: []string{"sh", "-c", command},
 		Stdout:  true,
 		Stderr:  true,
@@ -382,7 +382,7 @@ func restartServerPod(ctx context.Context, virtualCluster *VirtualCluster) {
 		Should(Succeed())
 }
 
-func listServerPods(ctx context.Context, virtualCluster *VirtualCluster) []v1.Pod {
+func listServerPods(ctx context.Context, virtualCluster *VirtualCluster) []corev1.Pod {
 	labelSelector := "cluster=" + virtualCluster.Cluster.Name + ",role=server"
 
 	serverPods, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
@@ -391,7 +391,7 @@ func listServerPods(ctx context.Context, virtualCluster *VirtualCluster) []v1.Po
 	return serverPods.Items
 }
 
-func listAgentPods(ctx context.Context, virtualCluster *VirtualCluster) []v1.Pod {
+func listAgentPods(ctx context.Context, virtualCluster *VirtualCluster) []corev1.Pod {
 	labelSelector := fmt.Sprintf("cluster=%s,type=agent,mode=%s", virtualCluster.Cluster.Name, virtualCluster.Cluster.Spec.Mode)
 
 	agentPods, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
@@ -401,7 +401,7 @@ func listAgentPods(ctx context.Context, virtualCluster *VirtualCluster) []v1.Pod
 }
 
 // getEnv will get an environment variable from a pod it will return empty string if not found
-func getEnv(pod *v1.Pod, envName string) (string, bool) {
+func getEnv(pod *corev1.Pod, envName string) (string, bool) {
 	container := pod.Spec.Containers[0]
 	for _, envVar := range container.Env {
 		if envVar.Name == envName {
@@ -413,7 +413,7 @@ func getEnv(pod *v1.Pod, envName string) (string, bool) {
 }
 
 // isArgFound will return true if the argument passed to the function is found in container args
-func isArgFound(pod *v1.Pod, arg string) bool {
+func isArgFound(pod *corev1.Pod, arg string) bool {
 	container := pod.Spec.Containers[0]
 	for _, cmd := range container.Command {
 		if strings.Contains(cmd, arg) {

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -135,18 +135,18 @@ func patchPVC(ctx context.Context, clientset *kubernetes.Clientset) {
 
 	k3kDeployment := &deployments.Items[0]
 
-	pvc := &v1.PersistentVolumeClaim{
+	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "coverage-data-pvc",
 			Namespace: k3kNamespace,
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{
-				v1.ReadWriteOnce,
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
 			},
-			Resources: v1.VolumeResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceStorage: resource.MustParse("100M"),
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("100M"),
 				},
 			},
 		},
@@ -164,21 +164,21 @@ func patchPVC(ctx context.Context, clientset *kubernetes.Clientset) {
 		}
 	}
 
-	k3kSpec.Volumes = append(k3kSpec.Volumes, v1.Volume{
+	k3kSpec.Volumes = append(k3kSpec.Volumes, corev1.Volume{
 		Name: "tmp-covdata",
-		VolumeSource: v1.VolumeSource{
-			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: "coverage-data-pvc",
 			},
 		},
 	})
 
-	k3kSpec.Containers[0].VolumeMounts = append(k3kSpec.Containers[0].VolumeMounts, v1.VolumeMount{
+	k3kSpec.Containers[0].VolumeMounts = append(k3kSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      "tmp-covdata",
 		MountPath: "/tmp/covdata",
 	})
 
-	k3kSpec.Containers[0].Env = append(k3kSpec.Containers[0].Env, v1.EnvVar{
+	k3kSpec.Containers[0].Env = append(k3kSpec.Containers[0].Env, corev1.EnvVar{
 		Name:  "GOCOVERDIR",
 		Value: "/tmp/covdata",
 	})
@@ -205,7 +205,7 @@ func patchPVC(ctx context.Context, clientset *kubernetes.Clientset) {
 		}
 
 		g.Expect(availableCond.Type).To(Equal(appsv1.DeploymentAvailable))
-		g.Expect(availableCond.Status).To(Equal(v1.ConditionTrue))
+		g.Expect(availableCond.Status).To(Equal(corev1.ConditionTrue))
 	}).
 		WithPolling(time.Second).
 		WithTimeout(time.Second * 30).
@@ -242,7 +242,7 @@ var _ = AfterSuite(func() {
 func dumpK3kCoverageData(ctx context.Context, folder string) {
 	By("Restarting k3k controller")
 
-	var podList v1.PodList
+	var podList corev1.PodList
 
 	err := k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: k3kNamespace})
 	Expect(err).To(Not(HaveOccurred()))
@@ -265,12 +265,12 @@ func dumpK3kCoverageData(ctx context.Context, folder string) {
 			Name:      k3kPod.Name,
 		}
 
-		var controllerPod v1.Pod
+		var controllerPod corev1.Pod
 
 		err = k8sClient.Get(ctx, key, &controllerPod)
 		g.Expect(err).To(Not(HaveOccurred()))
 
-		_, cond := pod.GetPodCondition(&controllerPod.Status, v1.PodReady)
+		_, cond := pod.GetPodCondition(&controllerPod.Status, corev1.PodReady)
 		g.Expect(cond).NotTo(BeNil())
 		g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 	}).
@@ -283,25 +283,25 @@ func dumpK3kCoverageData(ctx context.Context, folder string) {
 
 	GinkgoWriter.Printf("Downloading covdata from k3k controller %s/%s to %s\n", k3kNamespace, k3kPod.Name, folder)
 
-	tarPod := &v1.Pod{
+	tarPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tar",
 			Namespace: k3kNamespace,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
 				Name:    "tar",
 				Image:   "busybox",
 				Command: []string{"/bin/sh", "-c", "sleep 3600"},
-				VolumeMounts: []v1.VolumeMount{{
+				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "tmp-covdata",
 					MountPath: "/tmp/covdata",
 				}},
 			}},
-			Volumes: []v1.Volume{{
+			Volumes: []corev1.Volume{{
 				Name: "tmp-covdata",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "coverage-data-pvc",
 					},
 				},
@@ -318,7 +318,7 @@ func dumpK3kCoverageData(ctx context.Context, folder string) {
 		err = k8sClient.Get(ctx, client.ObjectKeyFromObject(tarPod), tarPod)
 		g.Expect(err).To(Not(HaveOccurred()))
 
-		_, cond := pod.GetPodCondition(&tarPod.Status, v1.PodReady)
+		_, cond := pod.GetPodCondition(&tarPod.Status, corev1.PodReady)
 		g.Expect(cond).NotTo(BeNil())
 		g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 	}).
@@ -356,13 +356,13 @@ func podExec(ctx context.Context, clientset *kubernetes.Clientset, config *rest.
 		SubResource("exec")
 	scheme := runtime.NewScheme()
 
-	if err := v1.AddToScheme(scheme); err != nil {
+	if err := corev1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("error adding to scheme: %v", err)
 	}
 
 	parameterCodec := runtime.NewParameterCodec(scheme)
 
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Command: command,
 		Stdin:   stdin != nil,
 		Stdout:  stdout != nil,
@@ -390,8 +390,8 @@ func podExec(ctx context.Context, clientset *kubernetes.Clientset, config *rest.
 	return stderr.Bytes(), nil
 }
 
-func caCertSecret(name, namespace string, crt, key []byte) *v1.Secret {
-	return &v1.Secret{
+func caCertSecret(name, namespace string, crt, key []byte) *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -478,18 +478,18 @@ func privateRegistry(ctx context.Context, namespace string) error {
 					"app": "private-registry",
 				},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": "private-registry",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "private-registry",
 							Image: registryImage,
-							VolumeMounts: []v1.VolumeMount{
+							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config",
 									MountPath: "/etc/docker/registry/",
@@ -505,27 +505,27 @@ func privateRegistry(ctx context.Context, namespace string) error {
 							},
 						},
 					},
-					Volumes: []v1.Volume{
+					Volumes: []corev1.Volume{
 						{
 							Name: "config",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "private-registry-config",
 								},
 							},
 						},
 						{
 							Name: "ca-cert",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "private-registry-ca-cert",
 								},
 							},
 						},
 						{
 							Name: "registry-cert",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "private-registry-cert",
 								},
 							},
@@ -540,7 +540,7 @@ func privateRegistry(ctx context.Context, namespace string) error {
 		return err
 	}
 
-	registryService := &v1.Service{
+	registryService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "private-registry",
 			Namespace: namespace,
@@ -549,11 +549,11 @@ func privateRegistry(ctx context.Context, namespace string) error {
 			Kind:       "Service",
 			APIVersion: "v1",
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app": "private-registry",
 			},
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "registry-port",
 					Port:       5000,
@@ -598,10 +598,10 @@ func buildRegistryNetPolicy(ctx context.Context, namespace string) error {
 	return k8sClient.Create(ctx, &np)
 }
 
-func buildRegistryConfigSecret(tlsMap map[string]string, namespace, name string, tlsSecret bool) (*v1.Secret, error) {
-	secretType := v1.SecretTypeOpaque
+func buildRegistryConfigSecret(tlsMap map[string]string, namespace, name string, tlsSecret bool) (*corev1.Secret, error) {
+	secretType := corev1.SecretTypeOpaque
 	if tlsSecret {
-		secretType = v1.SecretTypeTLS
+		secretType = corev1.SecretTypeTLS
 	}
 
 	data := make(map[string][]byte)
@@ -615,7 +615,7 @@ func buildRegistryConfigSecret(tlsMap map[string]string, namespace, name string,
 		data[key] = b
 	}
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",

--- a/tests/framework/k3k/namespace.go
+++ b/tests/framework/k3k/namespace.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,10 +19,10 @@ import (
 
 // CreateNamespace creates a new namespace with a generated name and the "e2e: true" label.
 // The namespace is created using the provided Kubernetes clientset.
-func CreateNamespace(clientset kubernetes.Interface) *v1.Namespace {
+func CreateNamespace(clientset kubernetes.Interface) *corev1.Namespace {
 	GinkgoHelper()
 
-	namespace := &v1.Namespace{
+	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "ns-",
 			Labels: map[string]string{

--- a/tests/framework/log/log.go
+++ b/tests/framework/log/log.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,7 +21,7 @@ import (
 func GetK3kPodLogs(ctx context.Context, k8sClient client.Client, clientset kubernetes.Interface, namespace string) io.ReadCloser {
 	GinkgoHelper()
 
-	var podList v1.PodList
+	var podList corev1.PodList
 
 	err := k8sClient.List(ctx, &podList, &client.ListOptions{Namespace: namespace})
 	Expect(err).To(Not(HaveOccurred()))
@@ -46,7 +46,7 @@ func GetK3kPodLogs(ctx context.Context, k8sClient client.Client, clientset kuber
 		}
 	}
 
-	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{Previous: fetchPrevious})
+	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Previous: fetchPrevious})
 	podLogs, err := req.Stream(ctx)
 	Expect(err).To(Not(HaveOccurred()))
 

--- a/tests/integration/k3k-kubelet/configmap_test.go
+++ b/tests/integration/k3k-kubelet/configmap_test.go
@@ -7,7 +7,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,7 +27,7 @@ var ConfigMapTests = func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		ns := v1.Namespace{
+		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
 		}
 		err := hostTestEnv.k8sClient.Create(ctx, &ns)
@@ -49,7 +49,7 @@ var ConfigMapTests = func() {
 	})
 
 	AfterEach(func() {
-		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -57,7 +57,7 @@ var ConfigMapTests = func() {
 	It("creates a ConfigMap on the host cluster", func() {
 		ctx := context.Background()
 
-		configMap := &v1.ConfigMap{
+		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cm-",
 				Namespace:    "default",
@@ -75,7 +75,7 @@ var ConfigMapTests = func() {
 
 		By(fmt.Sprintf("Created configmap %s in virtual cluster", configMap.Name))
 
-		var hostConfigMap v1.ConfigMap
+		var hostConfigMap corev1.ConfigMap
 
 		hostConfigMapName := translateName(cluster, configMap.Namespace, configMap.Name)
 
@@ -98,7 +98,7 @@ var ConfigMapTests = func() {
 	It("updates a ConfigMap on the host cluster", func() {
 		ctx := context.Background()
 
-		configMap := &v1.ConfigMap{
+		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cm-",
 				Namespace:    "default",
@@ -113,7 +113,7 @@ var ConfigMapTests = func() {
 
 		By(fmt.Sprintf("Created configmap %s in virtual cluster", configMap.Name))
 
-		var hostConfigMap v1.ConfigMap
+		var hostConfigMap corev1.ConfigMap
 
 		hostConfigMapName := translateName(cluster, configMap.Namespace, configMap.Name)
 
@@ -159,7 +159,7 @@ var ConfigMapTests = func() {
 	It("deletes a configMap on the host cluster", func() {
 		ctx := context.Background()
 
-		configMap := &v1.ConfigMap{
+		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cm-",
 				Namespace:    "default",
@@ -174,7 +174,7 @@ var ConfigMapTests = func() {
 
 		By(fmt.Sprintf("Created configmap %s in virtual cluster", configMap.Name))
 
-		var hostConfigMap v1.ConfigMap
+		var hostConfigMap corev1.ConfigMap
 
 		hostConfigMapName := translateName(cluster, configMap.Namespace, configMap.Name)
 
@@ -210,7 +210,7 @@ var ConfigMapTests = func() {
 		err := hostTestEnv.k8sClient.Update(ctx, &cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		configMap := &v1.ConfigMap{
+		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cm-",
 				Namespace:    "default",
@@ -225,7 +225,7 @@ var ConfigMapTests = func() {
 
 		By(fmt.Sprintf("Created configmap %s in virtual cluster", configMap.Name))
 
-		var hostConfigMap v1.ConfigMap
+		var hostConfigMap corev1.ConfigMap
 
 		hostConfigMapName := translateName(cluster, configMap.Namespace, configMap.Name)
 

--- a/tests/integration/k3k-kubelet/ingress_test.go
+++ b/tests/integration/k3k-kubelet/ingress_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +29,7 @@ var IngressTests = func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		ns := v1.Namespace{
+		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
 		}
 		err := hostTestEnv.k8sClient.Create(ctx, &ns)
@@ -63,7 +63,7 @@ var IngressTests = func() {
 	})
 
 	AfterEach(func() {
-		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -299,7 +299,7 @@ var IngressTests = func() {
 
 	It("will sync an Ingress with a TLS secret", func() {
 		ctx := context.Background()
-		ingressSecret := &v1.Secret{
+		ingressSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "ingress-secret-",
 				Namespace:    "default",
@@ -362,7 +362,7 @@ var IngressTests = func() {
 
 		var hostIngress networkingv1.Ingress
 
-		var hostSecret v1.Secret
+		var hostSecret corev1.Secret
 
 		hostIngressName := translateName(cluster, ingress.Namespace, ingress.Name)
 
@@ -395,7 +395,7 @@ var IngressTests = func() {
 		err := hostTestEnv.k8sClient.Update(ctx, &cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		ingressSecret := &v1.Secret{
+		ingressSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "ingress-secret-",
 				Namespace:    "default",
@@ -458,7 +458,7 @@ var IngressTests = func() {
 
 		var hostIngress networkingv1.Ingress
 
-		var hostSecret v1.Secret
+		var hostSecret corev1.Secret
 
 		hostIngressName := translateName(cluster, ingress.Namespace, ingress.Name)
 

--- a/tests/integration/k3k-kubelet/persistentvolumeclaims_test.go
+++ b/tests/integration/k3k-kubelet/persistentvolumeclaims_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/k3k/k3k-kubelet/controller/syncer"
@@ -28,7 +28,7 @@ var PVCTests = func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		ns := v1.Namespace{
+		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
 		}
 		err := hostTestEnv.k8sClient.Create(ctx, &ns)
@@ -50,7 +50,7 @@ var PVCTests = func() {
 	})
 
 	AfterEach(func() {
-		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -58,7 +58,7 @@ var PVCTests = func() {
 	It("creates a pvc on the host cluster and virtual pv in virtual cluster", func() {
 		ctx := context.Background()
 
-		pvc := &v1.PersistentVolumeClaim{
+		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "pvc-",
 				Namespace:    "default",
@@ -66,13 +66,13 @@ var PVCTests = func() {
 					"foo": "bar",
 				},
 			},
-			Spec: v1.PersistentVolumeClaimSpec{
+			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: ptr.To("test-sc"),
-				AccessModes: []v1.PersistentVolumeAccessMode{
-					v1.ReadOnlyMany,
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadOnlyMany,
 				},
-				Resources: v1.VolumeResourceRequirements{
-					Requests: v1.ResourceList{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
 						"storage": resource.MustParse("1G"),
 					},
 				},
@@ -84,7 +84,7 @@ var PVCTests = func() {
 
 		By(fmt.Sprintf("Created PVC %s in virtual cluster", pvc.Name))
 
-		var hostPVC v1.PersistentVolumeClaim
+		var hostPVC corev1.PersistentVolumeClaim
 
 		hostPVCName := translateName(cluster, pvc.Namespace, pvc.Name)
 
@@ -102,7 +102,7 @@ var PVCTests = func() {
 
 		GinkgoWriter.Printf("labels: %v\n", hostPVC.Labels)
 
-		var virtualPV v1.PersistentVolume
+		var virtualPV corev1.PersistentVolume
 
 		key := client.ObjectKey{Name: pvc.Name}
 

--- a/tests/integration/k3k-kubelet/priority_class_test.go
+++ b/tests/integration/k3k-kubelet/priority_class_test.go
@@ -7,7 +7,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +28,7 @@ var PriorityClassTests = func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		ns := v1.Namespace{
+		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
 		}
 		err := hostTestEnv.k8sClient.Create(ctx, &ns)
@@ -57,7 +57,7 @@ var PriorityClassTests = func() {
 	})
 
 	AfterEach(func() {
-		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/tests/integration/k3k-kubelet/secret_test.go
+++ b/tests/integration/k3k-kubelet/secret_test.go
@@ -7,7 +7,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,7 +27,7 @@ var SecretTests = func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		ns := v1.Namespace{
+		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
 		}
 		err := hostTestEnv.k8sClient.Create(ctx, &ns)
@@ -49,7 +49,7 @@ var SecretTests = func() {
 	})
 
 	AfterEach(func() {
-		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -57,7 +57,7 @@ var SecretTests = func() {
 	It("creates a Secret on the host cluster", func() {
 		ctx := context.Background()
 
-		secret := &v1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "secret-",
 				Namespace:    "default",
@@ -75,7 +75,7 @@ var SecretTests = func() {
 
 		By(fmt.Sprintf("Created Secret %s in virtual cluster", secret.Name))
 
-		var hostSecret v1.Secret
+		var hostSecret corev1.Secret
 
 		hostSecretName := translateName(cluster, secret.Namespace, secret.Name)
 
@@ -98,7 +98,7 @@ var SecretTests = func() {
 	It("updates a Secret on the host cluster", func() {
 		ctx := context.Background()
 
-		secret := &v1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "secret-",
 				Namespace:    "default",
@@ -113,7 +113,7 @@ var SecretTests = func() {
 
 		By(fmt.Sprintf("Created secret %s in virtual cluster", secret.Name))
 
-		var hostSecret v1.Secret
+		var hostSecret corev1.Secret
 
 		hostSecretName := translateName(cluster, secret.Namespace, secret.Name)
 
@@ -157,7 +157,7 @@ var SecretTests = func() {
 	It("deletes a secret on the host cluster", func() {
 		ctx := context.Background()
 
-		secret := &v1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "secret-",
 				Namespace:    "default",
@@ -172,7 +172,7 @@ var SecretTests = func() {
 
 		By(fmt.Sprintf("Created secret %s in virtual cluster", secret.Name))
 
-		var hostSecret v1.Secret
+		var hostSecret corev1.Secret
 
 		hostSecretName := translateName(cluster, secret.Namespace, secret.Name)
 
@@ -208,7 +208,7 @@ var SecretTests = func() {
 		err := hostTestEnv.k8sClient.Update(ctx, &cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		secret := &v1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "secret-",
 				Namespace:    "default",
@@ -223,7 +223,7 @@ var SecretTests = func() {
 
 		By(fmt.Sprintf("Created secret %s in virtual cluster", secret.Name))
 
-		var hostSecret v1.Secret
+		var hostSecret corev1.Secret
 
 		hostSecretName := translateName(cluster, secret.Namespace, secret.Name)
 

--- a/tests/integration/k3k-kubelet/service_test.go
+++ b/tests/integration/k3k-kubelet/service_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,7 +28,7 @@ var ServiceTests = func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		ns := v1.Namespace{
+		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "ns-"},
 		}
 		err := hostTestEnv.k8sClient.Create(ctx, &ns)
@@ -50,7 +50,7 @@ var ServiceTests = func() {
 	})
 
 	AfterEach(func() {
-		ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err := hostTestEnv.k8sClient.Delete(context.Background(), &ns)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -58,7 +58,7 @@ var ServiceTests = func() {
 	It("creates a service on the host cluster", func() {
 		ctx := context.Background()
 
-		service := &v1.Service{
+		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "service-",
 				Namespace:    "default",
@@ -66,9 +66,9 @@ var ServiceTests = func() {
 					"foo": "bar",
 				},
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeNodePort,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
 					{
 						Name:       "test-port",
 						Port:       8888,
@@ -83,7 +83,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created service %s in virtual cluster", service.Name))
 
-		var hostService v1.Service
+		var hostService corev1.Service
 
 		hostServiceName := translateName(cluster, service.Namespace, service.Name)
 
@@ -97,7 +97,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created Service %s in host cluster", hostServiceName))
 
-		Expect(hostService.Spec.Type).To(Equal(v1.ServiceTypeNodePort))
+		Expect(hostService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
 		Expect(hostService.Spec.Ports[0].Name).To(Equal("test-port"))
 		Expect(hostService.Spec.Ports[0].Port).To(Equal(int32(8888)))
 
@@ -107,7 +107,7 @@ var ServiceTests = func() {
 	It("updates a service on the host cluster", func() {
 		ctx := context.Background()
 
-		service := &v1.Service{
+		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "service-",
 				Namespace:    "default",
@@ -115,9 +115,9 @@ var ServiceTests = func() {
 					"foo": "bar",
 				},
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeNodePort,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
 					{
 						Name:       "test-port",
 						Port:       8888,
@@ -132,7 +132,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created service %s in virtual cluster", service.Name))
 
-		var hostService v1.Service
+		var hostService corev1.Service
 
 		hostServiceName := translateName(cluster, service.Namespace, service.Name)
 
@@ -146,7 +146,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created Service %s in host cluster", hostServiceName))
 
-		Expect(hostService.Spec.Type).To(Equal(v1.ServiceTypeNodePort))
+		Expect(hostService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
 		Expect(hostService.Spec.Ports[0].Name).To(Equal("test-port"))
 		Expect(hostService.Spec.Ports[0].Port).To(Equal(int32(8888)))
 
@@ -176,14 +176,14 @@ var ServiceTests = func() {
 	It("deletes a service on the host cluster", func() {
 		ctx := context.Background()
 
-		service := &v1.Service{
+		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "service-",
 				Namespace:    "default",
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeNodePort,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
 					{
 						Name:       "test-port",
 						Port:       8888,
@@ -198,7 +198,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created service %s in virtual cluster", service.Name))
 
-		var hostService v1.Service
+		var hostService corev1.Service
 
 		hostServiceName := translateName(cluster, service.Namespace, service.Name)
 
@@ -212,7 +212,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created service %s in host cluster", hostServiceName))
 
-		Expect(hostService.Spec.Type).To(Equal(v1.ServiceTypeNodePort))
+		Expect(hostService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
 		Expect(hostService.Spec.Ports[0].Name).To(Equal("test-port"))
 		Expect(hostService.Spec.Ports[0].Port).To(Equal(int32(8888)))
 
@@ -237,14 +237,14 @@ var ServiceTests = func() {
 		err := hostTestEnv.k8sClient.Update(ctx, &cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		service := &v1.Service{
+		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "service-",
 				Namespace:    "default",
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeNodePort,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
 					{
 						Name:       "test-port",
 						Port:       8888,
@@ -259,7 +259,7 @@ var ServiceTests = func() {
 
 		By(fmt.Sprintf("Created service %s in virtual cluster", service.Name))
 
-		var hostService v1.Service
+		var hostService corev1.Service
 
 		hostServiceName := translateName(cluster, service.Namespace, service.Name)
 

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,10 +52,10 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 		})
 
 		When("bound to a namespace", func() {
-			var namespace *v1.Namespace
+			var namespace *corev1.Namespace
 
 			BeforeEach(func() {
-				namespace = &v1.Namespace{
+				namespace = &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "ns-",
 					},
@@ -177,7 +177,7 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 
 				bindPolicyToNamespace(namespace, policy)
 
-				var ns v1.Namespace
+				var ns corev1.Namespace
 
 				// Check privileged
 
@@ -279,7 +279,7 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 
 				bindPolicyToNamespace(namespace, policy)
 
-				var ns v1.Namespace
+				var ns corev1.Namespace
 
 				// wait a bit for the namespace to be updated
 				Eventually(func() bool {
@@ -470,9 +470,9 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 			})
 
 			It("updates the cluster policy status with the DefaultServerAffinity and DefaultAgentAffinity", func() {
-				serverAffinity := &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				serverAffinity := &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
 							{Weight: 10},
 						},
 					},
@@ -522,9 +522,9 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 			})
 
 			It("overrides the cluster ServerAffinity and AgentAffinity with the DefaultServerAffinity and DefaultAgentAffinity from the policy", func() {
-				serverAffinity := &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				serverAffinity := &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
 							{Weight: 10},
 						},
 					},
@@ -582,17 +582,17 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 
 			It("should create a ResourceQuota if Quota is enabled", func() {
 				policy := newPolicy(v1beta1.VirtualClusterPolicySpec{
-					Quota: &v1.ResourceQuotaSpec{
-						Hard: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("800m"),
-							v1.ResourceMemory: resource.MustParse("1Gi"),
+					Quota: &corev1.ResourceQuotaSpec{
+						Hard: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("800m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
 				})
 
 				bindPolicyToNamespace(namespace, policy)
 
-				var resourceQuota v1.ResourceQuota
+				var resourceQuota corev1.ResourceQuota
 
 				Eventually(func() error {
 					key := types.NamespacedName{
@@ -611,17 +611,17 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 
 			It("should delete the ResourceQuota if Quota is deleted", func() {
 				policy := newPolicy(v1beta1.VirtualClusterPolicySpec{
-					Quota: &v1.ResourceQuotaSpec{
-						Hard: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("800m"),
-							v1.ResourceMemory: resource.MustParse("1Gi"),
+					Quota: &corev1.ResourceQuotaSpec{
+						Hard: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("800m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
 				})
 
 				bindPolicyToNamespace(namespace, policy)
 
-				var resourceQuota v1.ResourceQuota
+				var resourceQuota corev1.ResourceQuota
 
 				Eventually(func() error {
 					key := types.NamespacedName{
@@ -660,17 +660,17 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 
 			It("should delete the ResourceQuota if unbound", func() {
 				clusterPolicy := newPolicy(v1beta1.VirtualClusterPolicySpec{
-					Quota: &v1.ResourceQuotaSpec{
-						Hard: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("800m"),
-							v1.ResourceMemory: resource.MustParse("1Gi"),
+					Quota: &corev1.ResourceQuotaSpec{
+						Hard: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("800m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
 				})
 
 				bindPolicyToNamespace(namespace, clusterPolicy)
 
-				var resourceQuota v1.ResourceQuota
+				var resourceQuota corev1.ResourceQuota
 
 				Eventually(func() error {
 					key := types.NamespacedName{
@@ -722,7 +722,7 @@ func newPolicy(spec v1beta1.VirtualClusterPolicySpec) *v1beta1.VirtualClusterPol
 	return policy
 }
 
-func bindPolicyToNamespace(namespace *v1.Namespace, pol *v1beta1.VirtualClusterPolicy) {
+func bindPolicyToNamespace(namespace *corev1.Namespace, pol *v1beta1.VirtualClusterPolicy) {
 	GinkgoHelper()
 
 	if len(namespace.Labels) == 0 {


### PR DESCRIPTION
Having a consistent aliasing is useful to ensure consistencies along the project. This PR adds the `importas` linter to help us enforcing using the same aliases in the project, starting with a minimal configuration within the Kubernetes packages:

- `k8s.io/apimachinery/pkg/apis/meta/v1` -> `metav1`
- `k8s.io/apimachinery/pkg/api/errors` -> `apierrors`
- `k8s.io/api/core/v1` -> `corev1`
- `k8s.io/api/apps/v1` -> `appsv1`
- `k8s.io/api/networking/v1` -> `networkingv1`

```yaml
settings:
    importas:
      # Enforce import aliases for k8s packages
      alias:
      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
        alias: metav1
      - pkg: k8s.io/apimachinery/pkg/api/errors
        alias: apierrors
      - pkg: k8s.io/api/core/v1
        alias: corev1
      - pkg: k8s.io/api/apps/v1
        alias: appsv1
      - pkg: k8s.io/api/networking/v1
        alias: networkingv1
```

It also adds a `make lint-fix` target to run the `golangci-lint fix` used to fix the existing issues.