### PR TITLE
Fix PVC race condition (flaky test)

### DIFF
--- a/k3k-kubelet/controller/syncer/persistentvolumeclaims.go
+++ b/k3k-kubelet/controller/syncer/persistentvolumeclaims.go
@@ -191,6 +191,13 @@ func (r *PVCReconciler) createVirtualPersistentVolume(ctx context.Context, pvc c
 
 	pvcPatch.Annotations[volume.AnnBoundByController] = "yes"
 	pvcPatch.Annotations[volume.AnnBindCompleted] = "yes"
+	pvcPatch.Spec.VolumeName = pv.Name
+
+	// Update spec to set the volumeName binding
+	if err := r.VirtualClient.Update(ctx, pvcPatch); err != nil {
+		return err
+	}
+
 	pvcPatch.Status.Phase = corev1.ClaimBound
 	pvcPatch.Status.AccessModes = pvcPatch.Spec.AccessModes
 

--- a/tests/e2e/cluster_app_test.go
+++ b/tests/e2e/cluster_app_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,15 +40,16 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 			pvc        *corev1.PersistentVolumeClaim
 
 			namespace = "default"
-			labels    = map[string]string{
-				"app": "k3k-deployment-test-app",
-			}
 		)
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 
 			ctx := context.Background()
+
+			labels := map[string]string{
+				"app": "k3k-deployment-test-app-" + rand.String(5),
+			}
 
 			By("Creating the PVC")
 
@@ -68,6 +70,11 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 			pvc, err = virtualCluster.Client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			Expect(err).To(Not(HaveOccurred()))
+
+			DeferCleanup(func() {
+				err := virtualCluster.Client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
+				Expect(err).To(Not(HaveOccurred()))
+			})
 
 			By("Creating the Deployment")
 
@@ -111,6 +118,11 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 			deployment, err = virtualCluster.Client.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
 			Expect(err).To(Not(HaveOccurred()))
+
+			DeferCleanup(func() {
+				err := virtualCluster.Client.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{})
+				Expect(err).To(Not(HaveOccurred()))
+			})
 		})
 
 		It("should bound the PVC in the virtual cluster", func() {
@@ -191,19 +203,18 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 			statefulSet *appsv1.StatefulSet
 
 			namespace = "default"
-			labels    = map[string]string{
-				"app": "k3k-sts-test-app",
-			}
 		)
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 
 			ctx := context.Background()
 
-			namespace := "default"
-
 			By("Creating the StatefulSet")
+
+			labels := map[string]string{
+				"app": "k3k-sts-test-app-" + rand.String(5),
+			}
 
 			statefulSet = &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -251,6 +262,11 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 
 			statefulSet, err = virtualCluster.Client.AppsV1().StatefulSets(namespace).Create(ctx, statefulSet, metav1.CreateOptions{})
 			Expect(err).To(Not(HaveOccurred()))
+
+			DeferCleanup(func() {
+				err := virtualCluster.Client.AppsV1().StatefulSets(namespace).Delete(ctx, statefulSet.Name, metav1.DeleteOptions{})
+				Expect(err).To(Not(HaveOccurred()))
+			})
 		})
 
 		It("should bound the PVCs in the virtual cluster", func() {
@@ -279,7 +295,7 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Ordered, func() {
 				labelSelector := metav1.FormatLabelSelector(statefulSet.Spec.Selector)
 				listOpts := metav1.ListOptions{LabelSelector: labelSelector}
 
-				pvcs, err := virtualCluster.Client.CoreV1().PersistentVolumeClaims(statefulSet.Namespace).List(ctx, listOpts)
+				pvcs, err := virtualCluster.Client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, listOpts)
 				g.Expect(err).NotTo(HaveOccurred())
 
 				for _, pvc := range pvcs.Items {

--- a/tests/e2e/cluster_status_test.go
+++ b/tests/e2e/cluster_status_test.go
@@ -178,6 +178,9 @@ var _ = When("a cluster's status is tracked", Label(e2eTestLabel), Label(statusT
 				Expect(k8sClient.Delete(ctx, priorityClassVCP)).To(Succeed())
 			})
 
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(vcp), vcp)
+			Expect(err).NotTo(HaveOccurred())
+
 			vcp.Spec.DefaultPriorityClass = priorityClassVCP.Name
 			Expect(k8sClient.Update(ctx, vcp)).To(Succeed())
 

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -361,9 +361,6 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 				})
 				bindPolicyToNamespace(namespace, policy)
 
-				err := k8sClient.Update(ctx, policy)
-				Expect(err).To(Not(HaveOccurred()))
-
 				cluster := &v1beta1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "cluster-",
@@ -376,7 +373,7 @@ var _ = Describe("VirtualClusterPolicy Controller", Label("controller"), Label("
 					},
 				}
 
-				err = k8sClient.Create(ctx, cluster)
+				err := k8sClient.Create(ctx, cluster)
 				Expect(err).To(Not(HaveOccurred()))
 
 				// wait a bit


### PR DESCRIPTION
## Fix PVC `Lost` Status in Virtual Clusters

### Problem

In order to create a PVC on the host cluster we create a fake "pseudoPV" on the virtual cluster, and we bind it to a PVC.

PersistentVolumeClaims in virtual clusters would intermittently enter a `Lost` state, preventing pods from scheduling. This was a race condition between k3k's PVC syncer and Kubernetes' native PV controller.

The PVC syncer created a pseudo PV and set the PVC status to Bound, but failed to set `spec.volumeName` in the PVC.

This created an incomplete binding:
  - ✅ PV → PVC: `spec.claimRef` set correctly
  - ❌ PVC → PV: `spec.volumeName` missing

When Kubernetes' PV controller detected this inconsistency (`Bound` but with no `volumeName` reference), it marked the PVC as `Lost`.

### Failing Example

<details>
<summary>pvc.yaml</summary>

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
  finalizers:
  - kubernetes.io/pvc-protection
  - pvc.k3k.io/finalizer
  labels:
    app: k3k-sts-test-app-kb9fr
  name: www-k3k-sts-test-app-4ljrq-0
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  volumeMode: Filesystem
status:
  phase: Lost
```
</details>

<details>
<summary>pv.yaml</summary>

```yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/bound-by-controller: "true"
    pv.kubernetes.io/provisioned-by: k3k-kubelet
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    pod.k3k.io/pseudoPV: "true"
  name: www-k3k-sts-test-app-4ljrq-0
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: www-k3k-sts-test-app-4ljrq-0
    namespace: default
  flexVolume:
    driver: pseudopv
  persistentVolumeReclaimPolicy: Delete
  volumeMode: Filesystem
status:
  phase: Bound
```
</details>


Set `spec.volumeName` to properly bind the PVC to its PV will fix this issue.

## Additional changes

The PR also adds cleanup for resources in a BeforeEach, and use a dynamic label selector, that will properly create new resources and delete the old one in flaky tests.