### PR TITLE
Add `K3K` prefix to k3kcli env vars, align cli test, add failCount

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,6 +96,14 @@ jobs:
         files: ${{ github.workspace }}/covdata/cover.out
         flags: cli
 
+    - name: Export logs
+      if: always()
+      env:
+        KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      run: |
+        journalctl -u k3s -o cat --no-pager > /tmp/k3s.log
+        kubectl logs -n k3k-system -l "app.kubernetes.io/name=k3k" --tail=-1 > /tmp/k3k.log
+
     - name: Archive k3s logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,12 +58,22 @@ jobs:
         
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
+        echo "REPO=ttl.sh/$(uuidgen)" >> $GITHUB_ENV
+        echo "VERSION=1h" >> $GITHUB_ENV
         echo "K3S_HOST_VERSION=${{ env.KUBERNETES_VERSION }}+k3s1" >> $GITHUB_ENV
-    
-    - name: Build and package
+
+    - name: Install k3s
+      run: |
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_HOST_VERSION} INSTALL_K3S_EXEC="--write-kubeconfig-mode=777" sh -s -
+
+        echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> $GITHUB_ENV
+
+    - name: Build and package and push dev images
       run: |
         make build
         make package
+        make push
+        make install
 
         # add k3kcli to $PATH
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -73,7 +83,6 @@ jobs:
 
     - name: Run cli tests
       env:
-        K3K_DOCKER_INSTALL: "true"
         K3S_HOST_VERSION: "${{ env.K3S_HOST_VERSION }}"
       run: make test-cli
 

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -312,9 +312,9 @@ func waitForClusterReconciled(ctx context.Context, k8sClient client.Client, clus
 func waitForClusterReady(ctx context.Context, k8sClient client.Client, cluster *v1beta1.Cluster, timeout time.Duration) error {
 	interval := 5 * time.Second
 
-	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), interval, time.Minute*5, true, func(ctx context.Context) (bool, error) {
 		key := client.ObjectKeyFromObject(cluster)
-		if err := k8sClient.Get(context.Background(), key, cluster); err != nil {
+		if err := k8sClient.Get(ctx, key, cluster); err != nil {
 			return false, fmt.Errorf("failed to get resource: %w", err)
 		}
 

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -311,8 +311,9 @@ func waitForClusterReconciled(ctx context.Context, k8sClient client.Client, clus
 
 func waitForClusterReady(ctx context.Context, k8sClient client.Client, cluster *v1beta1.Cluster, timeout time.Duration) error {
 	interval := 5 * time.Second
+	failCount := 0
 
-	return wait.PollUntilContextTimeout(context.Background(), interval, time.Minute*5, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		key := client.ObjectKeyFromObject(cluster)
 		if err := k8sClient.Get(ctx, key, cluster); err != nil {
 			return false, fmt.Errorf("failed to get resource: %w", err)
@@ -325,7 +326,13 @@ func waitForClusterReady(ctx context.Context, k8sClient client.Client, cluster *
 
 		// If resource failed -> stop polling with an error
 		if cluster.Status.Phase == v1beta1.ClusterFailed {
-			return true, fmt.Errorf("cluster creation failed: %s", cluster.Status.Phase)
+			failCount++
+
+			if failCount > 3 {
+				return true, fmt.Errorf("cluster creation failed: %s", cluster.Status.Phase)
+			}
+
+			return false, nil
 		}
 
 		// Condition not met, continue polling.

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -77,7 +77,7 @@ func NewClusterCreateCmd(appCtx *AppContext) *cobra.Command {
 
 func createAction(appCtx *AppContext, config *CreateConfig) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+		ctx := cmd.Context()
 		client := appCtx.Client
 		name := args[0]
 
@@ -314,7 +314,7 @@ func waitForClusterReady(ctx context.Context, k8sClient client.Client, cluster *
 
 	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		key := client.ObjectKeyFromObject(cluster)
-		if err := k8sClient.Get(ctx, key, cluster); err != nil {
+		if err := k8sClient.Get(context.Background(), key, cluster); err != nil {
 			return false, fmt.Errorf("failed to get resource: %w", err)
 		}
 

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -92,6 +92,7 @@ func CobraFlagNamespace(appCtx *AppContext, flag *pflag.FlagSet) {
 }
 
 func InitializeConfig(cmd *cobra.Command) {
+	viper.SetEnvPrefix("K3K")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -62,14 +62,20 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, namespace.Name)
 			})
 
+			By("creating the cluster")
+
 			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("listing the clusters")
 
 			stdout, stderr, err = K3kcli("cluster", "list")
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(BeEmpty())
 			Expect(stdout).To(ContainSubstring(clusterNamespace))
+
+			By("deleting the clusters")
 
 			_, stderr, err = K3kcli("cluster", "delete", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
@@ -101,7 +107,7 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
-			_, stderr, err = K3kcli("cluster", "create", "--version", k3sVersion, clusterName)
+			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, "--version", k3sVersion, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
 		})

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -62,20 +62,20 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, namespace.Name)
 			})
 
-			By("creating the cluster")
+			By("Creating the cluster")
 
 			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
 
-			By("listing the clusters")
+			By("Listing the clusters")
 
 			stdout, stderr, err = K3kcli("cluster", "list")
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(BeEmpty())
 			Expect(stdout).To(ContainSubstring(clusterNamespace))
 
-			By("deleting the clusters")
+			By("Deleting the cluster")
 
 			_, stderr, err = K3kcli("cluster", "delete", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
@@ -107,7 +107,9 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
-			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, "--version", k3sVersion, clusterName)
+			By("Creating the cluster")
+
+			_, stderr, err = K3kcli("cluster", "create", "--version", k3sVersion, "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
 		})
@@ -123,14 +125,20 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 
 			policyName := "policy-" + rand.String(5)
 
+			By("Creating a policy")
+
 			_, stderr, err = K3kcli("policy", "create", policyName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring(`Creating policy '%s'`, policyName))
+
+			By("Listing the policies")
 
 			stdout, stderr, err = K3kcli("policy", "list")
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(BeEmpty())
 			Expect(stdout).To(ContainSubstring(policyName))
+
+			By("Deleting the policy")
 
 			stdout, stderr, err = K3kcli("policy", "delete", policyName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
@@ -224,7 +232,6 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 			)
 
 			clusterName := "cluster-" + rand.String(5)
-
 			namespace := fwk3k.CreateNamespace(k8s)
 			clusterNamespace := namespace.Name
 
@@ -232,10 +239,14 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
+			By("Creating the cluster")
+
 			// Create the cluster first
 			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("updating the cluster")
 
 			// Update the cluster server count
 			_, stderr, err = K3kcli("cluster", "update", "-y", "--servers", "2", "--namespace", clusterNamespace, clusterName)
@@ -258,7 +269,6 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 			)
 
 			clusterName := "cluster-" + rand.String(5)
-
 			namespace := fwk3k.CreateNamespace(k8s)
 			clusterNamespace := namespace.Name
 
@@ -266,10 +276,14 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
+			By("Creating the cluster")
+
 			// Create the cluster with initial version
 			_, stderr, err = K3kcli("cluster", "create", "--version", k3sOldVersion, "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("updating the cluster")
 
 			// Update the cluster version
 			_, stderr, err = K3kcli("cluster", "update", "-y", "--version", k3sVersion, "--namespace", clusterNamespace, clusterName)
@@ -291,7 +305,6 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 			)
 
 			clusterName := "cluster-" + rand.String(5)
-
 			namespace := fwk3k.CreateNamespace(k8s)
 			clusterNamespace := namespace.Name
 
@@ -299,10 +312,14 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
+			By("Creating the cluster")
+
 			// Create the cluster with a version
 			_, stderr, err = K3kcli("cluster", "create", "--version", k3sVersion, "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("Updating the cluster")
 
 			// Attempt to downgrade should fail
 			_, stderr, err = K3kcli("cluster", "update", "-y", "--version", k3sOldVersion, "--namespace", clusterNamespace, clusterName)
@@ -336,7 +353,6 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 			)
 
 			clusterName := "cluster-" + rand.String(5)
-
 			namespace := fwk3k.CreateNamespace(k8s)
 			clusterNamespace := namespace.Name
 
@@ -344,10 +360,14 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
+			By("Creating the cluster")
+
 			// Create the cluster first
 			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("Updating the cluster")
 
 			// Update the cluster with labels
 			_, stderr, err = K3kcli("cluster", "update", "-y", "--labels", "env=test", "--labels", "team=dev", "--namespace", clusterNamespace, clusterName)
@@ -370,7 +390,6 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 			)
 
 			clusterName := "cluster-" + rand.String(5)
-
 			namespace := fwk3k.CreateNamespace(k8s)
 			clusterNamespace := namespace.Name
 
@@ -378,10 +397,14 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
+			By("Creating the cluster")
+
 			// Create the cluster first
 			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("Updating the cluster")
 
 			// Update the cluster with annotations
 			_, stderr, err = K3kcli("cluster", "update", "-y", "--annotations", "description=test-cluster", "--annotations", "owner=qa-team", "--namespace", clusterNamespace, clusterName)
@@ -413,9 +436,13 @@ var _ = When("using the k3kcli", Label("cli"), func() {
 				fwk3k.DeleteNamespaces(k8s, clusterNamespace)
 			})
 
+			By("Creating the cluster")
+
 			_, stderr, err = K3kcli("cluster", "create", "--namespace", clusterNamespace, clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))
 			Expect(stderr).To(ContainSubstring("You can start using the cluster"))
+
+			By("Generating the kubeconfig")
 
 			_, stderr, err = K3kcli("kubeconfig", "generate", "--namespace", clusterNamespace, "--name", clusterName)
 			Expect(err).To(Not(HaveOccurred()), string(stderr))


### PR DESCRIPTION
This PR fixes the k3kcli tests, failing because of a env var that was clashing with another variable set for the Makefile (`VERSION`). This was cause also of other issues in the past, so this PR adds a `K3K` prefix to avoid this, with `viper.SetEnvPrefix("K3K")`.

It also aligns the k3kcli tests to use a local k3s installation instead of the `testcointainers`, and add a `failCount` to try three times before failing completely.