### PR TITLE
Enhance command flag handling and completion for cluster and policy creation

### DIFF
--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -70,6 +70,7 @@ func NewClusterCreateCmd(appCtx *AppContext) *cobra.Command {
 	}
 
 	CobraFlagNamespace(appCtx, cmd.Flags())
+
 	createFlags(cmd, createConfig)
 
 	return cmd

--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -32,6 +33,13 @@ func createFlags(cmd *cobra.Command, cfg *CreateConfig) {
 	cmd.Flags().StringVar(&cfg.policy, "policy", "", "The policy to create the cluster in")
 	cmd.Flags().StringVar(&cfg.customCertsPath, "custom-certs", "", "The path for custom certificate directory")
 	cmd.Flags().DurationVar(&cfg.timeout, "timeout", 3*time.Minute, "The timeout for waiting for the cluster to become ready (e.g., 10s, 5m, 1h).")
+
+	mustRegisterFlagCompletion(cmd, "mode", completeClusterMode)
+	mustRegisterFlagCompletion(cmd, "persistence-type", completePersistenceMode)
+
+	if err := cmd.MarkFlagDirname("custom-certs"); err != nil {
+		logrus.Fatal(err)
+	}
 }
 
 func validateCreateConfig(cfg *CreateConfig) error {

--- a/cli/cmds/completion.go
+++ b/cli/cmds/completion.go
@@ -1,0 +1,68 @@
+package cmds
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
+)
+
+var completeClusterMode = cobra.FixedCompletions(
+	[]string{
+		string(v1beta1.SharedClusterMode),
+		string(v1beta1.VirtualClusterMode),
+	},
+	cobra.ShellCompDirectiveNoFileComp,
+)
+
+var completePersistenceMode = cobra.FixedCompletions(
+	[]string{
+		string(v1beta1.DynamicPersistenceMode),
+		string(v1beta1.EphemeralPersistenceMode),
+	},
+	cobra.ShellCompDirectiveNoFileComp,
+)
+
+// mustRegisterFlagCompletion registers a completion function for a flag and
+// aborts if the flag does not exist. This only fails on programmer error, so
+// there is no reason to bubble it up to the caller.
+func mustRegisterFlagCompletion(cmd *cobra.Command, flagName string, f cobra.CompletionFunc) {
+	if err := cmd.RegisterFlagCompletionFunc(flagName, f); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// disableFileCompletion walks the command tree and turns off cobra's default
+// filename completion for both positional arguments and flag values, leaving
+// anything that is explicitly configured (enum completers, MarkFlagFilename,
+// MarkFlagDirname, ValidArgs, bool flags) untouched.
+func disableFileCompletion(cmd *cobra.Command) {
+	if cmd.ValidArgsFunction == nil && len(cmd.ValidArgs) == 0 {
+		cmd.ValidArgsFunction = cobra.NoFileCompletions
+	}
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Value.Type() == "bool" {
+			return
+		}
+
+		if _, ok := cmd.GetFlagCompletionFunc(f.Name); ok {
+			return
+		}
+
+		if _, ok := f.Annotations[cobra.BashCompFilenameExt]; ok {
+			return
+		}
+
+		if _, ok := f.Annotations[cobra.BashCompSubdirsInDir]; ok {
+			return
+		}
+
+		_ = cmd.RegisterFlagCompletionFunc(f.Name, cobra.NoFileCompletions)
+	})
+
+	for _, sub := range cmd.Commands() {
+		disableFileCompletion(sub)
+	}
+}

--- a/cli/cmds/policy_create.go
+++ b/cli/cmds/policy_create.go
@@ -50,6 +50,8 @@ func NewPolicyCreateCmd(appCtx *AppContext) *cobra.Command {
 	cmd.Flags().StringSliceVar(&config.namespaces, "namespace", []string{}, "The namespaces where to bind the policy")
 	cmd.Flags().BoolVar(&config.overwrite, "overwrite", false, "Overwrite namespace binding of existing policy")
 
+	mustRegisterFlagCompletion(cmd, "mode", completeClusterMode)
+
 	return cmd
 }
 

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -70,11 +70,17 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&appCtx.Kubeconfig, "kubeconfig", "", "kubeconfig path ($HOME/.kube/config or $KUBECONFIG if set)")
 	rootCmd.PersistentFlags().BoolVar(&appCtx.Debug, "debug", false, "Turn on debug logs")
 
+	if err := rootCmd.MarkPersistentFlagFilename("kubeconfig"); err != nil {
+		logrus.Fatal(err)
+	}
+
 	rootCmd.AddCommand(
 		NewClusterCmd(appCtx),
 		NewPolicyCmd(appCtx),
 		NewKubeconfigCmd(appCtx),
 	)
+
+	disableFileCompletion(rootCmd)
 
 	return rootCmd
 }


### PR DESCRIPTION
## Improve k3kcli shell completion for flags

Note: to enable the autocomplete (for zsh):
```
source <(k3kcli completion zsh)
```

### Original behavior

`k3kcli` relied on cobra's default completion, which falls back to **filename completion** for every flag and positional argument. That's noise for flags that take an enum or a free-form value — e.g. tab-completing `--mode` would suggest files in the current directory instead of the valid modes.

<img width="350" height="89" alt="image" src="https://github.com/user-attachments/assets/ed8359c2-8d58-48e3-9473-2abd83238690" />  

### Fix
  
This PR adds proper shell completion for the CLI's enum flags, disables misleading file completion everywhere it isn't wanted, and unifies the registration error handling.

<img width="369" height="78" alt="image" src="https://github.com/user-attachments/assets/964b3d8f-6cd9-4f83-a2f8-f44d7a62020c" />
<img width="615" height="88" alt="image" src="https://github.com/user-attachments/assets/20afd2d6-34f8-4206-b265-3525411eccbc" />


### Changes

- **Enum flag completion** via the standard `cobra.FixedCompletions`:
  - `--mode` on `cluster create` and `policy create` → `shared`, `virtual`
  - `--persistence-type` on `cluster create` → `dynamic`, `ephemeral`
- **`disableFileCompletion(cmd)`** walks the whole command tree and turns off cobra's default filename completion for positional args and flag values, while leaving intentional completions untouched (explicit enum completers, bool flags, and flags marked as file/dir).
- **Preserve file/dir completion where it makes sense**:
  - `--kubeconfig` marked as a filename flag (`MarkPersistentFlagFilename`)
  - `--custom-certs` marked as a directory flag (`MarkFlagDirname`)
- **Unified registration error handling** with a `mustRegisterFlagCompletion` helper that `logrus.Fatal`s on the only failure mode (a nonexistent flag — a programmer error). This lets `createFlags` drop its `error` return, removing the need to bubble the error up to `logrus.Fatal` at the call site, and replaces the silently-ignored `_ =` registration in `policy_create.go`.
