### PR TITLE
Filter requests. infrastructure resources for node capacity

### DIFF
--- a/k3k-kubelet/provider/configure_capacity.go
+++ b/k3k-kubelet/provider/configure_capacity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"maps"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -171,7 +172,14 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 
 	// Distribute each resource type from the policy's hard quota
 	for resourceName, totalQuantity := range quotas {
-		_, useMilli := milliScaleResources[resourceName]
+		// for node capacity it only makes sense to use limits for infrastructure resources like
+		// limits.cpu and limits.memory and for extended resources it only uses requests
+		filteredResourceName, eligibleResource := filterQuotaResource(resourceName)
+		if !eligibleResource {
+			continue
+		}
+
+		_, useMilli := milliScaleResources[filteredResourceName]
 
 		// eligible nodes for each distribution cycle
 		var eligibleNodes []string
@@ -185,7 +193,7 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 				continue
 			}
 
-			resourceQuantity, found := hostNodeResources[resourceName]
+			resourceQuantity, found := hostNodeResources[filteredResourceName]
 			if !found {
 				// skip the node if the resource does not exist on the host node
 				continue
@@ -225,11 +233,11 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 				nodeQuantity = min(nodeQuantity, hostCap[virtualNodeName])
 
 				if nodeQuantity > 0 {
-					existing := resourceMap[virtualNodeName][resourceName]
+					existing := resourceMap[virtualNodeName][filteredResourceName]
 					if useMilli {
-						resourceMap[virtualNodeName][resourceName] = *resource.NewMilliQuantity(existing.MilliValue()+nodeQuantity, totalQuantity.Format)
+						resourceMap[virtualNodeName][filteredResourceName] = *resource.NewMilliQuantity(existing.MilliValue()+nodeQuantity, totalQuantity.Format)
 					} else {
-						resourceMap[virtualNodeName][resourceName] = *resource.NewQuantity(existing.Value()+nodeQuantity, totalQuantity.Format)
+						resourceMap[virtualNodeName][filteredResourceName] = *resource.NewQuantity(existing.Value()+nodeQuantity, totalQuantity.Format)
 					}
 				}
 
@@ -246,4 +254,25 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 	}
 
 	return resourceMap
+}
+
+func filterQuotaResource(resourceName corev1.ResourceName) (corev1.ResourceName, bool) {
+	// skip requests. for core infrastructure resources
+	if resourceName == corev1.ResourceCPU ||
+		resourceName == corev1.ResourceMemory ||
+		resourceName == corev1.ResourceEphemeralStorage ||
+		resourceName == corev1.ResourceRequestsCPU ||
+		resourceName == corev1.ResourceRequestsMemory ||
+		resourceName == corev1.ResourceRequestsEphemeralStorage {
+		return resourceName, false
+	}
+
+	// for other resources, strip limits and requests prefix
+	// for example "requests.nvidia.com/gpu" will return back "nvidia.com/gpu"
+	// to update the virtual node capacity properly
+	filteredResourceName := strings.TrimPrefix(resourceName.String(), "requests.")
+	filteredResourceName = strings.TrimPrefix(filteredResourceName, "limits.")
+
+	return corev1.ResourceName(filteredResourceName), true
+
 }

--- a/k3k-kubelet/provider/configure_capacity.go
+++ b/k3k-kubelet/provider/configure_capacity.go
@@ -274,5 +274,4 @@ func filterQuotaResource(resourceName corev1.ResourceName) (corev1.ResourceName,
 	filteredResourceName = strings.TrimPrefix(filteredResourceName, "limits.")
 
 	return corev1.ResourceName(filteredResourceName), true
-
 }

--- a/k3k-kubelet/provider/configure_capacity.go
+++ b/k3k-kubelet/provider/configure_capacity.go
@@ -184,6 +184,16 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 	resourceMap := make(map[string]corev1.ResourceList, len(virtResourceMap))
 	maps.Copy(resourceMap, virtResourceMap)
 
