### PR TITLE
Fix dangling Pods

### DIFF
--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -794,9 +794,12 @@ func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 
 	var hostPods corev1.PodList
 
-	listOpts := client.MatchingLabels{translate.ClusterNameLabel: p.ClusterName}
+	listOpts := []client.ListOption{
+		client.InNamespace(p.ClusterNamespace),
+		client.MatchingLabels{translate.ClusterNameLabel: p.ClusterName},
+	}
 
-	if err := p.Host.Client.List(ctx, &hostPods, listOpts); err != nil {
+	if err := p.Host.Client.List(ctx, &hostPods, listOpts...); err != nil {
 		p.logger.Error(err, "Error listing pods from host cluster")
 		return nil, err
 	}

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -15,8 +15,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/virtual-kubelet/virtual-kubelet/node/api"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -782,32 +780,51 @@ func (p *Provider) getPodFromHostCluster(ctx context.Context, hostPodName string
 // The Pods returned are expected to be immutable, and may be accessed
 // concurrently outside of the calling goroutine. Therefore it is recommended
 // to return a version after DeepCopy.
+//
+// It returns only the Pods this instance owns: those whose virtual Pod is assigned to this node
+// (spec.nodeName == p.agentHostname), plus genuinely dangling Pods whose virtual counterpart no
+// longer exists. This matters because GetPods feeds the virtual-kubelet framework's startup
+// reconciliation (deleteDanglingPods), which deletes any Pod returned here that is absent from
+// this instance's virtual Pod lister (scoped to the same node) — so on a multi-node host,
+// returning a Pod owned by another node would make this instance wrongly delete it. Ownership is
+// the virtual Pod's node, not the host Pod's physical node: host Pods are scheduled with only a
+// soft, sometimes-absent affinity toward their owner, so their physical placement is unreliable.
 func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 	p.logger.V(1).Info("GetPods")
 
-	selector := labels.NewSelector()
+	var hostPods corev1.PodList
 
-	requirement, err := labels.NewRequirement(translate.ClusterNameLabel, selection.Equals, []string{p.ClusterName})
-	if err != nil {
-		p.logger.Error(err, "Error creating label selector for GetPods")
-		return nil, err
-	}
+	listOpts := client.MatchingLabels{translate.ClusterNameLabel: p.ClusterName}
 
-	selector = selector.Add(*requirement)
-
-	var podList corev1.PodList
-
-	err = p.Host.Client.List(ctx, &podList, &client.ListOptions{LabelSelector: selector})
-	if err != nil {
+	if err := p.Host.Client.List(ctx, &hostPods, listOpts); err != nil {
 		p.logger.Error(err, "Error listing pods from host cluster")
 		return nil, err
 	}
 
+	// Map each virtual Pod to its node. Read live (not from the manager cache): this can run at
+	// startup before that cache is synced, and a stale read would misclassify a live Pod as gone.
+	virtualPods, err := p.Virtual.CoreClient.Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		p.logger.Error(err, "Error listing pods from virtual cluster")
+		return nil, err
+	}
+
+	nodeByPod := make(map[types.NamespacedName]string, len(virtualPods.Items))
+	for _, virtPod := range virtualPods.Items {
+		nodeByPod[client.ObjectKeyFromObject(&virtPod)] = virtPod.Spec.NodeName
+	}
+
 	retPods := []*corev1.Pod{}
 
-	for _, pod := range podList.DeepCopy().Items {
-		p.Translator.TranslateFrom(&pod)
-		retPods = append(retPods, &pod)
+	for _, hostPod := range hostPods.DeepCopy().Items {
+		p.Translator.TranslateFrom(&hostPod)
+
+		// skip Pods owned by another node; that node's instance is responsible for them
+		if node := nodeByPod[client.ObjectKeyFromObject(&hostPod)]; node != p.agentHostname {
+			continue
+		}
+
+		retPods = append(retPods, &hostPod)
 	}
 
 	return retPods, nil

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -674,11 +675,33 @@ func updatePod(dst, src *corev1.Pod) {
 	updateContainerImages(dst.Spec.Containers, src.Spec.Containers)
 	updateContainerImages(dst.Spec.InitContainers, src.Spec.InitContainers)
 
+	updateMetadata(dst, src)
+
 	dst.Spec.ActiveDeadlineSeconds = src.Spec.ActiveDeadlineSeconds
 	dst.Spec.Tolerations = src.Spec.Tolerations
+}
 
-	dst.Annotations = src.Annotations
-	dst.Labels = src.Labels
+// updateMetadata copies the labels and annotations from src (the virtual Pod) onto dst (the host Pod),
+// while preserving the k3k metadata (labels and annotations with the "k3k.io/*" prefix)
+func updateMetadata(dst, src *corev1.Pod) {
+	dst.Labels = mergeManagedMetadata(dst.Labels, src.Labels)
+	dst.Annotations = mergeManagedMetadata(dst.Annotations, src.Annotations)
+}
+
+// mergeManagedMetadata returns a new map with all the entries from src (the virtual object),
+// plus the k3k metadata (keys with the translate.MetadataPrefix) carried over from dst (the host object).
+func mergeManagedMetadata(dst, src map[string]string) map[string]string {
+	merged := make(map[string]string, len(src))
+
+	maps.Copy(merged, src)
+
+	for key, value := range dst {
+		if strings.HasPrefix(key, translate.MetadataPrefix) {
+			merged[key] = value
+		}
+	}
+
+	return merged
 }
 
 // updateContainerImages will update the images of the original container images with the same name

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -409,6 +409,9 @@ func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
 	hostPod := virtualPod.DeepCopy()
 	p.Translator.TranslateTo(hostPod)
 
+	// record which k3k-kubelet agent synced this Pod, so GetPods can scope to this agent's own Pods
+	hostPod.Labels[translate.AgentNameLabel] = p.agentHostname
+
 	logger = logger.WithValues("pod", hostPod.Name)
 
 	// Clear the NodeName to allow scheduling, and set affinity to prefer scheduling the Pod on the same host node as the virtual kubelet,
@@ -781,14 +784,7 @@ func (p *Provider) getPodFromHostCluster(ctx context.Context, hostPodName string
 // concurrently outside of the calling goroutine. Therefore it is recommended
 // to return a version after DeepCopy.
 //
-// It returns only the Pods this instance owns: those whose virtual Pod is assigned to this node
-// (spec.nodeName == p.agentHostname), plus genuinely dangling Pods whose virtual counterpart no
-// longer exists. This matters because GetPods feeds the virtual-kubelet framework's startup
-// reconciliation (deleteDanglingPods), which deletes any Pod returned here that is absent from
-// this instance's virtual Pod lister (scoped to the same node) — so on a multi-node host,
-// returning a Pod owned by another node would make this instance wrongly delete it. Ownership is
-// the virtual Pod's node, not the host Pod's physical node: host Pods are scheduled with only a
-// soft, sometimes-absent affinity toward their owner, so their physical placement is unreliable.
+// It returns only the Pods synced by this k3k-kubelet agent, identified by the AgentNameLabel.
 func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 	p.logger.V(1).Info("GetPods")
 
@@ -796,7 +792,10 @@ func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 
 	listOpts := []client.ListOption{
 		client.InNamespace(p.ClusterNamespace),
-		client.MatchingLabels{translate.ClusterNameLabel: p.ClusterName},
+		client.MatchingLabels{
+			translate.ClusterNameLabel: p.ClusterName,
+			translate.AgentNameLabel:   p.agentHostname,
+		},
 	}
 
 	if err := p.Host.Client.List(ctx, &hostPods, listOpts...); err != nil {
@@ -804,29 +803,10 @@ func (p *Provider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 		return nil, err
 	}
 
-	// Map each virtual Pod to its node. Read live (not from the manager cache): this can run at
-	// startup before that cache is synced, and a stale read would misclassify a live Pod as gone.
-	virtualPods, err := p.Virtual.CoreClient.Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		p.logger.Error(err, "Error listing pods from virtual cluster")
-		return nil, err
-	}
-
-	nodeByPod := make(map[types.NamespacedName]string, len(virtualPods.Items))
-	for _, virtPod := range virtualPods.Items {
-		nodeByPod[client.ObjectKeyFromObject(&virtPod)] = virtPod.Spec.NodeName
-	}
-
-	retPods := []*corev1.Pod{}
+	retPods := make([]*corev1.Pod, 0, len(hostPods.Items))
 
 	for _, hostPod := range hostPods.DeepCopy().Items {
 		p.Translator.TranslateFrom(&hostPod)
-
-		// skip Pods owned by another node; that node's instance is responsible for them
-		if node := nodeByPod[client.ObjectKeyFromObject(&hostPod)]; node != p.agentHostname {
-			continue
-		}
-
 		retPods = append(retPods, &hostPod)
 	}
 

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/rancher/k3k/k3k-kubelet/translate"
 )

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -307,14 +307,16 @@ func Test_configureEnv(t *testing.T) {
 	}
 }
 
-// TestGetPods_ScopedToVirtualNode pins the behavior that GetPods returns only the Pods this
-// instance owns -- determined by the *virtual* Pod's node (spec.nodeName == agentHostname), the
-// same signal the virtual-kubelet framework's deleteDanglingPods uses -- plus genuinely dangling
-// Pods (whose virtual counterpart no longer exists). Pods owned by another node are excluded so
-// this instance never treats them as dangling and deletes them. The host Pod's own physical
+// TestGetPods_ScopedToVirtualNode pins the behavior that GetPods returns only the Pods whose
+// virtual counterpart is assigned to this node (spec.nodeName == agentHostname), the same signal
+// the virtual-kubelet framework's deleteDanglingPods uses. Pods owned by another node -- and Pods
+// whose virtual counterpart no longer exists -- are excluded. The host Pod's own physical
 // spec.nodeName is unrelated to ownership and must be ignored.
 func TestGetPods_ScopedToVirtualNode(t *testing.T) {
-	const clusterName = "c-test"
+	const (
+		clusterName      = "c-test"
+		clusterNamespace = "ns-test"
+	)
 
 	// host Pods carry the tracking metadata TranslateFrom reads to recover the virtual identity.
 	// Their physical NodeName is set to deliberately-mismatched values to prove it is ignored.
@@ -322,7 +324,7 @@ func TestGetPods_ScopedToVirtualNode(t *testing.T) {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      hostName,
-				Namespace: "ns-test",
+				Namespace: clusterNamespace,
 				Labels: map[string]string{
 					translate.ClusterNameLabel: clusterName,
 				},
@@ -364,11 +366,12 @@ func TestGetPods_ScopedToVirtualNode(t *testing.T) {
 		Virtual: ClusterContext{CoreClient: virtClient.CoreV1()},
 		Translator: translate.ToHostTranslator{
 			ClusterName:      clusterName,
-			ClusterNamespace: "ns-test",
+			ClusterNamespace: clusterNamespace,
 		},
-		ClusterName:   clusterName,
-		agentHostname: "node-a",
-		logger:        logr.Discard(),
+		ClusterName:      clusterName,
+		ClusterNamespace: clusterNamespace,
+		agentHostname:    "node-a",
+		logger:           logr.Discard(),
 	}
 
 	pods, err := p.GetPods(context.Background())
@@ -379,6 +382,6 @@ func TestGetPods_ScopedToVirtualNode(t *testing.T) {
 		names[pod.Name] = true
 	}
 
-	// a1 (own node) and c1 (dangling) are returned; b1 (other node) is excluded.
-	assert.Equal(t, map[string]bool{"a1": true, "c1": true}, names)
+	// only a1 (own node) is returned; b1 (other node) and c1 (dangling) are excluded.
+	assert.Equal(t, map[string]bool{"a1": true}, names)
 }

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -1,10 +1,16 @@
 package provider
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -299,4 +305,80 @@ func Test_configureEnv(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestGetPods_ScopedToVirtualNode pins the behavior that GetPods returns only the Pods this
+// instance owns -- determined by the *virtual* Pod's node (spec.nodeName == agentHostname), the
+// same signal the virtual-kubelet framework's deleteDanglingPods uses -- plus genuinely dangling
+// Pods (whose virtual counterpart no longer exists). Pods owned by another node are excluded so
+// this instance never treats them as dangling and deletes them. The host Pod's own physical
+// spec.nodeName is unrelated to ownership and must be ignored.
+func TestGetPods_ScopedToVirtualNode(t *testing.T) {
+	const clusterName = "c-test"
+
+	// host Pods carry the tracking metadata TranslateFrom reads to recover the virtual identity.
+	// Their physical NodeName is set to deliberately-mismatched values to prove it is ignored.
+	newHostPod := func(hostName, virtName, hostNodeName string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hostName,
+				Namespace: "ns-test",
+				Labels: map[string]string{
+					translate.ClusterNameLabel: clusterName,
+				},
+				Annotations: map[string]string{
+					translate.ResourceNameAnnotation:      virtName,
+					translate.ResourceNamespaceAnnotation: "default",
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: hostNodeName},
+		}
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	hostClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			newHostPod("host-a1", "a1", "node-b"), // owned by node-a (virtual), physically on node-b
+			newHostPod("host-b1", "b1", "node-a"), // owned by node-b (virtual), physically on node-a
+			newHostPod("host-c1", "c1", "node-a"), // dangling: no virtual Pod exists
+		).
+		Build()
+
+	// virtual Pods: a1 on node-a (ours), b1 on node-b (other); c1 intentionally absent (dangling).
+	virtClient := fakeclientset.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "a1", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "node-a"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "node-b"},
+		},
+	)
+
+	p := Provider{
+		Host:    ClusterContext{Client: hostClient},
+		Virtual: ClusterContext{CoreClient: virtClient.CoreV1()},
+		Translator: translate.ToHostTranslator{
+			ClusterName:      clusterName,
+			ClusterNamespace: "ns-test",
+		},
+		ClusterName:   clusterName,
+		agentHostname: "node-a",
+		logger:        logr.Discard(),
+	}
+
+	pods, err := p.GetPods(context.Background())
+	require.NoError(t, err)
+
+	names := map[string]bool{}
+	for _, pod := range pods {
+		names[pod.Name] = true
+	}
+
+	// a1 (own node) and c1 (dangling) are returned; b1 (other node) is excluded.
+	assert.Equal(t, map[string]bool{"a1": true, "c1": true}, names)
 }

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -13,7 +13,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/rancher/k3k/k3k-kubelet/translate"
 )
