### PR TITLE
Fix logged events in syncer

### DIFF
--- a/k3k-kubelet/controller/syncer/configmap.go
+++ b/k3k-kubelet/controller/syncer/configmap.go
@@ -83,7 +83,7 @@ func (c *ConfigMapSyncer) filterResources(object client.Object) bool {
 
 // Reconcile implements reconcile.Reconciler and synchronizes the objects in objs to the host cluster
 func (c *ConfigMapSyncer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx).WithValues("cluster", c.ClusterName, "clusterNamespace", c.ClusterName)
+	log := ctrl.LoggerFrom(ctx).WithValues("cluster", c.ClusterName, "clusterNamespace", c.ClusterNamespace)
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	var cluster v1beta1.Cluster

--- a/k3k-kubelet/controller/syncer/events.go
+++ b/k3k-kubelet/controller/syncer/events.go
@@ -63,6 +63,7 @@ func AddEventSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clust
 // between the host and virtual clusters.
 func (s *EventSyncer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := ctrl.LoggerFrom(ctx).WithValues("cluster", s.ClusterName, "clusterNamespace", s.ClusterNamespace)
+	ctx = ctrl.LoggerInto(ctx, logger)
 
 	event := &corev1.Event{}
 	if err := s.HostClient.Get(ctx, req.NamespacedName, event); err != nil {

--- a/k3k-kubelet/controller/syncer/events.go
+++ b/k3k-kubelet/controller/syncer/events.go
@@ -62,7 +62,7 @@ func AddEventSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clust
 // Reconcile implements reconcile.Reconciler and synchronizes relevant events
 // between the host and virtual clusters.
 func (s *EventSyncer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := ctrl.LoggerFrom(ctx).WithValues("cluster", s.ClusterName, "clusterNamespace", s.ClusterName)
+	logger := ctrl.LoggerFrom(ctx).WithValues("cluster", s.ClusterName, "clusterNamespace", s.ClusterNamespace)
 
 	event := &corev1.Event{}
 	if err := s.HostClient.Get(ctx, req.NamespacedName, event); err != nil {

--- a/k3k-kubelet/controller/syncer/secret.go
+++ b/k3k-kubelet/controller/syncer/secret.go
@@ -83,7 +83,7 @@ func (r *SecretSyncer) filterResources(object client.Object) bool {
 
 // Reconcile implements reconcile.Reconciler and synchronizes the objects in objs to the host cluster
 func (s *SecretSyncer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx).WithValues("cluster", s.ClusterName, "clusterNamespace", s.ClusterName)
+	log := ctrl.LoggerFrom(ctx).WithValues("cluster", s.ClusterName, "clusterNamespace", s.ClusterNamespace)
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	var cluster v1beta1.Cluster


### PR DESCRIPTION
Some events were being logged with the incorrect namespace, this fixes this to ensure that events are logged with the correct name/namespace.