### PR TITLE
Fix helm install

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         curl -sSfL -o ${{ env.FILENAME }} https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
         echo "${{ env.HELM_CHECKSUM_AMD64 }}  ${{ env.FILENAME }}" | sha256sum --check
-        tar -xvzf ${{ env.FILENAME }} linux-amd64
+        tar -xvzf ${{ env.FILENAME }} linux-amd64/helm
         sudo install -m 755 linux-amd64/helm /usr/local/bin/helm
 
         rm -fr "${{ env.FILENAME }}" linux-amd64

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -30,10 +30,10 @@ jobs:
       run: |
         curl -sSfL -o ${{ env.FILENAME }} https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
         echo "${{ env.HELM_CHECKSUM_AMD64 }}  ${{ env.FILENAME }}" | sha256sum --check
-        tar -xvzf ${{ env.FILENAME }} linux-amd64/helm
-        sudo install -m 755 helm /usr/local/bin/helm
+        tar -xvzf ${{ env.FILENAME }} linux-amd64
+        sudo install -m 755 linux-amd64/helm /usr/local/bin/helm
 
-        rm -f "${{ env.FILENAME }}" helm
+        rm -fr "${{ env.FILENAME }}" linux-amd64
 
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/.github/workflows/test-conformance-shared.yaml
+++ b/.github/workflows/test-conformance-shared.yaml
@@ -73,9 +73,9 @@ jobs:
         curl -sSfL -o ${{ env.FILENAME }} https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
         echo "${{ env.HELM_CHECKSUM_AMD64 }}  ${{ env.FILENAME }}" | sha256sum --check
         tar -xvzf ${{ env.FILENAME }} linux-amd64/helm
-        sudo install -m 755 helm /usr/local/bin/helm
+        sudo install -m 755 linux-amd64/helm /usr/local/bin/helm
 
-        rm -f "${{ env.FILENAME }}" helm
+        rm -fr "${{ env.FILENAME }}" linux-amd64/helm
 
     - name: Install hydrophone
       run: go install sigs.k8s.io/hydrophone@3de3e886a2f6f09635d8b981c195490af1584d97 #v0.7.0

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -71,9 +71,9 @@ jobs:
         curl -sSfL -o ${{ env.FILENAME }} https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz
         echo "${{ env.HELM_CHECKSUM_AMD64 }}  ${{ env.FILENAME }}" | sha256sum --check
         tar -xvzf ${{ env.FILENAME }} linux-amd64/helm
-        sudo install -m 755 helm /usr/local/bin/helm
+        sudo install -m 755 linux-amd64/helm /usr/local/bin/helm
 
-        rm -f "${{ env.FILENAME }}" helm
+        rm -fr "${{ env.FILENAME }}" linux-amd64/helm
 
     - name: Install hydrophone
       run: go install sigs.k8s.io/hydrophone@3de3e886a2f6f09635d8b981c195490af1584d97 #v0.7.0


### PR DESCRIPTION
Helm is now extracted into a `linux-amd64` folder, so we need to install it from there, and remove the folder.

Ref: https://github.com/rancher/k3k/actions/runs/24459916935/job/71470934094