@@ -307,33 +306,34 @@ func Test_configureEnv(t *testing.T) {
 	}
 }
 
-// TestGetPods_ScopedToVirtualNode pins the behavior that GetPods returns only the Pods whose
-// virtual counterpart is assigned to this node (spec.nodeName == agentHostname), the same signal
-// the virtual-kubelet framework's deleteDanglingPods uses. Pods owned by another node -- and Pods
-// whose virtual counterpart no longer exists -- are excluded. The host Pod's own physical
-// spec.nodeName is unrelated to ownership and must be ignored.
-func TestGetPods_ScopedToVirtualNode(t *testing.T) {
+// TestGetPods_ScopedToAgent pins the behavior that GetPods returns only the Pods synced by this
+// k3k-kubelet agent, identified by the AgentNameLabel and scoped to this cluster's host namespace.
+// Pods synced by another agent, or living in another namespace, are excluded. Pods are returned
+// regardless of whether their virtual counterpart still exists, so the virtual-kubelet startup
+// reconciliation can still clean up genuine orphans.
+func TestGetPods_ScopedToAgent(t *testing.T) {
 	const (
 		clusterName      = "c-test"
 		clusterNamespace = "ns-test"
+		agentName        = "node-a"
 	)
 
-	// host Pods carry the tracking metadata TranslateFrom reads to recover the virtual identity.
-	// Their physical NodeName is set to deliberately-mismatched values to prove it is ignored.
-	newHostPod := func(hostName, virtName, hostNodeName string) *corev1.Pod {
+	// host Pods carry the tracking metadata TranslateFrom reads to recover the virtual identity,
+	// plus the AgentNameLabel recording which agent synced them.
+	newHostPod := func(name, agent, namespace string) *corev1.Pod {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      hostName,
-				Namespace: clusterNamespace,
+				Name:      name,
+				Namespace: namespace,
 				Labels: map[string]string{
 					translate.ClusterNameLabel: clusterName,
+					translate.AgentNameLabel:   agent,
 				},
 				Annotations: map[string]string{
-					translate.ResourceNameAnnotation:      virtName,
+					translate.ResourceNameAnnotation:      name,
 					translate.ResourceNamespaceAnnotation: "default",
 				},
 			},
-			Spec: corev1.PodSpec{NodeName: hostNodeName},
 		}
 	}
 
@@ -343,34 +343,21 @@ func TestGetPods_ScopedToVirtualNode(t *testing.T) {
 	hostClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(
-			newHostPod("host-a1", "a1", "node-b"), // owned by node-a (virtual), physically on node-b
-			newHostPod("host-b1", "b1", "node-a"), // owned by node-b (virtual), physically on node-a
-			newHostPod("host-c1", "c1", "node-a"), // dangling: no virtual Pod exists
+			newHostPod("a1", agentName, clusterNamespace), // synced by this agent -> returned
+			newHostPod("b1", "node-b", clusterNamespace),  // synced by another agent -> excluded
+			newHostPod("d1", agentName, "ns-other"),       // another namespace -> excluded
 		).
 		Build()
 
-	// virtual Pods: a1 on node-a (ours), b1 on node-b (other); c1 intentionally absent (dangling).
-	virtClient := fakeclientset.NewSimpleClientset(
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "a1", Namespace: "default"},
-			Spec:       corev1.PodSpec{NodeName: "node-a"},
-		},
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "default"},
-			Spec:       corev1.PodSpec{NodeName: "node-b"},
-		},
-	)
-
 	p := Provider{
-		Host:    ClusterContext{Client: hostClient},
-		Virtual: ClusterContext{CoreClient: virtClient.CoreV1()},
+		Host: ClusterContext{Client: hostClient},
 		Translator: translate.ToHostTranslator{
 			ClusterName:      clusterName,
 			ClusterNamespace: clusterNamespace,
 		},
 		ClusterName:      clusterName,
 		ClusterNamespace: clusterNamespace,
-		agentHostname:    "node-a",
+		agentHostname:    agentName,
 		logger:           logr.Discard(),
 	}
 
