### PR TITLE
Report missing cluster on delete

### DIFF
--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -11,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
@@ -47,14 +47,21 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 
 		namespace := appCtx.Namespace(name)
 
+		cluster := v1beta1.Cluster{}
+		clusterKey := types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}
+		if err := client.Get(ctx, clusterKey, &cluster); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("cluster %q not found in namespace %q; use `k3kcli cluster list` to check the namespace, or pass --namespace", name, namespace)
+			}
+
+			return err
+		}
+
 		logrus.Infof("Deleting '%s' cluster in namespace '%s'", name, namespace)
 
-		cluster := v1beta1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-		}
 		// keep bootstrap secrets and tokens if --keep-data flag is passed
 		if keepData {
 			// skip removing tokenSecret

--- a/cli/cmds/cluster_delete_test.go
+++ b/cli/cmds/cluster_delete_test.go
@@ -1,0 +1,51 @@
+package cmds
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
+)
+
+func TestDeleteClusterReturnsNotFoundWhenDefaultNamespaceMisses(t *testing.T) {
+	appCtx := &AppContext{Client: fake.NewClientBuilder().WithScheme(testDeleteScheme(t)).Build()}
+
+	err := delete(appCtx)(&cobra.Command{}, []string{"demo"})
+
+	require.ErrorContains(t, err, `cluster "demo" not found in namespace "k3k-demo"`)
+	require.ErrorContains(t, err, "--namespace")
+}
+
+func TestDeleteClusterRemovesExistingCluster(t *testing.T) {
+	scheme := testDeleteScheme(t)
+	cluster := &v1beta1.Cluster{}
+	cluster.Name = "demo"
+	cluster.Namespace = "k3k-system"
+	appCtx := &AppContext{
+		Client:    fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build(),
+		namespace: "k3k-system",
+	}
+
+	err := delete(appCtx)(&cobra.Command{}, []string{"demo"})
+
+	require.NoError(t, err)
+	err = appCtx.Client.Get(t.Context(), types.NamespacedName{Name: "demo", Namespace: "k3k-system"}, &v1beta1.Cluster{})
+	require.True(t, apierrors.IsNotFound(err), "expected cluster to be deleted, got %v", err)
+}
+
+func testDeleteScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	return scheme
+}


### PR DESCRIPTION
## Summary
- check the target Cluster exists before logging deletion
- return a not-found error with namespace guidance when the default namespace misses
- add focused delete command coverage

Fixes #536

## Testing
- go test ./cli/... -count=1