### PR TITLE
set machine id on server pod if not exists

### DIFF
--- a/pkg/controller/cluster/server/template.go
+++ b/pkg/controller/cluster/server/template.go
@@ -135,6 +135,11 @@ configure_cgroups() {
 EXTRA_ARGS="{{.EXTRA_ARGS}}"
 configure_cgroups
 
+if [ ! -f /etc/machine-id ]; then
+	MACHINE_ID=$(printf '%s' "$POD_NAME" | md5sum | cut -d' ' -f1)
+	printf '%s' "$MACHINE_ID" > /etc/machine-id
+fi
+
 case "{{.CLUSTER_MODE}}" in
     "ha")
         start_ha_node


### PR DESCRIPTION
Cadvisor is logging the below due to the absence of a machine-id - while this is mostly harmless it increases the log output and has caused confusion when debugging other issues.

This change sets a machine ID deterministically based on the pod name on startup if not present, we may need to do the same for agents however as they currently dont use an entrypoint script I have ommitted for now.

```
ben@susepad:~> kubectl -n tenant-k3k444 logs k3k-test-server-0 | grep machine-id
E0710 09:17:26.339549      10 info.go:119] Failed to get system UUID: open /etc/machine-id: no such file or directory
W0710 09:17:26.339872      10 info.go:53] Couldn't collect info from any of the files in "/etc/machine-id,/var/lib/dbus/machine-id"
ben@susepad:~> kubectl -n tenant-k3k444 logs k3k-test-server-1 | grep machine-id
E0710 09:18:38.111132      10 info.go:119] Failed to get system UUID: open /etc/machine-id: no such file or directory
W0710 09:18:38.111415      10 info.go:53] Couldn't collect info from any of the files in "/etc/machine-id,/var/lib/dbus/machine-id"
ben@susepad:~> kubectl -n tenant-k3k444 logs k3k-test-server-2 | grep machine-id
E0710 09:19:50.417892      10 info.go:119] Failed to get system UUID: open /etc/machine-id: no such file or directory
W0710 09:19:50.418073      10 info.go:53] Couldn't collect info from any of the files in "/etc/machine-id,/var/lib/dbus/machine-id"
```