### PR TITLE
Add External Datastore feature

### DIFF
--- a/charts/k3k/templates/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/templates/crds/k3k.io_clusters.yaml
@@ -1413,6 +1413,11 @@ spec:
                         MountPath is the path within server and agent pods where the
                         secret contents will be mounted.
                       type: string
+                    name:
+                      description: |-
+                        Name is the name of the volume that will be mounted to the server
+                        or agent.
+                      type: string
                     optional:
                       description: optional field specify whether the Secret or its keys must be defined
                       type: boolean

--- a/docs/crds/crds.adoc
+++ b/docs/crds/crds.adoc
@@ -595,6 +595,8 @@ _Appears In:_
 [cols="25a,55a,10a,10a", options="header"]
 |===
 | Field | Description | Default | Validation
+| *`name`* __string__ | Name is the name of the volume that will be mounted to the server +
+or agent. + |  | 
 | *`secretName`* __string__ | secretName is the name of the secret in the pod's namespace to use. +
 More info: https://kubernetes.io/docs/concepts/storage/volumes#secret + |  | 
 | *`items`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#keytopath-v1-core[$$KeyToPath$$] array__ | items If unspecified, each key-value pair in the Data field of the referenced +

--- a/docs/crds/crds.md
+++ b/docs/crds/crds.md
@@ -448,6 +448,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the volume that will be mounted to the server<br />or agent. |  |  |
 | `secretName` _string_ | secretName is the name of the secret in the pod's namespace to use.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  |  |
 | `items` _[KeyToPath](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#keytopath-v1-core) array_ | items If unspecified, each key-value pair in the Data field of the referenced<br />Secret will be projected into the volume as a file whose name is the<br />key and content is the value. If specified, the listed keys will be<br />projected into the specified paths, and unlisted keys will not be<br />present. If a key is specified which is not present in the Secret,<br />the volume setup will error unless it is marked optional. Paths must be<br />relative and may not contain the '..' path or start with '..'. |  |  |
 | `defaultMode` _integer_ | defaultMode is Optional: mode bits used to set permissions on created files by default.<br />Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.<br />YAML accepts both octal and decimal values, JSON requires decimal values<br />for mode bits. Defaults to 0644.<br />Directories within the path are not affected by this setting.<br />This might be in conflict with other options that affect the file<br />mode, like fsGroup, and the result can be other mode bits set. |  |  |

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"crypto/x509"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -13,7 +13,6 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -24,7 +23,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -34,9 +32,6 @@ import (
 	"github.com/rancher/k3k/k3k-kubelet/provider"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
-	"github.com/rancher/k3k/pkg/controller/certs"
-	"github.com/rancher/k3k/pkg/controller/cluster/server"
-	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
 )
 
 var baseScheme = runtime.NewScheme()
@@ -77,7 +72,7 @@ func newKubelet(ctx context.Context, c *config) (*kubelet, error) {
 		return nil, err
 	}
 
-	virtConfig, err := virtRestConfig(ctx, c.VirtKubeconfig, hostClient, c.ClusterName, c.ClusterNamespace, c.Token)
+	virtConfig, err := virtRestConfig(ctx, c.VirtKubeconfig, hostClient, c.ClusterName, c.ClusterNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -258,76 +253,32 @@ func (k *kubelet) newProviderFunc(cfg config) nodeutil.NewProviderFunc {
 	}
 }
 
-func virtRestConfig(ctx context.Context, virtualConfigPath string, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace, token string) (*rest.Config, error) {
+func virtRestConfig(ctx context.Context, virtualConfigPath string, hostClient ctrlruntimeclient.Client, clusterName, clusterNamespace string) (*rest.Config, error) {
 	if virtualConfigPath != "" {
 		return clientcmd.BuildConfigFromFlags("", virtualConfigPath)
 	}
-	// virtual kubeconfig file is empty, trying to fetch the k3k cluster kubeconfig
-	var cluster v1beta1.Cluster
-	if err := hostClient.Get(ctx, types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, &cluster); err != nil {
-		return nil, err
+
+	var clusterKubeConfig corev1.Secret
+
+	kubeconfigSecretName := types.NamespacedName{
+		Name:      controller.SafeConcatNameWithPrefix(clusterName, "kubeconfig"),
+		Namespace: clusterNamespace,
 	}
-
-	endpoint := server.ServiceName(cluster.Name) + "." + cluster.Namespace
-
-	var b *bootstrap.ControlRuntimeBootstrap
 
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
 		return err != nil
 	}, func() error {
-		var err error
-
-		b, err = bootstrap.DecodedBootstrap(token, endpoint)
-		logger.Error(err, "decoded bootstrap")
-
-		return err
+		return hostClient.Get(ctx, kubeconfigSecretName, &clusterKubeConfig)
 	}); err != nil {
 		return nil, errors.New("unable to decode bootstrap: " + err.Error())
 	}
 
-	adminCert, adminKey, err := certs.CreateClientCertKey(
-		controller.AdminCommonName,
-		[]string{user.SystemPrivilegedGroup},
-		nil, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		time.Hour*24*time.Duration(356),
-		b.ClientCA.Content,
-		b.ClientCAKey.Content,
-	)
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(clusterKubeConfig.Data["kubeconfig.yaml"])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create config from kubeconfig file: %w", err)
 	}
 
-	url := "https://" + server.ServiceName(cluster.Name)
-
-	kubeconfigData, err := kubeconfigBytes(url, []byte(b.ServerCA.Content), adminCert, adminKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
-}
-
-func kubeconfigBytes(url string, serverCA, clientCert, clientKey []byte) ([]byte, error) {
-	config := clientcmdapi.NewConfig()
-
-	cluster := clientcmdapi.NewCluster()
-	cluster.CertificateAuthorityData = serverCA
-	cluster.Server = url
-
-	authInfo := clientcmdapi.NewAuthInfo()
-	authInfo.ClientCertificateData = clientCert
-	authInfo.ClientKeyData = clientKey
-
-	context := clientcmdapi.NewContext()
-	context.AuthInfo = "default"
-	context.Cluster = "default"
-
-	config.Clusters["default"] = cluster
-	config.AuthInfos["default"] = authInfo
-	config.Contexts["default"] = context
-	config.CurrentContext = "default"
-
-	return clientcmd.Write(*config)
+	return restConfig, nil
 }
 
 func addControllers(ctx context.Context, hostMgr, virtualMgr manager.Manager, c *config, hostClient ctrlruntimeclient.Client) error {

--- a/k3k-kubelet/node.go
+++ b/k3k-kubelet/node.go
@@ -69,7 +69,6 @@ func loadTLSConfig(cfg config, token, agentIP, podIP string) (*tls.Config, error
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
 		return err == request.ErrServerNotReady
 	}, func() error {
-
 		headers := map[string]string{
 			"k3s-Node-Name":     controller.SafeConcatName(cfg.ClusterName, "server-0"),
 			"k3s-Node-Password": token,
@@ -77,6 +76,7 @@ func loadTLSConfig(cfg config, token, agentIP, podIP string) (*tls.Config, error
 		}
 
 		tlsCrtData, err = request.RequestK3sServer(serviceName, "/v1-k3s/client-kubelet.crt", "node", token, headers)
+
 		return err
 	}); err != nil {
 		return nil, errors.New("unable to decode bootstrap: " + err.Error())

--- a/k3k-kubelet/node.go
+++ b/k3k-kubelet/node.go
@@ -2,25 +2,21 @@ package main
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
 	"k8s.io/client-go/util/retry"
 
-	certutil "github.com/rancher/dynamiclistener/cert"
-
 	"github.com/rancher/k3k/pkg/controller"
 	"github.com/rancher/k3k/pkg/controller/certs"
 	"github.com/rancher/k3k/pkg/controller/cluster/server"
-	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
+	"github.com/rancher/k3k/pkg/request"
 )
 
 func (k *kubelet) registerNode(agentIP, podIP string, cfg config) error {
-	tlsConfig, err := loadTLSConfig(cfg, k.name, k.token, agentIP, podIP)
+	tlsConfig, err := loadTLSConfig(cfg, k.token, agentIP, podIP)
 	if err != nil {
 		return errors.New("unable to get tls config: " + err.Error())
 	}
@@ -59,56 +55,41 @@ func nodeOpt(mux *http.ServeMux, tlsConfig *tls.Config, port int) nodeutil.NodeO
 	}
 }
 
-func loadTLSConfig(cfg config, nodeName, token, agentIP, podIP string) (*tls.Config, error) {
-	var b *bootstrap.ControlRuntimeBootstrap
+// loadTLSConfig function will request kubelet serving crt from k3s server and will use it to
+// register a new node to the server, note that we use serving cert to allow adding IPSans to
+// the certificate request
+func loadTLSConfig(cfg config, token, agentIP, podIP string) (*tls.Config, error) {
+	serviceName := fmt.Sprintf("%s.%s", server.ServiceName(cfg.ClusterName), cfg.ClusterNamespace)
 
-	endpoint := fmt.Sprintf("%s.%s", server.ServiceName(cfg.ClusterName), cfg.ClusterNamespace)
+	var (
+		tlsCrtData []byte
+		err        error
+	)
 
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
-		return err != nil
+		return err == request.ErrServerNotReady
 	}, func() error {
-		var err error
 
-		b, err = bootstrap.DecodedBootstrap(token, endpoint)
+		headers := map[string]string{
+			"k3s-Node-Name":     controller.SafeConcatName(cfg.ClusterName, "server-0"),
+			"k3s-Node-Password": token,
+			"k3s-Node-IP":       agentIP + "," + podIP,
+		}
 
+		tlsCrtData, err = request.RequestK3sServer(serviceName, "/v1-k3s/client-kubelet.crt", "node", token, headers)
 		return err
 	}); err != nil {
 		return nil, errors.New("unable to decode bootstrap: " + err.Error())
 	}
 
-	altNames := certutil.AltNames{
-		DNSNames: []string{cfg.AgentHostname},
-		IPs: []net.IP{
-			net.ParseIP(agentIP),
-			net.ParseIP(podIP),
-		},
-	}
+	cert, key := certs.SplitCertKeyPEM(tlsCrtData)
 
-	cert, key, err := certs.CreateClientCertKey(nodeName, nil, &altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, 0, b.ServerCA.Content, b.ServerCAKey.Content)
+	tlsCrt, err := tls.X509KeyPair(cert, key)
 	if err != nil {
-		return nil, errors.New("unable to get cert and key: " + err.Error())
+		return nil, err
 	}
-
-	clientCert, err := tls.X509KeyPair(cert, key)
-	if err != nil {
-		return nil, errors.New("unable to get key pair: " + err.Error())
-	}
-
-	// create rootCA CertPool
-	certs, err := certutil.ParseCertsPEM([]byte(b.ServerCA.Content))
-	if err != nil {
-		return nil, errors.New("unable to create ca certs: " + err.Error())
-	}
-
-	if len(certs) < 1 {
-		return nil, errors.New("ca cert is not parsed correctly")
-	}
-
-	pool := x509.NewCertPool()
-	pool.AddCert(certs[0])
 
 	return &tls.Config{
-		RootCAs:      pool,
-		Certificates: []tls.Certificate{clientCert},
+		Certificates: []tls.Certificate{tlsCrt},
 	}, nil
 }

