### PR TITLE
Fix cgroup dirs for virtual mode clusters

### DIFF
--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -423,6 +423,11 @@ func (s *Server) setupStartCommand() (string, error) {
 		mode = "ha"
 	}
 
+	var runtimeClass string
+	if s.cluster.Spec.RuntimeClassName != nil {
+		runtimeClass = *s.cluster.Spec.RuntimeClassName
+	}
+
 	tmplCmd, err := template.New("").Parse(tmpl)
 	if err != nil {
 		return "", err
@@ -435,6 +440,7 @@ func (s *Server) setupStartCommand() (string, error) {
 		"CLUSTER_MODE":  mode,
 		"K3K_MODE":      string(s.cluster.Spec.Mode),
 		"EXTRA_ARGS":    strings.Join(s.cluster.Spec.ServerArgs, " "),
+		"RUNTIME_CLASS": runtimeClass,
 	}); err != nil {
 		return "", err
 	}

--- a/pkg/controller/cluster/server/template.go
+++ b/pkg/controller/cluster/server/template.go
@@ -27,7 +27,7 @@ safe_mode() {
 	if [ -d "{{.ETCD_DIR}}" ]; then
 
 		info "Starting K3s in Safe Mode (Network Policy Disabled) to patch Node IP from ${CURRENT_IP} to ${POD_IP}"
-		/bin/k3s server --disable-network-policy --config $1 {{.EXTRA_ARGS}} > /dev/null 2>&1 &
+		/bin/k3s server --disable-network-policy --config $1 $EXTRA_ARGS > /dev/null 2>&1 &
 		PID=$!
 
 		# Start the loop to wait for the nodeIP to change
@@ -58,7 +58,7 @@ start_single_node() {
 	if [ -d "{{.ETCD_DIR}}" ]; then
 		info "Existing data found in single node setup. Performing cluster-reset to ensure quorum..."
 
-		if ! /bin/k3s server --cluster-reset --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}} > /dev/null 2>&1; then
+		if ! /bin/k3s server --cluster-reset --config {{.INIT_CONFIG}} $EXTRA_ARGS > /dev/null 2>&1; then
 			fatal "cluster reset failed!"
 		fi
 		info "Cluster reset complete. Removing Reset flag file."
@@ -71,7 +71,7 @@ start_single_node() {
 	info "Adding pod IP file."
 	echo $POD_IP > /var/lib/rancher/k3s/k3k-node-ip
 
-	/bin/k3s server --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.log
+	/bin/k3s server --config {{.INIT_CONFIG}} $EXTRA_ARGS 2>&1 | tee /var/log/k3s.log
 }
 
 start_ha_node() {
@@ -81,16 +81,37 @@ start_ha_node() {
 		info "Adding pod IP file."
 		echo $POD_IP > /var/lib/rancher/k3s/k3k-node-ip
 
-		/bin/k3s server --config {{.INIT_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.log
+		/bin/k3s server --config {{.INIT_CONFIG}} $EXTRA_ARGS 2>&1 | tee /var/log/k3s.log
 	else
 		safe_mode {{.SERVER_CONFIG}}
 
 		info "Adding pod IP file."
 		echo $POD_IP > /var/lib/rancher/k3s/k3k-node-ip
 
-		/bin/k3s server --config {{.SERVER_CONFIG}} {{.EXTRA_ARGS}} 2>&1 | tee /var/log/k3s.info 
+		/bin/k3s server --config {{.SERVER_CONFIG}} $EXTRA_ARGS 2>&1 | tee /var/log/k3s.info 
 	fi
 }
+
+# Configuring cgroups for k3s process in virtual mode
+configure_cgroups() {
+	# only configure the cgroups if the runtime used is the default and the mode is virtual
+	if [ -n "{{.RUNTIME_CLASS}}" ] || [ "{{.K3K_MODE}}" != "virtual" ]; then
+		return
+	fi
+
+	root_cgroup_raw=$(cat /proc/self/cgroup)
+        root_cgroup_stripped="${root_cgroup_raw#0::}"
+        root_cgroup_parent=$(dirname "$root_cgroup_stripped")
+
+	info "Current CGROUPS for $POD_NAME: ${root_cgroup_raw}"
+
+	# overriding kubelet cgroup and the cgroup root for pods, this will prevent k3s
+	# automatic placement see: https://github.com/k3s-io/k3s/blob/main/pkg/cgroups/cgroups_linux.go#L114-L127
+	EXTRA_ARGS="$EXTRA_ARGS --kubelet-arg=kubelet-cgroups=$root_cgroup_parent/k3s --kubelet-arg=cgroup-root=$root_cgroup_parent"
+}
+
+EXTRA_ARGS={{.EXTRA_ARGS}}
+configure_cgroups
 
 case "{{.CLUSTER_MODE}}" in
     "ha")

--- a/pkg/controller/cluster/server/template.go
+++ b/pkg/controller/cluster/server/template.go
@@ -100,8 +100,8 @@ configure_cgroups() {
 	fi
 
 	root_cgroup_raw=$(cat /proc/self/cgroup)
-        root_cgroup_stripped="${root_cgroup_raw#0::}"
-        root_cgroup_parent=$(dirname "$root_cgroup_stripped")
+	root_cgroup_stripped="${root_cgroup_raw#0::}"
+	root_cgroup_parent=$(dirname "$root_cgroup_stripped")
 
 	info "Current CGROUPS for $POD_NAME: ${root_cgroup_raw}"
 


### PR DESCRIPTION
The PR addresses #517 and #512, since in default virtual mode the k3s pods run with privileged mode and due to https://github.com/k3s-io/k3s/blob/main/pkg/cgroups/cgroups_linux.go#L114-L127, the k3s process of the server/agent pod cgroup was detached to /k3s:

```sh
# cat /proc/<pid-of-k3s-server>/cgroup
0::/k3s
```
This caused the underlying pods to not abide with the server limits added to the virtual cluster, for example metrics server running within k3s, runs in a different hierarchy than the server pod:

```sh
hussein   142989 33.1  0.7 1296324 60812 ?       Ssl  15:37   0:00 /metrics-server -.....

root@lab-ubuntu2404-0:~# cat /proc/142989/cgroup 

0::/kubepods/burstable/pod404bd273-57bc-4508-a386-e2b76d3c9cfe/3aaaa76f09e1de6bb75e84f9c15b737a2d590f69757953e3ec262bd5861dc15b
```

The fix is to get the parent dir of the pod, and assign it to the kubelet process and cgroup root for pods, this allows k3s server process and the pods to run within the right cgroup hierarchy for the server/agent pod:

```sh
root      124583  0.0  0.0   1024   712 ?        Ss   15:10   0:00 /bin/sh -c  ........ (startup command)
root      124601  5.2  8.4 12389908 668028 ?     Sl   15:10   0:39 /bin/k3s server

root@lab-ubuntu2404-0:~# cat /proc/124601/cgroup 
0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod33baea74_f206_4f95_9893_c56282acda4e.slice/k3s
root@lab-ubuntu2404-0:~# cat /proc/124583/cgroup 
0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod33baea74_f206_4f95_9893_c56282acda4e.slice/cri-containerd-f4362fd28f6c7834afa0c21f30eea45fd167496674370b2cb7a3c4e1564fd9cc.scope
```