@@ -382,6 +369,6 @@ func TestGetPods_ScopedToVirtualNode(t *testing.T) {
 		names[pod.Name] = true
 	}
 
-	// only a1 (own node) is returned; b1 (other node) and c1 (dangling) are excluded.
+	// only a1 (synced by this agent, in this namespace) is returned.
 	assert.Equal(t, map[string]bool{"a1": true}, names)
 }

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -372,3 +372,36 @@ func TestGetPods_ScopedToAgent(t *testing.T) {
 	// only a1 (synced by this agent, in this namespace) is returned.
 	assert.Equal(t, map[string]bool{"a1": true}, names)
 }
+
+func TestUpdateMetadata(t *testing.T) {
+	hostPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-pod",
+			Namespace: "ns-test",
+			Labels: map[string]string{
+				translate.ClusterNameLabel: "c-test",
+				translate.AgentNameLabel:   "node-a",
+				"app":                      "nginx",
+			},
+			Annotations: map[string]string{
+				translate.ResourceNameAnnotation:      "my-pod",
+				translate.ResourceNamespaceAnnotation: "default",
+			},
+		},
+	}
+
+	virtualPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "nginx"},
+		},
+	}
+
+	updateMetadata(hostPod, virtualPod)
+
+	assert.Equal(t, "c-test", hostPod.Labels[translate.ClusterNameLabel])
+	assert.Equal(t, "node-a", hostPod.Labels[translate.AgentNameLabel])
+	assert.Equal(t, "my-pod", hostPod.Annotations[translate.ResourceNameAnnotation])
+	assert.Equal(t, "default", hostPod.Annotations[translate.ResourceNamespaceAnnotation])
+}