--- a/pkg/apis/k3k.io/v1beta1/types.go
+++ b/pkg/apis/k3k.io/v1beta1/types.go
@@ -239,6 +239,10 @@ type ClusterSpec struct {
 // SecretMount defines a secret to be mounted into server or agent pods,
 // allowing for custom configurations, certificates, or other sensitive data.
 type SecretMount struct {
+	// Name is the name of the volume that will be mounted to the server
+	// or agent.
+	//
+	Name string `json:"name,omitempty"`
 	// Embeds SecretName, Items, DefaultMode, and Optional
 	corev1.SecretVolumeSource `json:",inline"`
 	// MountPath is the path within server and agent pods where the

--- a/pkg/controller/certs/certs.go
+++ b/pkg/controller/certs/certs.go
@@ -3,8 +3,10 @@ package certs
 import (
 	"crypto"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	certutil "github.com/rancher/dynamiclistener/cert"
@@ -71,4 +73,23 @@ func AddSANs(sans []string) certutil.AltNames {
 	}
 
 	return altNames
+}
+
+func SplitCertKeyPEM(bytes []byte) (certPem []byte, keyPem []byte) {
+	for {
+		b, rest := pem.Decode(bytes)
+		if b == nil {
+			break
+		}
+
+		bytes = rest
+
+		if strings.Contains(b.Type, "PRIVATE KEY") {
+			keyPem = append(keyPem, pem.EncodeToMemory(b)...)
+		} else {
+			certPem = append(certPem, pem.EncodeToMemory(b)...)
+		}
+	}
+
+	return certPem, keyPem
 }

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -457,6 +457,7 @@ func (c *ClusterReconciler) ensureBootstrapSecret(ctx context.Context, cluster *
 	if err != nil {
 		return err
 	}
+
 	if err := c.Client.Status().Update(ctx, cluster); err != nil {
 		return err
 	}

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -42,6 +43,7 @@ import (
 	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
 	"github.com/rancher/k3k/pkg/controller/kubeconfig"
 	"github.com/rancher/k3k/pkg/controller/policy"
+	"github.com/rancher/k3k/pkg/request"
 )
 
 const (
@@ -83,6 +85,7 @@ type Config struct {
 type ClusterReconciler struct {
 	DiscoveryClient *discovery.DiscoveryClient
 	Client          client.Client
+	RestConfig      *rest.Config
 	Scheme          *runtime.Scheme
 	PortAllocator   *agent.PortAllocator
 
@@ -110,6 +113,7 @@ func Add(ctx context.Context, mgr manager.Manager, config *Config, maxConcurrent
 		DiscoveryClient: discoveryClient,
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
+		RestConfig:      mgr.GetConfig(),
 		EventRecorder:   eventRecorder,
 		PortAllocator:   portAllocator,
 		Config: Config{
@@ -293,7 +297,7 @@ func (c *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	// if there was an error during the reconciliation, return
 	if reconcilerErr != nil {
-		if errors.Is(reconcilerErr, bootstrap.ErrServerNotReady) {
+		if errors.Is(reconcilerErr, request.ErrServerNotReady) {
 			log.V(1).Info("Server not ready, requeueing")
 			return reconcile.Result{RequeueAfter: time.Second * 10}, nil
 		}
@@ -449,31 +453,20 @@ func (c *ClusterReconciler) ensureBootstrapSecret(ctx context.Context, cluster *
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Ensuring bootstrap secret")
 
-	bootstrapData, err := bootstrap.GenerateBootstrapData(ctx, cluster, serviceIP, token)
+	resp, err := request.GetK3sConfig(serviceIP, token)
+	if err != nil {
+		return err
+	}
+	if err := c.Client.Status().Update(ctx, cluster); err != nil {
+		return err
+	}
+
+	data, err := bootstrap.Fetch(ctx, cluster, serviceIP, token, c.RestConfig, resp.ClusterInit)
 	if err != nil {
 		return err
 	}
 
-	bootstrapSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.SafeConcatNameWithPrefix(cluster.Name, "bootstrap"),
-			Namespace: cluster.Namespace,
-		},
-	}
-
-	_, err = controllerutil.CreateOrUpdate(ctx, c.Client, bootstrapSecret, func() error {
-		if err := controllerutil.SetControllerReference(cluster, bootstrapSecret, c.Scheme); err != nil {
-			return err
-		}
-
-		bootstrapSecret.Data = map[string][]byte{
-			"bootstrap": bootstrapData,
-		}
-
-		return nil
-	})
-
-	return err
+	return bootstrap.SaveToSecret(ctx, c.Client, c.Scheme, cluster, data)
 }
 
 // ensureKubeconfigSecret will create or update the Secret containing the kubeconfig data from the k3s server

--- a/pkg/controller/cluster/filter.go
+++ b/pkg/controller/cluster/filter.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/cluster/filter.go
+++ b/pkg/controller/cluster/filter.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/cluster/mounts/mounts.go
+++ b/pkg/controller/cluster/mounts/mounts.go
@@ -41,8 +41,13 @@ func buildSecretMountVolume(secretMount v1beta1.SecretMount) (corev1.Volume, cor
 		},
 	}
 
+	volumeName := secretMount.Name
+	if volumeName == "" {
+		volumeName = secretMount.SecretName
+	}
+
 	vol := corev1.Volume{
-		Name: secretMount.SecretName,
+		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Projected: &corev1.ProjectedVolumeSource{
 				Sources: projectedVolSources,
@@ -51,7 +56,7 @@ func buildSecretMountVolume(secretMount v1beta1.SecretMount) (corev1.Volume, cor
 	}
 
 	volMount := corev1.VolumeMount{
-		Name:      secretMount.SecretName,
+		Name:      volumeName,
 		MountPath: secretMount.MountPath,
 		SubPath:   secretMount.SubPath,
 	}

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -1,103 +1,64 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-	"syscall"
-	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
+	"github.com/rancher/k3k/pkg/request"
 )
 
-var ErrServerNotReady = errors.New("server not ready")
+const (
+	TLSDir = "/var/lib/rancher/k3s/server/tls/"
+)
 
-type ControlRuntimeBootstrap struct {
-	ServerCA        content `json:"serverCA"`
-	ServerCAKey     content `json:"serverCAKey"`
-	ClientCA        content `json:"clientCA"`
-	ClientCAKey     content `json:"clientCAKey"`
-	ETCDServerCA    content `json:"etcdServerCA"`
-	ETCDServerCAKey content `json:"etcdServerCAKey"`
+type Data struct {
+	ServerCA        cert `json:"serverCA"`
+	ServerCAKey     cert `json:"serverCAKey"`
+	ClientCA        cert `json:"clientCA"`
+	ClientCAKey     cert `json:"clientCAKey"`
+	ETCDServerCA    cert `json:"etcdServerCA"`
+	ETCDServerCAKey cert `json:"etcdServerCAKey"`
 }
 
-type content struct {
+type cert struct {
 	Timestamp string
 	Content   string
 }
 
-// Generate generates the bootstrap for the cluster:
-// 1- use the server token to get the bootstrap data from k3s
-// 2- save the bootstrap data as a secret
-func GenerateBootstrapData(ctx context.Context, cluster *v1beta1.Cluster, ip, token string) ([]byte, error) {
-	bootstrap, err := requestBootstrap(token, ip)
-	if err != nil {
-		return nil, fmt.Errorf("failed to request bootstrap secret: %w", err)
+// Fetch requests bootstrap data from k3s using the token and decodes it,
+// to avoid double encoding when stored as secret. In case of external datastore we attempt
+// to read the certificate files from the server pod directly since k3s bootstrap API is disabled.
+func Fetch(ctx context.Context, cluster *v1beta1.Cluster, ip, token string, restConfig *rest.Config, clusterInit bool) (*Data, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if !clusterInit {
+		// read bootstrap data from the server pod
+
+		log.V(1).Info("Fetching bootstrap data from server pod")
+		return fetchFromPod(ctx, restConfig, cluster)
 	}
 
-	if err := decodeBootstrap(bootstrap); err != nil {
-		return nil, fmt.Errorf("failed to decode bootstrap secret: %w", err)
-	}
-
-	return json.Marshal(bootstrap)
+	return fetchFromK3sServer(ip, token)
 }
 
-func requestBootstrap(token, serverIP string) (*ControlRuntimeBootstrap, error) {
-	url := "https://" + serverIP + "/v1-k3s/server-bootstrap"
-
-	client := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		},
-		Timeout: 5 * time.Second,
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Authorization", "Basic "+basicAuth("server", token))
-
-	resp, err := client.Do(req)
-	if err != nil {
-		if errors.Is(err, syscall.ECONNREFUSED) {
-			return nil, ErrServerNotReady
-		}
-
-		return nil, err
-	}
-
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	var runtimeBootstrap ControlRuntimeBootstrap
-	if err := json.NewDecoder(resp.Body).Decode(&runtimeBootstrap); err != nil {
-		return nil, err
-	}
-
-	return &runtimeBootstrap, nil
-}
-
-func basicAuth(username, password string) string {
-	auth := username + ":" + password
-	return base64.StdEncoding.EncodeToString([]byte(auth))
-}
-
-func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
+func decode(bootstrap *Data) error {
 	// client-ca
 	decoded, err := base64.StdEncoding.DecodeString(bootstrap.ClientCA.Content)
 	if err != nil {
@@ -145,24 +106,41 @@ func decodeBootstrap(bootstrap *ControlRuntimeBootstrap) error {
 	}
 
 	bootstrap.ETCDServerCAKey.Content = string(decoded)
-
 	return nil
 }
 
-func DecodedBootstrap(token, ip string) (*ControlRuntimeBootstrap, error) {
-	bootstrap, err := requestBootstrap(token, ip)
+// SaveToSecret marshals the bootstrap data and stores it in a Secret owned by the cluster,
+// creating the Secret if it does not exist or updating it otherwise.
+func SaveToSecret(ctx context.Context, c client.Client, scheme *runtime.Scheme, cluster *v1beta1.Cluster, data *Data) error {
+	bootstrapData, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if err := decodeBootstrap(bootstrap); err != nil {
-		return nil, err
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.SafeConcatNameWithPrefix(cluster.Name, "bootstrap"),
+			Namespace: cluster.Namespace,
+		},
 	}
 
-	return bootstrap, nil
+	_, err = controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
+		if err := controllerutil.SetControllerReference(cluster, secret, scheme); err != nil {
+			return err
+		}
+
+		secret.Data = map[string][]byte{
+			"bootstrap": bootstrapData,
+		}
+
+		return nil
+	})
+
+	return err
 }
 
-func GetFromSecret(ctx context.Context, client client.Client, cluster *v1beta1.Cluster) (*ControlRuntimeBootstrap, error) {
+// LoadFromSecret reads the bootstrap data of a certain cluster and returun back the decoded content
+func LoadFromSecret(ctx context.Context, client client.Client, cluster *v1beta1.Cluster) (*Data, error) {
 	key := types.NamespacedName{
 		Name:      controller.SafeConcatNameWithPrefix(cluster.Name, "bootstrap"),
 		Namespace: cluster.Namespace,
@@ -178,9 +156,113 @@ func GetFromSecret(ctx context.Context, client client.Client, cluster *v1beta1.C
 		return nil, errors.New("empty bootstrap")
 	}
 
-	var bootstrap ControlRuntimeBootstrap
+	var bootstrap Data
 
 	err := json.Unmarshal(bootstrapData, &bootstrap)
 
 	return &bootstrap, err
+}
+
+func fetchFromPod(ctx context.Context, restConfig *rest.Config, cluster *v1beta1.Cluster) (*Data, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// using the first server in the statefulset to get the bootstrap data
+	serverPodName := controller.SafeConcatNameWithPrefix(cluster.Name, "server-0")
+
+	bootstrapCerts := map[string]string{
+		"server-ca.crt": "",
+		"server-ca.key": "",
+		"client-ca.crt": "",
+		"client-ca.key": "",
+	}
+	for certName := range bootstrapCerts {
+		command := []string{"cat", TLSDir + certName}
+
+		certData, err := podExec(ctx, clientset, restConfig, cluster.Namespace, serverPodName, command)
+		if err != nil {
+			return nil, err
+		}
+
+		bootstrapCerts[certName] = string(certData)
+	}
+
+	bootstrap := &Data{
+		ServerCA: cert{
+			Content: bootstrapCerts["server-ca.crt"],
+		},
+		ServerCAKey: cert{
+			Content: bootstrapCerts["server-ca.key"],
+		},
+		ClientCA: cert{
+			Content: bootstrapCerts["client-ca.crt"],
+		},
+		ClientCAKey: cert{
+			Content: bootstrapCerts["client-ca.key"],
+		},
+	}
+
+	return bootstrap, nil
+}
+
+func fetchFromK3sServer(serviceIP, token string) (*Data, error) {
+	var bootstrap Data
+
+	resp, err := request.RequestK3sServer(serviceIP, "/v1-k3s/server-bootstrap", "server", token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(resp, &bootstrap); err != nil {
+		return nil, err
+	}
+
+	// we still need to decode each certs since the bootstrap data endpoint base64 encode each cert
+	if err := decode(&bootstrap); err != nil {
+		return nil, fmt.Errorf("failed to decode bootstrap secret: %w", err)
+	}
+
+	return &bootstrap, err
+}
+
+func podExec(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, namespace, name string, command []string) ([]byte, error) {
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(name).
+		Namespace(namespace).
+		SubResource("exec")
+	scheme := runtime.NewScheme()
+
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("error adding to scheme: %v", err)
+	}
+
+	parameterCodec := runtime.NewParameterCodec(scheme)
+
+	req.VersionedParams(&corev1.PodExecOptions{
+		Command: command,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return nil, fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error in Stream: %v", err)
+	}
+
+	return stdout.Bytes(), nil
 }

--- a/pkg/controller/cluster/server/bootstrap/bootstrap.go
+++ b/pkg/controller/cluster/server/bootstrap/bootstrap.go
@@ -14,11 +14,11 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
@@ -50,7 +50,6 @@ func Fetch(ctx context.Context, cluster *v1beta1.Cluster, ip, token string, rest
 	log := ctrl.LoggerFrom(ctx)
 	if !clusterInit {
 		// read bootstrap data from the server pod
-
 		log.V(1).Info("Fetching bootstrap data from server pod")
 		return fetchFromPod(ctx, restConfig, cluster)
 	}
@@ -106,6 +105,7 @@ func decode(bootstrap *Data) error {
 	}
 
 	bootstrap.ETCDServerCAKey.Content = string(decoded)
+
 	return nil
 }
 

--- a/pkg/controller/cluster/server/config.go
+++ b/pkg/controller/cluster/server/config.go
@@ -20,8 +20,8 @@ type serverConfig struct {
 	ClusterCIDR        string   `yaml:"cluster-cidr,omitempty"`
 	ClusterDNS         string   `yaml:"cluster-dns,omitempty"`
 	ClusterInit        bool     `yaml:"cluster-init,omitempty"`
-	DisableAgent       bool     `yaml:"disable-agent,omitempty"`
 	Disable            []string `yaml:"disable,omitempty"`
+	DisableAgent       bool     `yaml:"disable-agent,omitempty"`
 	EgressSelectorMode string   `yaml:"egress-selector-mode,omitempty"`
 	Server             string   `yaml:"server,omitempty"`
 	ServiceCIDR        string   `yaml:"service-cidr,omitempty"`

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/template"
@@ -29,9 +30,20 @@ const (
 	serverName     = "server"
 	configName     = "server-config"
 	initConfigName = "init-server-config"
+
+	configDir     = "/opt/rancher/k3s/server"
+	cniDir        = "/var/lib/cni"
+	dataDir       = "/var/lib/rancher/k3s"
+	etcdDataDir   = "/var/lib/rancher/k3s/server/db/etcd"
+	initConfigDir = "/opt/rancher/k3s/init"
+	kubeletDir    = "/var/lib/kubelet"
+	logDir        = "/var/log"
+	manifestDir   = "/var/lib/rancher/k3s/server/manifests"
+	runDir        = "/run"
+	tlsDir        = "/var/lib/rancher/k3s/server/tls"
+	varRunDir     = "/var/run"
 )
 
-// Server
 type Server struct {
 	cluster          *v1beta1.Cluster
 	client           client.Client
@@ -154,42 +166,42 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "config",
-						MountPath: "/opt/rancher/k3s/server",
+						MountPath: configDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "initconfig",
-						MountPath: "/opt/rancher/k3s/init",
+						MountPath: initConfigDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "run",
-						MountPath: "/run",
+						MountPath: runDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "varrun",
-						MountPath: "/var/run",
+						MountPath: varRunDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "varlibcni",
-						MountPath: "/var/lib/cni",
+						MountPath: cniDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "varlibkubelet",
-						MountPath: "/var/lib/kubelet",
+						MountPath: kubeletDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "varlibrancherk3s",
-						MountPath: "/var/lib/rancher/k3s",
+						MountPath: dataDir,
 						ReadOnly:  false,
 					},
 					{
 						Name:      "varlog",
-						MountPath: "/var/log",
+						MountPath: logDir,
 						ReadOnly:  false,
 					},
 				},
@@ -441,9 +453,9 @@ func (s *Server) setupStartCommand() (string, error) {
 	}
 
 	if err := tmplCmd.Execute(&output, map[string]string{
-		"ETCD_DIR":      "/var/lib/rancher/k3s/server/db/etcd",
-		"INIT_CONFIG":   "/opt/rancher/k3s/init/config.yaml",
-		"SERVER_CONFIG": "/opt/rancher/k3s/server/config.yaml",
+		"ETCD_DIR":      etcdDataDir,
+		"INIT_CONFIG":   filepath.Join(initConfigDir, "config.yaml"),
+		"SERVER_CONFIG": filepath.Join(configDir, "config.yaml"),
 		"CLUSTER_MODE":  mode,
 		"K3K_MODE":      string(s.cluster.Spec.Mode),
 		"EXTRA_ARGS":    strings.Join(s.cluster.Spec.ServerArgs, " "),
@@ -511,7 +523,6 @@ func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMou
 	)
 
 	// avoid re-adding secretName in case of combined secret
-
 	volume = &corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -528,21 +539,18 @@ func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMou
 		mountFile = strings.TrimPrefix(certName, "etcd-")
 	}
 
-	// add the mount for the cert except for the service account token
-	if certName != "service" {
+	for _, crtOrKey := range []string{"crt", "key"} {
+		// skip adding cert mount for service account token
+		if certName == "service" && crtOrKey == "crt" {
+			continue
+		}
+
 		mounts = append(mounts, corev1.VolumeMount{
 			Name:      volumeName,
-			MountPath: fmt.Sprintf("/var/lib/rancher/k3s/server/tls%s/%s.crt", etcdPrefix, mountFile),
-			SubPath:   subPathMount + ".crt",
+			MountPath: fmt.Sprintf("%s%s/%s.%s", tlsDir, etcdPrefix, mountFile, crtOrKey),
+			SubPath:   subPathMount + "." + crtOrKey,
 		})
 	}
-
-	// add the mount for the key
-	mounts = append(mounts, corev1.VolumeMount{
-		Name:      volumeName,
-		MountPath: fmt.Sprintf("/var/lib/rancher/k3s/server/tls%s/%s.key", etcdPrefix, mountFile),
-		SubPath:   subPathMount + ".key",
-	})
 
 	return volume, mounts
 }
@@ -603,7 +611,7 @@ func (s *Server) buildAddonsVolumes(ctx context.Context) ([]corev1.Volume, []cor
 
 		volumeMount := corev1.VolumeMount{
 			Name:      name,
-			MountPath: "/var/lib/rancher/k3s/server/manifests/" + addon.SecretRef,
+			MountPath: filepath.Join(manifestDir, addon.SecretRef),
 			ReadOnly:  true,
 		}
 		mounts = append(mounts, volumeMount)

--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -205,6 +205,7 @@ func (p *StatefulSetReconciler) getETCDTLS(ctx context.Context, cluster *v1beta1
 	log.V(1).Info("Generating ETCD TLS client certificate", "cluster", cluster)
 
 	var b *bootstrap.Data
+
 	if err := retry.OnError(k3kcontroller.Backoff, func(err error) bool {
 		return err == request.ErrServerNotReady
 	}, func() error {

--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rancher/k3k/pkg/controller/certs"
 	"github.com/rancher/k3k/pkg/controller/cluster/server"
 	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
+	"github.com/rancher/k3k/pkg/request"
 )
 
 const (
@@ -86,6 +87,29 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
+	}
+
+	// skip adding statefulset reconciler if external datasstore is in use
+	var svc corev1.Service
+	if err := p.Client.Get(ctx, types.NamespacedName{
+		Name:      server.ServiceName(cluster.Name),
+		Namespace: cluster.Namespace,
+	}, &svc); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	token, err := p.clusterToken(ctx, &cluster)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	resp, err := request.GetK3sConfig(svc.Spec.ClusterIP, token)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if !resp.ClusterInit {
+		return reconcile.Result{}, nil
 	}
 
 	podList, err := p.listPods(ctx, &sts)
@@ -180,21 +204,13 @@ func (p *StatefulSetReconciler) getETCDTLS(ctx context.Context, cluster *v1beta1
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Generating ETCD TLS client certificate", "cluster", cluster)
 
-	token, err := p.clusterToken(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	endpoint := server.ServiceName(cluster.Name) + "." + cluster.Namespace
-
-	var b *bootstrap.ControlRuntimeBootstrap
-
+	var b *bootstrap.Data
 	if err := retry.OnError(k3kcontroller.Backoff, func(err error) bool {
-		return true
+		return err == request.ErrServerNotReady
 	}, func() error {
 		var err error
 
-		b, err = bootstrap.DecodedBootstrap(token, endpoint)
+		b, err = bootstrap.LoadFromSecret(ctx, p.Client, cluster)
 
 		return err
 	}); err != nil {
@@ -210,6 +226,7 @@ func (p *StatefulSetReconciler) getETCDTLS(ctx context.Context, cluster *v1beta1
 	if err != nil {
 		return nil, err
 	}
+
 	// create rootCA CertPool
 	cert, err := certutil.ParseCertsPEM([]byte(b.ETCDServerCA.Content))
 	if err != nil {

--- a/pkg/controller/cluster/status.go
+++ b/pkg/controller/cluster/status.go
@@ -11,7 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
-	"github.com/rancher/k3k/pkg/controller/cluster/server/bootstrap"
+	"github.com/rancher/k3k/pkg/request"
 )
 
 const (
@@ -57,7 +57,7 @@ func (c *ClusterReconciler) updateStatus(ctx context.Context, cluster *v1beta1.C
 		return
 	}
 
-	if errors.Is(reconcileErr, bootstrap.ErrServerNotReady) {
+	if errors.Is(reconcileErr, request.ErrServerNotReady) {
 		cluster.Status.Phase = v1beta1.ClusterProvisioning
 		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 			Type:    ConditionReady,

--- a/pkg/controller/kubeconfig/kubeconfig.go
+++ b/pkg/controller/kubeconfig/kubeconfig.go
@@ -40,7 +40,7 @@ func New() *KubeConfig {
 }
 
 func (k *KubeConfig) Generate(ctx context.Context, client client.Client, cluster *v1beta1.Cluster, hostServerIP string, port int) (*clientcmdapi.Config, error) {
-	bootstrapData, err := bootstrap.GetFromSecret(ctx, client, cluster)
+	bootstrapData, err := bootstrap.LoadFromSecret(ctx, client, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -1,0 +1,79 @@
+package request
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+var ErrServerNotReady = errors.New("server not ready")
+
+// K3sConfigResponse is the subset of the response from k3s' /v1-k3s/config endpoint that we care about.
+type K3sConfigResponse struct {
+	ClusterInit bool `json:"clusterInit"`
+}
+
+// GetK3sConfig fetches the runtime configuration from a k3s server. It is used to detect
+// whether the cluster is running with embedded etcd (ClusterInit=true) or an external datastore.
+func GetK3sConfig(serviceIP, token string) (*K3sConfigResponse, error) {
+	data, err := RequestK3sServer(serviceIP, "/v1-k3s/config", "node", token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg K3sConfigResponse
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func RequestK3sServer(serviceIP, endpoint, user, token string, extraHeaders map[string]string) ([]byte, error) {
+	url := "https://" + serviceIP + endpoint
+
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Basic "+basicAuth(user, token))
+
+	for headerName, headerValue := range extraHeaders {
+		req.Header.Add(headerName, headerValue)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			return nil, ErrServerNotReady
+		}
+
+		return nil, err
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	return io.ReadAll(resp.Body)
+}


### PR DESCRIPTION
- #304 

This PR adds support for connecting a virtual cluster to an external datastore (via kine) instead of the embedded etcd.

The PR does not add a dedicated field for external datastore, instead it leverages the secretMount feature to allow adding a drop in config for external datastore.

Changes:
   - Add `pkg/request` package for a shared HTTP client for k3s API endpoint for example to query /v1-k3s/config, /v1-k3s/bootstrap, and /v1-k3s/client-kubelet.crt
   - Switch the kubelet's client cert flow to `/v1-k3s/client-kubelet.crt` instead of minting a cert locally from the bootstrap CA private key; the virtual-cluster kubeconfig is now loaded from the host-side
  - Refactor bootstrap package rename and adding a separate function for Fetch from k3s, Save to secret, and Load from secret.
  - Adding an alternative way to `Fetch` bootstrap data from k3s other than query /v1-k3s/bootstrap to handle external datastore.
  - Skip handling etcd server pods in statefulset reconciler if external datastore is in use kubeconfig secret rather than rebuilt from bootstrap data.
  - Add SecretMount.Name to v1beta1.Cluster, with mounts falling back to SecretName when unset, so multiple SecretMounts referencing the same secret don't produce duplicate volume names.

