### PR TITLE
Added `provider.cattle.io=k3k` label to Clusters

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func run(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	logger.Info("Starting k3k - Version: " + buildinfo.Version)
+	logger.Info("Starting k3k - version: " + buildinfo.Version)
 	ctrlruntimelog.SetLogger(logger)
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -54,6 +54,9 @@ const (
 	SyncSourceLabelKey  = "k3k.io/sync-source"
 	SyncSourceHostLabel = "host"
 
+	ProviderLabelKey   = "provider.cattle.io"
+	ProviderLabelValue = "k3k"
+
 	defaultVirtualClusterCIDR = "10.52.0.0/16"
 	defaultVirtualServiceCIDR = "10.53.0.0/16"
 	defaultSharedClusterCIDR  = "10.42.0.0/16"
@@ -303,7 +306,10 @@ func (c *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	// update Cluster if needed
-	if !equality.Semantic.DeepEqual(orig.Spec, cluster.Spec) {
+	needsSpecUpdate := !equality.Semantic.DeepEqual(orig.Spec, cluster.Spec)
+	needsLabelsUpdate := !equality.Semantic.DeepEqual(orig.Labels, cluster.Labels)
+
+	if needsSpecUpdate || needsLabelsUpdate {
 		log.Info("Updating Cluster")
 
 		if err := c.Client.Update(ctx, &cluster); err != nil {
@@ -323,6 +329,12 @@ func (c *ClusterReconciler) reconcileCluster(ctx context.Context, cluster *v1bet
 
 func (c *ClusterReconciler) reconcile(ctx context.Context, cluster *v1beta1.Cluster) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	if cluster.Labels == nil {
+		cluster.Labels = map[string]string{}
+	}
+
+	cluster.Labels[ProviderLabelKey] = ProviderLabelValue
 
 	var ns corev1.Namespace
 	if err := c.Client.Get(ctx, client.ObjectKey{Name: cluster.Namespace}, &ns); err != nil {

--- a/tests/e2e/cluster_create_test.go
+++ b/tests/e2e/cluster_create_test.go
@@ -3,6 +3,8 @@ package k3k_test
 import (
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fwk3k "github.com/rancher/k3k/tests/framework/k3k"
@@ -34,10 +36,25 @@ var _ = When("creating a shared mode cluster", Label(e2eTestLabel), Label(slowTe
 
 	It("creates nodes with the worker role", func() {
 		Eventually(func(g Gomega) {
-			nodes, err := virtualCluster.Client.CoreV1().Nodes().List(GinkgoT().Context(), metav1.ListOptions{})
+			ctx := GinkgoT().Context()
+
+			nodes, err := virtualCluster.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			g.Expect(err).To(Not(HaveOccurred()))
 			g.Expect(nodes.Items).To(HaveLen(1))
 			g.Expect(nodes.Items[0].Labels).To(HaveKeyWithValue("node-role.kubernetes.io/worker", "true"))
+		}).
+			WithTimeout(time.Minute).
+			WithPolling(time.Second).
+			Should(Succeed())
+	})
+
+	It("has the provider.cattle.io label set to k3k", func() {
+		Eventually(func(g Gomega) {
+			ctx := GinkgoT().Context()
+
+			key := client.ObjectKeyFromObject(virtualCluster.Cluster)
+			g.Expect(k8sClient.Get(ctx, key, virtualCluster.Cluster)).To(Succeed())
+			g.Expect(virtualCluster.Cluster.Labels).To(HaveKeyWithValue("provider.cattle.io", "k3k"))
 		}).
 			WithTimeout(time.Minute).
 			WithPolling(time.Second).


### PR DESCRIPTION
This PR add a `provider.cattle.io=k3k` label to all the Cluster resources.