+	// fill out any allocatable resource that does not exist in quota
+	for vn := range virtResourceMap {
+		if hostResources, ok := hostResourceMap[vn]; ok {
+			for resourceName, resourceQty := range hostResources {
+				if _, ok := quotas[resourceName]; !ok {
+					resourceMap[vn][resourceName] = resourceQty
+				}
+			}
+		}
+	}
 	// Distribute each resource type from the policy's hard quota
 	for resourceName, totalQuantity := range quotas {
 		_, useMilli := milliScaleResources[resourceName]

--- a/k3k-kubelet/provider/configure_capacity.go
+++ b/k3k-kubelet/provider/configure_capacity.go
@@ -38,6 +38,19 @@ var milliScaleResources = map[corev1.ResourceName]struct{}{
 	corev1.ResourceLimitsEphemeralStorage:   {},
 }
 
+// coreResources is a set of the core infrastructure resource requests, if a quota resource
+// is in this map then it should not be reflected to the virtual node capacity.
+var coreResources = map[corev1.ResourceName]struct{}{
+	corev1.ResourceCPU:                      {},
+	corev1.ResourceMemory:                   {},
+	corev1.ResourceStorage:                  {},
+	corev1.ResourceEphemeralStorage:         {},
+	corev1.ResourceRequestsCPU:              {},
+	corev1.ResourceRequestsMemory:           {},
+	corev1.ResourceRequestsStorage:          {},
+	corev1.ResourceRequestsEphemeralStorage: {},
+}
+
 // StartNodeCapacityUpdater starts a goroutine that periodically updates the capacity
 // of the virtual node based on host node capacity and any applied ResourceQuotas.
 func startNodeCapacityUpdater(ctx context.Context, logger logr.Logger, hostClient client.Client, virtualClient client.Client, virtualCluster v1beta1.Cluster, virtualNodeName string) {
@@ -110,6 +123,7 @@ func updateNodeCapacity(ctx context.Context, logger logr.Logger, hostClient clie
 		}
 
 		mergedQuota := mergeQuotas(resourceLists...)
+		mergedQuota = filterQuotas(mergedQuota)
 
 		// get the node's quota and merge it with the current values
 		m := distributeQuotas(hostResourceMap, virtResourceMap, mergedQuota)
@@ -172,14 +186,7 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 
 	// Distribute each resource type from the policy's hard quota
 	for resourceName, totalQuantity := range quotas {
-		// for node capacity it only makes sense to use limits for infrastructure resources like
-		// limits.cpu and limits.memory and for extended resources it only uses requests
-		filteredResourceName, eligibleResource := filterQuotaResource(resourceName)
-		if !eligibleResource {
-			continue
-		}
-
-		_, useMilli := milliScaleResources[filteredResourceName]
+		_, useMilli := milliScaleResources[resourceName]
 
 		// eligible nodes for each distribution cycle
 		var eligibleNodes []string
@@ -193,7 +200,7 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 				continue
 			}
 
-			resourceQuantity, found := hostNodeResources[filteredResourceName]
+			resourceQuantity, found := hostNodeResources[resourceName]
 			if !found {
 				// skip the node if the resource does not exist on the host node
 				continue
@@ -233,11 +240,11 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 				nodeQuantity = min(nodeQuantity, hostCap[virtualNodeName])
 
 				if nodeQuantity > 0 {
-					existing := resourceMap[virtualNodeName][filteredResourceName]
+					existing := resourceMap[virtualNodeName][resourceName]
 					if useMilli {
-						resourceMap[virtualNodeName][filteredResourceName] = *resource.NewMilliQuantity(existing.MilliValue()+nodeQuantity, totalQuantity.Format)
+						resourceMap[virtualNodeName][resourceName] = *resource.NewMilliQuantity(existing.MilliValue()+nodeQuantity, totalQuantity.Format)
 					} else {
-						resourceMap[virtualNodeName][filteredResourceName] = *resource.NewQuantity(existing.Value()+nodeQuantity, totalQuantity.Format)
+						resourceMap[virtualNodeName][resourceName] = *resource.NewQuantity(existing.Value()+nodeQuantity, totalQuantity.Format)
 					}
 				}
 
@@ -256,22 +263,21 @@ func distributeQuotas(hostResourceMap, virtResourceMap map[string]corev1.Resourc
 	return resourceMap
 }
 
-func filterQuotaResource(resourceName corev1.ResourceName) (corev1.ResourceName, bool) {
-	// skip requests. for core infrastructure resources
-	if resourceName == corev1.ResourceCPU ||
-		resourceName == corev1.ResourceMemory ||
-		resourceName == corev1.ResourceEphemeralStorage ||
-		resourceName == corev1.ResourceRequestsCPU ||
-		resourceName == corev1.ResourceRequestsMemory ||
-		resourceName == corev1.ResourceRequestsEphemeralStorage {
-		return resourceName, false
+// filterQuotas filters a resource list from any resource that is not eligible to be used for node capacity
+// like core resources requests, it also strips requests/limits prefixes from other extended resources
+// for example "requests.nvidia.com/gpu" will return back "nvidia.com/gpu"
+func filterQuotas(resources corev1.ResourceList) corev1.ResourceList {
+	filteredResources := make(map[corev1.ResourceName]resource.Quantity)
+
+	for resourceName, resourceValue := range resources {
+		if _, ok := coreResources[resourceName]; ok {
+			continue
+		}
+
+		filteredResourceName := strings.TrimPrefix(resourceName.String(), "requests.")
+		filteredResourceName = strings.TrimPrefix(filteredResourceName, "limits.")
+		filteredResources[corev1.ResourceName(filteredResourceName)] = resourceValue
 	}
 
-	// for other resources, strip limits and requests prefix
-	// for example "requests.nvidia.com/gpu" will return back "nvidia.com/gpu"
-	// to update the virtual node capacity properly
-	filteredResourceName := strings.TrimPrefix(resourceName.String(), "requests.")
-	filteredResourceName = strings.TrimPrefix(filteredResourceName, "limits.")
-
-	return corev1.ResourceName(filteredResourceName), true
+	return filteredResources
 }

--- a/k3k-kubelet/provider/configure_capacity_test.go
+++ b/k3k-kubelet/provider/configure_capacity_test.go
@@ -33,7 +33,7 @@ func Test_distributeQuotas(t *testing.T) {
 			name:            "no virtual nodes",
 			virtResourceMap: map[string]corev1.ResourceList{},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("2"),
+				corev1.ResourceLimitsCPU: resource.MustParse("2"),
 			},
 			want: map[string]corev1.ResourceList{},
 		},
@@ -66,8 +66,8 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-4": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceLimitsCPU:    resource.MustParse("2"),
+				corev1.ResourceLimitsMemory: resource.MustParse("4Gi"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
@@ -91,8 +91,8 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-2": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceLimitsCPU:    resource.MustParse("2"),
+				corev1.ResourceLimitsMemory: resource.MustParse("4Gi"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
@@ -118,7 +118,7 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-3": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("2"),
+				corev1.ResourceLimitsCPU: resource.MustParse("2"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {corev1.ResourceCPU: resource.MustParse("667m")},
@@ -139,8 +139,8 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-3": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU:  resource.MustParse("2"),
-				corev1.ResourcePods: resource.MustParse("11"),
+				corev1.ResourceLimitsCPU: resource.MustParse("2"),
+				corev1.ResourcePods:      resource.MustParse("11"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
@@ -178,8 +178,8 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("3"),
-				"nvidia.com/gpu":   resource.MustParse("4"),
+				corev1.ResourceLimitsCPU:                       resource.MustParse("3"),
+				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("4"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
@@ -210,7 +210,7 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("6"),
+				corev1.ResourceLimitsCPU: resource.MustParse("6"),
 			},
 			// Even split would be 3 each, but node-2 only has 2 CPU.
 			// node-2 gets capped at 2, the remaining 1 goes to node-1.
@@ -234,13 +234,54 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				"nvidia.com/gpu": resource.MustParse("4"),
+				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("4"),
 			},
 			// Even split would be 2 each, but node-2 only has 1 GPU.
 			// node-2 gets capped at 1, the remaining 1 goes to node-1.
 			want: map[string]corev1.ResourceList{
 				"node-1": {"nvidia.com/gpu": resource.MustParse("3")},
 				"node-2": {"nvidia.com/gpu": resource.MustParse("1")},
+			},
+		},
+		{
+			name: "bare cpu and requests.* core resources are skipped",
+			virtResourceMap: map[string]corev1.ResourceList{
+				"node-1": {},
+				"node-2": {},
+			},
+			hostResourceMap: map[string]corev1.ResourceList{
+				"node-1": largeAllocatable,
+				"node-2": largeAllocatable,
+			},
+			quotas: corev1.ResourceList{
+				corev1.ResourceCPU:                      resource.MustParse("2"),
+				corev1.ResourceRequestsCPU:              resource.MustParse("2"),
+				corev1.ResourceRequestsMemory:           resource.MustParse("4Gi"),
+				corev1.ResourceRequestsEphemeralStorage: resource.MustParse("4Gi"),
+			},
+			want: map[string]corev1.ResourceList{
+				"node-1": {},
+				"node-2": {},
+			},
+		},
+		{
+			name: "limits.cpu wins when mixed with requests.cpu",
+			virtResourceMap: map[string]corev1.ResourceList{
+				"node-1": {},
+				"node-2": {},
+			},
+			hostResourceMap: map[string]corev1.ResourceList{
+				"node-1": largeAllocatable,
+				"node-2": largeAllocatable,
+			},
+			// requests.cpu must not contribute to the cpu capacity; only limits.cpu does.
+			quotas: corev1.ResourceList{
+				corev1.ResourceLimitsCPU:   resource.MustParse("2"),
+				corev1.ResourceRequestsCPU: resource.MustParse("50"),
+			},
+			want: map[string]corev1.ResourceList{
+				"node-1": {corev1.ResourceCPU: resource.MustParse("1")},
+				"node-2": {corev1.ResourceCPU: resource.MustParse("1")},
 			},
 		},
 		{
@@ -262,7 +303,7 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				"nvidia.com/gpu": resource.MustParse("10"),
+				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("10"),
 			},
 			// Total host capacity is 4, quota is 10. Each node gets its full capacity.
 			want: map[string]corev1.ResourceList{

--- a/k3k-kubelet/provider/configure_capacity_test.go
+++ b/k3k-kubelet/provider/configure_capacity_test.go
@@ -316,7 +316,8 @@ func Test_distributeQuotas(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := distributeQuotas(tt.hostResourceMap, tt.virtResourceMap, tt.quotas)
+			filteredQuota := filterQuotas(tt.quotas)
+			got := distributeQuotas(tt.hostResourceMap, tt.virtResourceMap, filteredQuota)
 
 			assert.Equal(t, len(tt.want), len(got), "Number of nodes in result should match")
 

--- a/k3k-kubelet/provider/configure_capacity_test.go
+++ b/k3k-kubelet/provider/configure_capacity_test.go
@@ -33,7 +33,7 @@ func Test_distributeQuotas(t *testing.T) {
 			name:            "no virtual nodes",
 			virtResourceMap: map[string]corev1.ResourceList{},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU: resource.MustParse("2"),
+				corev1.ResourceCPU: resource.MustParse("2"),
 			},
 			want: map[string]corev1.ResourceList{},
 		},
@@ -49,8 +49,8 @@ func Test_distributeQuotas(t *testing.T) {
 			},
 			quotas: corev1.ResourceList{},
 			want: map[string]corev1.ResourceList{
-				"node-1": {},
-				"node-2": {},
+				"node-1": largeAllocatable,
+				"node-2": largeAllocatable,
 			},
 		},
 		{
@@ -66,17 +66,19 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-4": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU:    resource.MustParse("2"),
-				corev1.ResourceLimitsMemory: resource.MustParse("4Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
 				},
 				"node-2": {
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
 				},
 			},
 		},
@@ -91,17 +93,19 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-2": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU:    resource.MustParse("2"),
-				corev1.ResourceLimitsMemory: resource.MustParse("4Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
 				},
 				"node-2": {
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
 				},
 			},
 		},
@@ -118,12 +122,12 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-3": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU: resource.MustParse("2"),
+				corev1.ResourceCPU: resource.MustParse("2"),
 			},
 			want: map[string]corev1.ResourceList{
-				"node-1": {corev1.ResourceCPU: resource.MustParse("667m")},
-				"node-2": {corev1.ResourceCPU: resource.MustParse("667m")},
-				"node-3": {corev1.ResourceCPU: resource.MustParse("666m")},
+				"node-1": {corev1.ResourceCPU: resource.MustParse("667m"), corev1.ResourceMemory: resource.MustParse("100Gi"), corev1.ResourcePods: resource.MustParse("1000")},
+				"node-2": {corev1.ResourceCPU: resource.MustParse("667m"), corev1.ResourceMemory: resource.MustParse("100Gi"), corev1.ResourcePods: resource.MustParse("1000")},
+				"node-3": {corev1.ResourceCPU: resource.MustParse("666m"), corev1.ResourceMemory: resource.MustParse("100Gi"), corev1.ResourcePods: resource.MustParse("1000")},
 			},
 		},
 		{
@@ -139,21 +143,24 @@ func Test_distributeQuotas(t *testing.T) {
 				"node-3": largeAllocatable,
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU: resource.MustParse("2"),
-				corev1.ResourcePods:      resource.MustParse("11"),
+				corev1.ResourceCPU:  resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("11"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
-					corev1.ResourceCPU:  resource.MustParse("667m"),
-					corev1.ResourcePods: resource.MustParse("4"),
+					corev1.ResourceCPU:    resource.MustParse("667m"),
+					corev1.ResourcePods:   resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
 				},
 				"node-2": {
-					corev1.ResourceCPU:  resource.MustParse("667m"),
-					corev1.ResourcePods: resource.MustParse("4"),
+					corev1.ResourceCPU:    resource.MustParse("667m"),
+					corev1.ResourcePods:   resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
 				},
 				"node-3": {
-					corev1.ResourceCPU:  resource.MustParse("666m"),
-					corev1.ResourcePods: resource.MustParse("3"),
+					corev1.ResourceCPU:    resource.MustParse("666m"),
+					corev1.ResourcePods:   resource.MustParse("3"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
 				},
 			},
 		},
@@ -178,8 +185,8 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU:                       resource.MustParse("3"),
-				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("4"),
+				corev1.ResourceCPU: resource.MustParse("3"),
+				"nvidia.com/gpu":   resource.MustParse("4"),
 			},
 			want: map[string]corev1.ResourceList{
 				"node-1": {
@@ -210,7 +217,7 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU: resource.MustParse("6"),
+				corev1.ResourceCPU: resource.MustParse("6"),
 			},
 			// Even split would be 3 each, but node-2 only has 2 CPU.
 			// node-2 gets capped at 2, the remaining 1 goes to node-1.
@@ -234,54 +241,13 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("4"),
+				"nvidia.com/gpu": resource.MustParse("4"),
 			},
 			// Even split would be 2 each, but node-2 only has 1 GPU.
 			// node-2 gets capped at 1, the remaining 1 goes to node-1.
 			want: map[string]corev1.ResourceList{
 				"node-1": {"nvidia.com/gpu": resource.MustParse("3")},
 				"node-2": {"nvidia.com/gpu": resource.MustParse("1")},
-			},
-		},
-		{
-			name: "bare cpu and requests.* core resources are skipped",
-			virtResourceMap: map[string]corev1.ResourceList{
-				"node-1": {},
-				"node-2": {},
-			},
-			hostResourceMap: map[string]corev1.ResourceList{
-				"node-1": largeAllocatable,
-				"node-2": largeAllocatable,
-			},
-			quotas: corev1.ResourceList{
-				corev1.ResourceCPU:                      resource.MustParse("2"),
-				corev1.ResourceRequestsCPU:              resource.MustParse("2"),
-				corev1.ResourceRequestsMemory:           resource.MustParse("4Gi"),
-				corev1.ResourceRequestsEphemeralStorage: resource.MustParse("4Gi"),
-			},
-			want: map[string]corev1.ResourceList{
-				"node-1": {},
-				"node-2": {},
-			},
-		},
-		{
-			name: "limits.cpu wins when mixed with requests.cpu",
-			virtResourceMap: map[string]corev1.ResourceList{
-				"node-1": {},
-				"node-2": {},
-			},
-			hostResourceMap: map[string]corev1.ResourceList{
-				"node-1": largeAllocatable,
-				"node-2": largeAllocatable,
-			},
-			// requests.cpu must not contribute to the cpu capacity; only limits.cpu does.
-			quotas: corev1.ResourceList{
-				corev1.ResourceLimitsCPU:   resource.MustParse("2"),
-				corev1.ResourceRequestsCPU: resource.MustParse("50"),
-			},
-			want: map[string]corev1.ResourceList{
-				"node-1": {corev1.ResourceCPU: resource.MustParse("1")},
-				"node-2": {corev1.ResourceCPU: resource.MustParse("1")},
 			},
 		},
 		{
@@ -303,7 +269,7 @@ func Test_distributeQuotas(t *testing.T) {
 				},
 			},
 			quotas: corev1.ResourceList{
-				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("10"),
+				"nvidia.com/gpu": resource.MustParse("10"),
 			},
 			// Total host capacity is 4, quota is 10. Each node gets its full capacity.
 			want: map[string]corev1.ResourceList{
@@ -316,8 +282,8 @@ func Test_distributeQuotas(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filteredQuota := filterQuotas(tt.quotas)
-			got := distributeQuotas(tt.hostResourceMap, tt.virtResourceMap, filteredQuota)
+			// quotas are assumed to be filtered and merged into one list. there is a dedicated test for filtering quotas
+			got := distributeQuotas(tt.hostResourceMap, tt.virtResourceMap, tt.quotas)
 
 			assert.Equal(t, len(tt.want), len(got), "Number of nodes in result should match")
 
@@ -332,6 +298,91 @@ func Test_distributeQuotas(t *testing.T) {
 					assert.True(t, ok, "Resource %s not found for node %s", resName, nodeName)
 					assert.True(t, expectedQty.Equal(actualQty), "Resource %s for node %s did not match. want: %s, got: %s", resName, nodeName, expectedQty.String(), actualQty.String())
 				}
+			}
+		})
+	}
+}
+
+func Test_mergeQuotas(t *testing.T) {
+	tests := []struct {
+		name       string
+		quotasList []corev1.ResourceList
+		want       corev1.ResourceList
+	}{
+		{
+			name:       "no resource lists",
+			quotasList: []corev1.ResourceList{},
+			want:       corev1.ResourceList{},
+		},
+		{
+			name: "single resource list",
+			quotasList: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		{
+			name: "most restrictive value wins",
+			quotasList: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("32Gi"),
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+		{
+			name: "resource only in one list is included",
+			quotasList: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+		{
+			name: "three lists pick minimum across all",
+			quotasList: []corev1.ResourceList{
+				{corev1.ResourceCPU: resource.MustParse("10")},
+				{corev1.ResourceCPU: resource.MustParse("6")},
+				{corev1.ResourceCPU: resource.MustParse("8")},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("6"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeQuotas(tt.quotasList...)
+
+			assert.Equal(t, len(tt.want), len(got), "Number of resources in merged quota should match")
+
+			for resName, expectedQty := range tt.want {
+				actualQty, ok := got[resName]
+				assert.True(t, ok, "Resource %s not found in merged quota", resName)
+				assert.True(t, expectedQty.Equal(actualQty), "Resource %s did not match. want: %s, got: %s", resName, expectedQty.String(), actualQty.String())
 			}
 		})
 	}

--- a/k3k-kubelet/provider/configure_capacity_test.go
+++ b/k3k-kubelet/provider/configure_capacity_test.go
@@ -125,9 +125,21 @@ func Test_distributeQuotas(t *testing.T) {
 				corev1.ResourceCPU: resource.MustParse("2"),
 			},
 			want: map[string]corev1.ResourceList{
-				"node-1": {corev1.ResourceCPU: resource.MustParse("667m"), corev1.ResourceMemory: resource.MustParse("100Gi"), corev1.ResourcePods: resource.MustParse("1000")},
-				"node-2": {corev1.ResourceCPU: resource.MustParse("667m"), corev1.ResourceMemory: resource.MustParse("100Gi"), corev1.ResourcePods: resource.MustParse("1000")},
-				"node-3": {corev1.ResourceCPU: resource.MustParse("666m"), corev1.ResourceMemory: resource.MustParse("100Gi"), corev1.ResourcePods: resource.MustParse("1000")},
+				"node-1": {
+					corev1.ResourceCPU:    resource.MustParse("667m"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
+				},
+				"node-2": {
+					corev1.ResourceCPU:    resource.MustParse("667m"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
+				},
+				"node-3": {
+					corev1.ResourceCPU:    resource.MustParse("666m"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
+					corev1.ResourcePods:   resource.MustParse("1000"),
+				},
 			},
 		},
 		{

--- a/k3k-kubelet/provider/configure_capacity_test.go
+++ b/k3k-kubelet/provider/configure_capacity_test.go
@@ -336,3 +336,79 @@ func Test_distributeQuotas(t *testing.T) {
 		})
 	}
 }
+
+func Test_filterQuotas(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		quotas corev1.ResourceList
+		want   corev1.ResourceList
+	}{
+		{
+			name: "no quotas",
+			want: corev1.ResourceList{},
+		}, {
+			name: "filter core infrastructure request resources with no requests prefix",
+			quotas: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("500m"),
+				corev1.ResourceMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceStorage:          resource.MustParse("5Gi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
+			},
+			want: corev1.ResourceList{},
+		}, {
+			name: "filter core infrastructure request resources with requests prefix",
+			quotas: corev1.ResourceList{
+				corev1.ResourceRequestsCPU:              resource.MustParse("500m"),
+				corev1.ResourceRequestsMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceRequestsStorage:          resource.MustParse("5Gi"),
+				corev1.ResourceRequestsEphemeralStorage: resource.MustParse("5Gi"),
+			},
+			want: corev1.ResourceList{},
+		}, {
+			name: "trim limits prefix in core infrastructure resources",
+			quotas: corev1.ResourceList{
+				corev1.ResourceLimitsCPU:              resource.MustParse("500m"),
+				corev1.ResourceLimitsMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceLimitsEphemeralStorage: resource.MustParse("5Gi"),
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("500m"),
+				corev1.ResourceMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
+			},
+		}, {
+			name: "trim requests prefix in extended resources",
+			quotas: corev1.ResourceList{
+				"requests.nvidia.com/gpu": resource.MustParse("2"),
+			},
+			want: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("2"),
+			},
+		}, {
+			name: "will not filter extended resources or object counts",
+			quotas: corev1.ResourceList{
+				"nvidia.com/gpu":    resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("5"),
+			},
+			want: corev1.ResourceList{
+				"nvidia.com/gpu":    resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("5"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filteredQuota := filterQuotas(tt.quotas)
+
+			for expectedResourceName, expectedResourceQty := range tt.want {
+				actualResourceQty, ok := filteredQuota[expectedResourceName]
+				assert.True(t, ok, "%s resource is not found in filtered quotas", expectedResourceName)
+				assert.True(t, expectedResourceQty.Equal(actualResourceQty), "Filtered Resource %s did not match. want: %s, got: %s", expectedResourceName, expectedResourceQty.String(), actualResourceQty.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Based on recent testing https://github.com/rancher/k3k/issues/683#issuecomment-4348654767 it seems that we are not properly handling `requests.*` and `limits.*` for the virtual node capacity in shared mode.

The `updateNodeCapacity` flow previously took every key from a namespace's merged `ResourceQuota.Status.Hard` and tried to apply it directly as virtual node capacity. That conflates request budgets with capacity ceilings: keys like `requests.cpu` and `limits.cpu` were both looked up against the host node's Allocatable (which only knows the bare cpu key), so the result depended on map iteration order and at best one of them silently won. Worse, extended-resource quotas (which Kubernetes only allows in the `requests.<name>` form) never matched the host's bare resource key and were dropped entirely.

This change adds a `filterQuotaResource` step that skips quota keys that describe request budgets rather than capacity (cpu, memory, ephemeral-storage, requests.cpu, requests.memory, requests.ephemeral-storage) and strips the limits. / requests. prefix off everything else before lookup, so `limits.cpu` distributes as `cpu` capacity and `requests.nvidia.com/gpu` distributes as `nvidia.com/gpu`.

For example, given the following quota across two virtual nodes:

```yaml
  spec:
    hard:
      limits.cpu: "8"                                                                                
      limits.memory: 16Gi
      requests.cpu: "4"                                                                              
      requests.nvidia.com/gpu: "2"
```                                                                
each virtual node now reports:
```yaml                                                                                                 
  status:         
    allocatable:                                                                                     
      cpu: "4"
      memory: 8Gi                                                                                    
      nvidia.com/gpu: "1"
```