--- a/k3k-kubelet/translate/host.go
+++ b/k3k-kubelet/translate/host.go
@@ -14,18 +14,20 @@ import (
 )
 
 const (
+	// MetadataPrefix is the common prefix for all k3k-managed labels and annotations.
+	MetadataPrefix = "k3k.io/"
 	// ClusterNameLabel is the key for the label that contains the name of the virtual cluster
 	// this resource was made in
-	ClusterNameLabel = "k3k.io/clusterName"
+	ClusterNameLabel = MetadataPrefix + "clusterName"
 	// AgentNameLabel is the key for the label that contains the name of the k3k-kubelet agent
 	// (the host node it runs on) that synced this resource
-	AgentNameLabel = "k3k.io/agentName"
+	AgentNameLabel = MetadataPrefix + "agentName"
 	// ResourceNameAnnotation is the key for the annotation that contains the original name of this
 	// resource in the virtual cluster
-	ResourceNameAnnotation = "k3k.io/name"
+	ResourceNameAnnotation = MetadataPrefix + "name"
 	// ResourceNamespaceAnnotation is the key for the annotation that contains the original namespace of this
 	// resource in the virtual cluster
-	ResourceNamespaceAnnotation = "k3k.io/namespace"
+	ResourceNamespaceAnnotation = MetadataPrefix + "namespace"
 	// MetadataNameField is the downwardapi field for object's name
 	MetadataNameField = "metadata.name"
 	// MetadataNamespaceField is the downward field for the object's namespace

--- a/k3k-kubelet/translate/host.go
+++ b/k3k-kubelet/translate/host.go
@@ -17,6 +17,9 @@ const (
 	// ClusterNameLabel is the key for the label that contains the name of the virtual cluster
 	// this resource was made in
 	ClusterNameLabel = "k3k.io/clusterName"
+	// AgentNameLabel is the key for the label that contains the name of the k3k-kubelet agent
+	// (the host node it runs on) that synced this resource
+	AgentNameLabel = "k3k.io/agentName"
 	// ResourceNameAnnotation is the key for the annotation that contains the original name of this
 	// resource in the virtual cluster
 	ResourceNameAnnotation = "k3k.io/name"

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -688,6 +688,7 @@ func (c *ClusterReconciler) ensureClusterService(ctx context.Context, cluster *v
 		} else {
 			maps.Copy(currentService.Annotations, expectedService.Annotations)
 		}
+
 		currentService.Spec = expectedService.Spec
 
 		return nil

--- a/tests/cli/tests_suite_test.go
+++ b/tests/cli/tests_suite_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	k3kNamespace = "k3k-system"
-
 	k3sVersion    = "v1.36.2-k3s1"
 	k3sOldVersion = "v1.36.0-k3s1"
 )

--- a/tests/e2e/cluster_kubelet_restart_test.go
+++ b/tests/e2e/cluster_kubelet_restart_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/api/v1/pod"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -182,6 +183,177 @@ var _ = Context("In a shared cluster", Label(e2eTestLabel), Label(slowTestsLabel
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(hPod.UID).To(Equal(hostPodUID))
 				g.Expect(hPod.Status.Phase).To(Equal(corev1.PodRunning))
+			}).
+				WithPolling(5 * time.Second).
+				WithTimeout(time.Minute).
+				Should(Succeed())
+		})
+	})
+
+	When("restarting the k3k-kubelet with Pods spread across nodes", func() {
+		const appLabel = "dangling-test"
+
+		var (
+			nodeCount      int
+			virtualPodUIDs map[string]types.UID // virtual pod name -> UID
+			hostPodUIDs    map[string]types.UID // host pod name  -> UID
+		)
+
+		BeforeAll(func() {
+			ctx := context.Background()
+
+			By("Listing the virtual cluster nodes")
+
+			nodeList, err := virtualCluster.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			nodeCount = len(nodeList.Items)
+			if nodeCount < 2 {
+				Skip("cross-node dangling-pod deletion can only be reproduced on a multi-node host cluster")
+			}
+
+			By("Creating a Deployment with one Pod per node (required anti-affinity)")
+
+			replicas := int32(nodeCount)
+
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dangling-test",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": appLabel},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": appLabel},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "nginx",
+								Image: "nginx",
+							}},
+							// force one Pod per node, so some Pods necessarily live on a node
+							// other than any given k3k-kubelet instance's own node
+							Affinity: &corev1.Affinity{
+								PodAntiAffinity: &corev1.PodAntiAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{"app": appLabel},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err = virtualCluster.Client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for all Pods to be Running on distinct nodes")
+
+			Eventually(func(g Gomega) {
+				podList, err := virtualCluster.Client.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: "app=" + appLabel})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(podList.Items).To(HaveLen(nodeCount))
+
+				nodes := map[string]struct{}{}
+
+				for i := range podList.Items {
+					p := &podList.Items[i]
+					g.Expect(p.Status.Phase).To(Equal(corev1.PodRunning))
+					g.Expect(p.Spec.NodeName).NotTo(BeEmpty())
+					nodes[p.Spec.NodeName] = struct{}{}
+				}
+
+				// the anti-affinity must have spread the Pods across every node
+				g.Expect(nodes).To(HaveLen(nodeCount))
+			}).
+				WithPolling(time.Second).
+				WithTimeout(2 * time.Minute).
+				Should(Succeed())
+
+			By("Recording the virtual and host Pod UIDs before the restart")
+
+			virtualPodUIDs = map[string]types.UID{}
+			hostPodUIDs = map[string]types.UID{}
+
+			podList, err := virtualCluster.Client.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: "app=" + appLabel})
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := range podList.Items {
+				vPod := &podList.Items[i]
+				virtualPodUIDs[vPod.Name] = vPod.UID
+
+				hostPodName := translator.NamespacedName(vPod)
+
+				hPod, err := k8s.CoreV1().Pods(hostPodName.Namespace).Get(ctx, hostPodName.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				hostPodUIDs[hostPodName.Name] = hPod.UID
+			}
+		})
+
+		It("should not delete Pods scheduled on other nodes after a restart", func() {
+			ctx := context.Background()
+
+			By("Restarting every k3k-kubelet agent Pod (one per host node)")
+
+			oldAgentPods := listAgentPods(ctx, virtualCluster)
+			Expect(oldAgentPods).NotTo(BeEmpty())
+
+			oldAgentUIDs := map[types.UID]bool{}
+			for _, agentPod := range oldAgentPods {
+				oldAgentUIDs[agentPod.UID] = true
+			}
+
+			for _, agentPod := range oldAgentPods {
+				Expect(k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).Delete(ctx, agentPod.Name, metav1.DeleteOptions{})).To(Succeed())
+			}
+
+			By("Waiting for every k3k-kubelet agent Pod to be replaced and become Ready")
+
+			Eventually(func(g Gomega) {
+				newAgentPods := listAgentPods(ctx, virtualCluster)
+				g.Expect(newAgentPods).To(HaveLen(len(oldAgentPods)))
+
+				for _, agentPod := range newAgentPods {
+					g.Expect(oldAgentUIDs).NotTo(HaveKey(agentPod.UID), "Pod %q was not replaced", agentPod.Name)
+
+					_, cond := pod.GetPodCondition(&agentPod.Status, corev1.PodReady)
+					g.Expect(cond).NotTo(BeNil())
+					g.Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				}
+			}).
+				WithPolling(time.Second).
+				WithTimeout(2 * time.Minute).
+				Should(Succeed())
+
+			// deleteDanglingPods runs asynchronously at each k3k-kubelet's startup, so poll over a
+			// window rather than checking once. If any workload Pod on another node is wrongly
+			// treated as dangling, its host Pod is deleted (Get returns NotFound / a new UID).
+
+			By("Checking no workload Pod is deleted from the virtual or host cluster")
+
+			Consistently(func(g Gomega) {
+				for name, uid := range virtualPodUIDs {
+					vPod, err := virtualCluster.Client.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(vPod.UID).To(Equal(uid))
+					g.Expect(vPod.Status.Phase).To(Equal(corev1.PodRunning))
+				}
+
+				for hostName, uid := range hostPodUIDs {
+					hPod, err := k8s.CoreV1().Pods(virtualCluster.Cluster.Namespace).Get(ctx, hostName, metav1.GetOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(hPod.UID).To(Equal(uid))
+					g.Expect(hPod.Status.Phase).To(Equal(corev1.PodRunning))
+				}
 			}).
 				WithPolling(5 * time.Second).
 				WithTimeout(time.Minute).

--- a/tests/e2e/cluster_kubelet_restart_test.go
+++ b/tests/e2e/cluster_kubelet_restart_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FContext("In a shared cluster", Label(e2eTestLabel), Label(slowTestsLabel), Ordered, func() {
+var _ = Context("In a shared cluster", Label(e2eTestLabel), Label(slowTestsLabel), Ordered, func() {
 	var (
 		virtualCluster *VirtualCluster
 		translator     *translate.ToHostTranslator

--- a/tests/e2e/cluster_kubelet_restart_test.go
+++ b/tests/e2e/cluster_kubelet_restart_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Context("In a shared cluster", Label(e2eTestLabel), Label(slowTestsLabel), Ordered, func() {
+var _ = FContext("In a shared cluster", Label(e2eTestLabel), Label(slowTestsLabel), Ordered, func() {
 	var (
 		virtualCluster *VirtualCluster
 		translator     *translate.ToHostTranslator


### PR DESCRIPTION


 In **shared mode** on a **multi-node** host cluster, restarting a k3k-kubelet could delete healthy synced pods, on both the host and the virtual cluster.

The deletion is driven by the `virtual-kubelet` library's `deleteDanglingPods`, which runs once every time a k3k-kubelet instance starts. It calls `Provider.GetPods()` to learn which pods the provider "has", then deletes any of them tre absent from that instance's **virtual pod lister**, which is scoped to `spec.nodeName == <this instance's node>`.

`GetPods()` listed host pods **cluster-wide** (filtered only by the `k3k.io/clusterName` label), so on a multi-node host every restarting instance saw pods belonging to *other* nodes, found them missing from its own node-scoped lister, and deleted them.

On a single-node cluster there is only one instance, so the two sets always match and the bug is not happening.

## Fix

Scope `GetPods()` to the pods this instance owns. Ownership is the **virtual pod's** `spec.nodeName` (the same signal the framework's lister uses), not the host pod's physical node. Host pods are scheduled with only a soft, sometimes-absent affinity toward their owner, so their physical placement is unreliable.

`GetPods()` now returns only the pods assigned to the virtual kubelet for that cluster, filtering them with a new `k3k.io/agentName` label.

This PR also fixes an existing bug removing the `k3k.io/clusterName` labels and k3k annotations.
