### PR TITLE
Reject non-positive storage request sizes

### DIFF
--- a/charts/k3k/templates/crds/k3k.io_clusters.yaml
+++ b/charts/k3k/templates/crds/k3k.io_clusters.yaml
@@ -1333,6 +1333,8 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                     x-kubernetes-validations:
+                    - message: storageRequestSize must be greater than zero
+                      rule: self.sign() == 1
                     - message: storageRequestSize is immutable
                       rule: self == oldSelf
                   type:

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
@@ -190,14 +189,9 @@ func createAction(appCtx *AppContext, config *CreateConfig) func(cmd *cobra.Comm
 }
 
 func newCluster(name, namespace string, config *CreateConfig) (*v1beta1.Cluster, error) {
-	var storageRequestSize *resource.Quantity
-	if config.storageRequestSize != "" {
-		parsed, err := resource.ParseQuantity(config.storageRequestSize)
-		if err != nil {
-			return nil, err
-		}
-
-		storageRequestSize = ptr.To(parsed)
+	storageRequestSize, err := parseStorageRequestSize(config.storageRequestSize)
+	if err != nil {
+		return nil, err
 	}
 
 	cluster := &v1beta1.Cluster{

--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -42,24 +42,39 @@ func validateCreateConfig(cfg *CreateConfig) error {
 	if cfg.persistenceType != "" {
 		switch v1beta1.PersistenceMode(cfg.persistenceType) {
 		case v1beta1.EphemeralPersistenceMode, v1beta1.DynamicPersistenceMode:
-			return nil
 		default:
 			return errors.New(`persistence-type should be one of "dynamic" or "ephemeral"`)
 		}
 	}
 
-	if _, err := resource.ParseQuantity(cfg.storageRequestSize); err != nil {
-		return errors.New(`invalid storage size, should be a valid resource quantity e.g "10Gi"`)
+	if _, err := parseStorageRequestSize(cfg.storageRequestSize); err != nil {
+		return err
 	}
 
 	if cfg.mode != "" {
 		switch cfg.mode {
 		case string(v1beta1.VirtualClusterMode), string(v1beta1.SharedClusterMode):
-			return nil
 		default:
 			return errors.New(`mode should be one of "shared" or "virtual"`)
 		}
 	}
 
 	return nil
+}
+
+func parseStorageRequestSize(size string) (*resource.Quantity, error) {
+	if size == "" {
+		return nil, nil
+	}
+
+	parsed, err := resource.ParseQuantity(size)
+	if err != nil {
+		return nil, errors.New(`invalid storage size, should be a valid resource quantity e.g "10Gi"`)
+	}
+
+	if parsed.Sign() <= 0 {
+		return nil, errors.New("invalid storage size, should be greater than zero")
+	}
+
+	return &parsed, nil
 }

--- a/cli/cmds/cluster_create_test.go
+++ b/cli/cmds/cluster_create_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
@@ -93,4 +94,102 @@ func Test_printClusterDetails(t *testing.T) {
 			assert.Equal(t, tt.want, clusterDetails)
 		})
 	}
+}
+
+func TestValidateCreateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  CreateConfig
+		wantErr string
+	}{
+		{
+			name: "valid defaults",
+			config: CreateConfig{
+				servers:         1,
+				persistenceType: string(v1beta1.DynamicPersistenceMode),
+				mode:            string(v1beta1.SharedClusterMode),
+			},
+		},
+		{
+			name: "invalid server count",
+			config: CreateConfig{
+				servers:         0,
+				persistenceType: string(v1beta1.DynamicPersistenceMode),
+				mode:            string(v1beta1.SharedClusterMode),
+			},
+			wantErr: "invalid number of servers",
+		},
+		{
+			name: "invalid persistence type",
+			config: CreateConfig{
+				servers:         1,
+				persistenceType: "invalid",
+				mode:            string(v1beta1.SharedClusterMode),
+			},
+			wantErr: `persistence-type should be one of "dynamic" or "ephemeral"`,
+		},
+		{
+			name: "invalid storage request size",
+			config: CreateConfig{
+				servers:            1,
+				persistenceType:    string(v1beta1.DynamicPersistenceMode),
+				storageRequestSize: "bad",
+				mode:               string(v1beta1.SharedClusterMode),
+			},
+			wantErr: `invalid storage size, should be a valid resource quantity e.g "10Gi"`,
+		},
+		{
+			name: "negative storage request size",
+			config: CreateConfig{
+				servers:            1,
+				persistenceType:    string(v1beta1.DynamicPersistenceMode),
+				storageRequestSize: "-1G",
+				mode:               string(v1beta1.SharedClusterMode),
+			},
+			wantErr: "invalid storage size, should be greater than zero",
+		},
+		{
+			name: "zero storage request size",
+			config: CreateConfig{
+				servers:            1,
+				persistenceType:    string(v1beta1.DynamicPersistenceMode),
+				storageRequestSize: "0",
+				mode:               string(v1beta1.SharedClusterMode),
+			},
+			wantErr: "invalid storage size, should be greater than zero",
+		},
+		{
+			name: "invalid mode",
+			config: CreateConfig{
+				servers:            1,
+				persistenceType:    string(v1beta1.DynamicPersistenceMode),
+				storageRequestSize: "10Gi",
+				mode:               "invalid",
+			},
+			wantErr: `mode should be one of "shared" or "virtual"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCreateConfig(&tt.config)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestNewClusterRejectsNonPositiveStorageRequestSize(t *testing.T) {
+	config := &CreateConfig{
+		servers:            1,
+		persistenceType:    string(v1beta1.DynamicPersistenceMode),
+		storageRequestSize: "-1G",
+		mode:               string(v1beta1.SharedClusterMode),
+	}
+
+	_, err := newCluster("test", "default", config)
+	require.ErrorContains(t, err, "invalid storage size, should be greater than zero")
 }

--- a/pkg/apis/k3k.io/v1beta1/types.go
+++ b/pkg/apis/k3k.io/v1beta1/types.go
@@ -464,6 +464,7 @@ type PersistenceConfig struct {
 	// This field is only relevant in "dynamic" mode.
 	//
 	// +kubebuilder:default="2G"
+	// +kubebuilder:validation:XValidation:message="storageRequestSize must be greater than zero",rule="self.sign() == 1"
 	// +kubebuilder:validation:XValidation:message="storageRequestSize is immutable",rule="self == oldSelf"
 	// +optional
 	StorageRequestSize *resource.Quantity `json:"storageRequestSize,omitempty"`


### PR DESCRIPTION
## Summary
- validate storageRequestSize after parsing and reject zero or negative values in the cluster create path
- reuse the same parser when constructing the Cluster object
- add CRD CEL validation for direct Cluster manifests

Fixes #729

## Tests
- go test ./cli/cmds -run TestValidateCreateConfig -count=1 -v -timeout=30s
- go test ./cli/cmds -run "TestNewClusterRejectsNonPositiveStorageRequestSize|Test_printClusterDetails" -count=1 -v -timeout=30s
- go test ./cli/cmds -count=1 -timeout=60s
- go test ./pkg/apis/k3k.io/v1beta1 ./cli/cmds -count=1 -timeout=60s
- go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.0 crd:generateEmbeddedObjectMeta=true,allowDangerousTypes=false object paths=./pkg/apis/k3k.io/... output:crd:dir=./charts/k3k/templates/crds
