### PR TITLE
Add optional CCNP in chart

### DIFF
--- a/charts/k3k/templates/ccnp.yaml
+++ b/charts/k3k/templates/ccnp.yaml
@@ -72,5 +72,24 @@ spec:
 {{- end -}}
 {{- /* if $k3kService */ -}}
 {{- end -}}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "allow-k3k-to-servers"
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: k3k
+  egress:
+    -
+      toEndpoints:
+        - matchLabels:
+            role: server
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+
 {{- /* if ccnp netpol is enabled */ -}}
 {{- end -}}

--- a/charts/k3k/templates/ccnp.yaml
+++ b/charts/k3k/templates/ccnp.yaml
@@ -1,0 +1,76 @@
+{{- if eq .Values.netpol.flavor "ccnp" }}
+{{/* Mimic the logic in getURLFromService, see pkg/controller/kubeconfig/kubeconfig.go */}}
+{{- $k3kService := (lookup "v1" "Service" "default" "kubernetes") -}}
+
+{{- if $k3kService -}}
+  {{- $ip := "" -}}
+  {{- $port := "" -}}
+
+  {{- /* Case: NodePort (uses Host IP and NodePort) */ -}}
+  {{- if eq $k3kService.spec.type "NodePort" -}}
+    {{- $ip = "reserved:host" -}}
+    {{- if $k3kService.spec.ports -}}
+      {{- $port = (index $k3kService.spec.ports 0).nodePort -}}
+    {{- end -}}
+  {{- /* Case: ClusterIP (look up endpoint and use that) */ -}}
+  {{- else if eq $k3kService.spec.type "ClusterIP" -}}
+    {{- $endpointslice := (lookup "discovery.k8s.io/v1" "EndpointSlice" "default" "kubernetes") }}
+    {{- $ip = get ($endpointslice.endpoints | first) "addresses" | first -}}
+    {{/* Pain: If the k8s api is exposed on the host IP, the EndpointSlice just names it by IP. However,
+         Cilium doesn't allow traffic by CIDR to the host, it wants the special "this is traffic to the
+         host" label. */}}
+    {{- $nodes := lookup "v1" "Node" "" "" -}}
+    {{- $nodeaddrs := list -}}
+    {{- range $k, $node := $nodes.items -}}
+      {{- range $addr := $node.status.addresses }}
+        {{ $nodeaddrs = append $nodeaddrs $addr.address}}
+      {{- end -}}
+    {{- end -}}
+    {{- if has (index (splitList "/" $ip) 0) $nodeaddrs -}}
+      {{- $ip = "reserved:host" -}}
+    {{- end -}}
+    {{- $port = get ($endpointslice.ports | first) "port" -}}
+  {{- /* Case: LoadBalancer */ -}}
+  {{- else if eq $k3kService.spec.type "LoadBalancer" -}}
+    {{- if and $k3kService.status.loadBalancer.ingress (gt (len $k3kService.status.loadBalancer.ingress) 0) -}}
+      {{- $ip = (index $k3kService.status.loadBalancer.ingress 0).ip -}}
+    {{- end -}}
+    {{- if $k3kService.spec.ports -}}
+      {{- $port = (index $k3kService.spec.ports 0).port -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- /* Only generate the policy if we successfully resolved a port */ -}}
+  {{- if $port -}}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "allow-agent-to-k3k-dynamic"
+spec:
+  endpointSelector:
+    matchLabels:
+      type: agent
+  egress:
+    -
+    {{- if eq $ip "reserved:host" }}
+      toEndpoints:
+        - matchLabels:
+            "reserved:host": ""
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": default
+    {{- else if $ip }}
+        # If it's a specific IP, we use toCIDR for precision
+      toCIDR:
+        - {{ printf "%s/32" $ip }}
+    {{- end }}
+      toPorts:
+        - ports:
+            - port: {{ $port | quote }}
+              protocol: TCP
+{{- /* if $port */ -}}
+{{- end -}}
+{{- /* if $k3kService */ -}}
+{{- end -}}
+{{- /* if ccnp netpol is enabled */ -}}
+{{- end -}}

--- a/charts/k3k/values.yaml
+++ b/charts/k3k/values.yaml
@@ -81,3 +81,7 @@ agent:
       registry: ""
       repository: "rancher/k3s"
       pullPolicy: ""
+
+netpol:
+  # none or ccnp
+  flavor: none


### PR DESCRIPTION
Add an option to the chart which generates an appropriate Cilium clusterwide network policy to allow the k3k-kubelet to reach the kubernetes service. This is helpful in environments which use the Cilium CNI, as that blocks traffic to the host out of the box, with hubble logs like this:
```
May 10 13:30:14.412: k3k-mycluster/k3k-mycluster-kubelet-g752n:39506 (ID:48215) <> 192.168.1.170:6443 (host) policy-verdict:none TRAFFIC_DIRECTION_UNKNOWN DENIED (TCP Flags: SYN)
May 10 13:30:14.412: k3k-mycluster/k3k-mycluster-kubelet-g752n:39506 (ID:48215) <> 192.168.1.170:6443 (host) Policy denied DROPPED (TCP Flags: SYN)
```

I validated that this works for my environment, but haven't tried it in other places yet. I'll try to remember to test in EKS sometime next week, but that's the only other kubernetes/cilium environment I generally have handy.