### PR TITLE
Add completion to `--namespace` flag

### DIFF
--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -70,9 +70,9 @@ func NewClusterCreateCmd(appCtx *AppContext) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 
-	CobraFlagNamespace(appCtx, cmd, completeNamespaces(appCtx))
-
 	createFlags(cmd, createConfig)
+
+	CobraFlagNamespace(appCtx, cmd, completeNamespaces)
 
 	return cmd
 }

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -70,7 +70,7 @@ func NewClusterCreateCmd(appCtx *AppContext) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 
-	CobraFlagNamespace(appCtx, cmd.Flags())
+	CobraFlagNamespace(appCtx, cmd, completeNamespaces(appCtx))
 
 	createFlags(cmd, createConfig)
 

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -29,8 +29,9 @@ func NewClusterDeleteCmd(appCtx *AppContext) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 	}
 
-	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
 	cmd.Flags().BoolVar(&keepData, "keep-data", false, "keeps persistence volumes created for the cluster after deletion")
+
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces)
 
 	return cmd
 }

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -29,7 +29,7 @@ func NewClusterDeleteCmd(appCtx *AppContext) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 	}
 
-	CobraFlagNamespace(appCtx, cmd.Flags())
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
 	cmd.Flags().BoolVar(&keepData, "keep-data", false, "keeps persistence volumes created for the cluster after deletion")
 
 	return cmd

--- a/cli/cmds/cluster_list.go
+++ b/cli/cmds/cluster_list.go
@@ -22,7 +22,7 @@ func NewClusterListCmd(appCtx *AppContext) *cobra.Command {
 		Args:    cobra.NoArgs,
 	}
 
-	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces)
 
 	return cmd
 }

--- a/cli/cmds/cluster_list.go
+++ b/cli/cmds/cluster_list.go
@@ -22,7 +22,7 @@ func NewClusterListCmd(appCtx *AppContext) *cobra.Command {
 		Args:    cobra.NoArgs,
 	}
 
-	CobraFlagNamespace(appCtx, cmd.Flags())
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
 
 	return cmd
 }

--- a/cli/cmds/cluster_update.go
+++ b/cli/cmds/cluster_update.go
@@ -40,7 +40,7 @@ func NewClusterUpdateCmd(appCtx *AppContext) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 	}
 
-	CobraFlagNamespace(appCtx, cmd.Flags())
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
 	updateFlags(cmd, updateConfig)
 
 	return cmd

--- a/cli/cmds/cluster_update.go
+++ b/cli/cmds/cluster_update.go
@@ -40,7 +40,8 @@ func NewClusterUpdateCmd(appCtx *AppContext) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 	}
 
-	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces)
+
 	updateFlags(cmd, updateConfig)
 
 	return cmd

--- a/cli/cmds/completion.go
+++ b/cli/cmds/completion.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -58,9 +59,18 @@ func completeNamespaces(appCtx *AppContext) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		names := make([]string, 0, len(namespaces.Items))
+		// Exclude already selected namespaces
+		selected := sets.New[string]()
+		if vals, err := cmd.Flags().GetStringSlice("namespace"); err == nil {
+			selected.Insert(vals...)
+		}
+
+		names := []string{}
+
 		for _, ns := range namespaces.Items {
-			names = append(names, ns.Name)
+			if !selected.Has(ns.Name) {
+				names = append(names, ns.Name)
+			}
 		}
 
 		return names, cobra.ShellCompDirectiveNoFileComp
@@ -82,19 +92,12 @@ func completeClusterNamespaces(appCtx *AppContext) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		seen := make(map[string]struct{})
-		names := make([]string, 0)
-
+		namespaces := sets.New[string]()
 		for _, cluster := range clusters.Items {
-			if _, ok := seen[cluster.Namespace]; ok {
-				continue
-			}
-
-			seen[cluster.Namespace] = struct{}{}
-			names = append(names, cluster.Namespace)
+			namespaces.Insert(cluster.Namespace)
 		}
 
-		return names, cobra.ShellCompDirectiveNoFileComp
+		return sets.List(namespaces), cobra.ShellCompDirectiveNoFileComp
 	}
 }
 

--- a/cli/cmds/completion.go
+++ b/cli/cmds/completion.go
@@ -1,9 +1,14 @@
 package cmds
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
@@ -23,6 +28,75 @@ var completePersistenceMode = cobra.FixedCompletions(
 	},
 	cobra.ShellCompDirectiveNoFileComp,
 )
+
+// completionClient builds a Kubernetes client for use inside completion
+// functions. Cobra does not run PersistentPreRunE during shell completion, so
+// appCtx.Client is usually nil here and we have to build the client ourselves.
+func completionClient(appCtx *AppContext) (client.Client, error) {
+	if appCtx.Client != nil {
+		return appCtx.Client, nil
+	}
+
+	restConfig, err := loadRESTConfig(appCtx.Kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildClient(restConfig)
+}
+
+// completeNamespaces completes with every namespace in the host cluster.
+func completeNamespaces(appCtx *AppContext) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cl, err := completionClient(appCtx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var namespaces corev1.NamespaceList
+		if err := cl.List(context.Background(), &namespaces); err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := make([]string, 0, len(namespaces.Items))
+		for _, ns := range namespaces.Items {
+			names = append(names, ns.Name)
+		}
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// completeClusterNamespaces completes with the unique namespaces that contain at
+// least one k3k Cluster, which is the relevant set when acting on an existing
+// cluster (delete, list, update, kubeconfig).
+func completeClusterNamespaces(appCtx *AppContext) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cl, err := completionClient(appCtx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var clusters v1beta1.ClusterList
+		if err := cl.List(context.Background(), &clusters); err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		seen := make(map[string]struct{})
+		names := make([]string, 0)
+
+		for _, cluster := range clusters.Items {
+			if _, ok := seen[cluster.Namespace]; ok {
+				continue
+			}
+
+			seen[cluster.Namespace] = struct{}{}
+			names = append(names, cluster.Namespace)
+		}
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
 
 // mustRegisterFlagCompletion registers a completion function for a flag and
 // aborts if the flag does not exist. This only fails on programmer error, so

--- a/cli/cmds/completion.go
+++ b/cli/cmds/completion.go
@@ -30,75 +30,66 @@ var completePersistenceMode = cobra.FixedCompletions(
 	cobra.ShellCompDirectiveNoFileComp,
 )
 
-// completionClient builds a Kubernetes client for use inside completion
-// functions. Cobra does not run PersistentPreRunE during shell completion, so
-// appCtx.Client is usually nil here and we have to build the client ourselves.
-func completionClient(appCtx *AppContext) (client.Client, error) {
-	if appCtx.Client != nil {
-		return appCtx.Client, nil
-	}
-
-	restConfig, err := loadRESTConfig(appCtx.Kubeconfig)
+// completeNamespaces is a cobra.CompletionFunc that completes with every namespace in the host cluster.
+func completeNamespaces(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := completionClient(cmd)
 	if err != nil {
-		return nil, err
+		return nil, cobra.ShellCompDirectiveError
 	}
 
-	return buildClient(restConfig)
+	return namespaceCompletions(cmd, client)
 }
 
-// completeNamespaces completes with every namespace in the host cluster.
-func completeNamespaces(appCtx *AppContext) cobra.CompletionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cl, err := completionClient(appCtx)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		var namespaces corev1.NamespaceList
-		if err := cl.List(context.Background(), &namespaces); err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		// Exclude already selected namespaces
-		selected := sets.New[string]()
-		if vals, err := cmd.Flags().GetStringSlice("namespace"); err == nil {
-			selected.Insert(vals...)
-		}
-
-		names := []string{}
-
-		for _, ns := range namespaces.Items {
-			if !selected.Has(ns.Name) {
-				names = append(names, ns.Name)
-			}
-		}
-
-		return names, cobra.ShellCompDirectiveNoFileComp
+// namespaceCompletions lists every namespace in the host cluster, excluding any
+// already provided to the command's "namespace" flag.
+func namespaceCompletions(cmd *cobra.Command, cl client.Client) ([]string, cobra.ShellCompDirective) {
+	var namespaces corev1.NamespaceList
+	if err := cl.List(context.Background(), &namespaces); err != nil {
+		return nil, cobra.ShellCompDirectiveError
 	}
+
+	// Exclude already selected namespaces
+	selected := sets.New[string]()
+	if vals, err := cmd.Flags().GetStringSlice("namespace"); err == nil {
+		selected.Insert(vals...)
+	}
+
+	names := []string{}
+
+	for _, ns := range namespaces.Items {
+		if !selected.Has(ns.Name) {
+			names = append(names, ns.Name)
+		}
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-// completeClusterNamespaces completes with the unique namespaces that contain at
-// least one k3k Cluster, which is the relevant set when acting on an existing
-// cluster (delete, list, update, kubeconfig).
-func completeClusterNamespaces(appCtx *AppContext) cobra.CompletionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cl, err := completionClient(appCtx)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		var clusters v1beta1.ClusterList
-		if err := cl.List(context.Background(), &clusters); err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		namespaces := sets.New[string]()
-		for _, cluster := range clusters.Items {
-			namespaces.Insert(cluster.Namespace)
-		}
-
-		return sets.List(namespaces), cobra.ShellCompDirectiveNoFileComp
+// completeClusterNamespaces is a cobra.CompletionFunc that completes with the namespaces
+// with a k3k virtual cluster in it.
+func completeClusterNamespaces(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := completionClient(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
 	}
+
+	return clusterNamespaceCompletions(client)
+}
+
+// clusterNamespaceCompletions lists the unique namespaces that contain at least
+// one k3k Cluster.
+func clusterNamespaceCompletions(cl client.Client) ([]string, cobra.ShellCompDirective) {
+	var clusters v1beta1.ClusterList
+	if err := cl.List(context.Background(), &clusters); err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	namespaces := sets.New[string]()
+	for _, cluster := range clusters.Items {
+		namespaces.Insert(cluster.Namespace)
+	}
+
+	return sets.List(namespaces), cobra.ShellCompDirectiveNoFileComp
 }
 
 // mustRegisterFlagCompletion registers a completion function for a flag and
@@ -142,4 +133,25 @@ func disableFileCompletion(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {
 		disableFileCompletion(sub)
 	}
+}
+
+// completionClient builds a Kubernetes client for use inside completion functions.
+// It checks if the kubeconfig flag is set, to point to the right cluster.
+func completionClient(cmd *cobra.Command) (client.Client, error) {
+	kubeconfig, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := loadRESTConfig(kubeconfig, completionRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := buildClient(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }

--- a/cli/cmds/completion.go
+++ b/cli/cmds/completion.go
@@ -40,12 +40,27 @@ func completeNamespaces(cmd *cobra.Command, args []string, toComplete string) ([
 	return namespaceCompletions(cmd, client)
 }
 
+// completeClusterNamespaces is a cobra.CompletionFunc that completes with the namespaces with a k3k virtual cluster in it.
+func completeClusterNamespaces(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := completionClient(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	return clusterNamespaceCompletions(cmd.Context(), client)
+}
+
 // namespaceCompletions lists every namespace in the host cluster, excluding any
 // already provided to the command's "namespace" flag.
 func namespaceCompletions(cmd *cobra.Command, cl client.Client) ([]string, cobra.ShellCompDirective) {
 	var namespaces corev1.NamespaceList
-	if err := cl.List(context.Background(), &namespaces); err != nil {
+	if err := cl.List(cmd.Context(), &namespaces); err != nil {
 		return nil, cobra.ShellCompDirectiveError
+	}
+
+	allNames := sets.New[string]()
+	for _, ns := range namespaces.Items {
+		allNames.Insert(ns.Name)
 	}
 
 	// Exclude already selected namespaces
@@ -54,42 +69,24 @@ func namespaceCompletions(cmd *cobra.Command, cl client.Client) ([]string, cobra
 		selected.Insert(vals...)
 	}
 
-	names := []string{}
+	names := allNames.Difference(selected)
 
-	for _, ns := range namespaces.Items {
-		if !selected.Has(ns.Name) {
-			names = append(names, ns.Name)
-		}
-	}
-
-	return names, cobra.ShellCompDirectiveNoFileComp
+	return sets.List(names), cobra.ShellCompDirectiveNoFileComp
 }
 
-// completeClusterNamespaces is a cobra.CompletionFunc that completes with the namespaces
-// with a k3k virtual cluster in it.
-func completeClusterNamespaces(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := completionClient(cmd)
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-
-	return clusterNamespaceCompletions(client)
-}
-
-// clusterNamespaceCompletions lists the unique namespaces that contain at least
-// one k3k Cluster.
-func clusterNamespaceCompletions(cl client.Client) ([]string, cobra.ShellCompDirective) {
+// clusterNamespaceCompletions lists the unique namespaces that contain at least one k3k Cluster.
+func clusterNamespaceCompletions(ctx context.Context, client client.Client) ([]string, cobra.ShellCompDirective) {
 	var clusters v1beta1.ClusterList
-	if err := cl.List(context.Background(), &clusters); err != nil {
+	if err := client.List(ctx, &clusters); err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	namespaces := sets.New[string]()
+	names := sets.New[string]()
 	for _, cluster := range clusters.Items {
-		namespaces.Insert(cluster.Namespace)
+		names.Insert(cluster.Namespace)
 	}
 
-	return sets.List(namespaces), cobra.ShellCompDirectiveNoFileComp
+	return sets.List(names), cobra.ShellCompDirectiveNoFileComp
 }
 
 // mustRegisterFlagCompletion registers a completion function for a flag and

--- a/cli/cmds/completion_test.go
+++ b/cli/cmds/completion_test.go
@@ -46,9 +46,7 @@ func Test_completeNamespaces(t *testing.T) {
 		).
 		Build()
 
-	appCtx := &AppContext{Client: fakeClient}
-
-	names, directive := completeNamespaces(appCtx)(&cobra.Command{}, nil, "")
+	names, directive := namespaceCompletions(&cobra.Command{}, fakeClient)
 
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 	assert.ElementsMatch(t, []string{"default", "k3k-foo", "k3k-bar"}, names)
@@ -64,13 +62,11 @@ func Test_completeNamespaces_excludesSelected(t *testing.T) {
 		).
 		Build()
 
-	appCtx := &AppContext{Client: fakeClient}
-
 	cmd := &cobra.Command{}
 	cmd.Flags().StringSlice("namespace", nil, "")
 	assert.NoError(t, cmd.Flags().Set("namespace", "k3k-foo"))
 
-	names, directive := completeNamespaces(appCtx)(cmd, nil, "")
+	names, directive := namespaceCompletions(cmd, fakeClient)
 
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 	// already-selected "k3k-foo" is filtered out
@@ -91,9 +87,7 @@ func Test_completeClusterNamespaces(t *testing.T) {
 		).
 		Build()
 
-	appCtx := &AppContext{Client: fakeClient}
-
-	names, directive := completeClusterNamespaces(appCtx)(&cobra.Command{}, nil, "")
+	names, directive := clusterNamespaceCompletions(fakeClient)
 
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 	// only namespaces that contain a cluster, deduplicated; "default" is excluded

--- a/cli/cmds/completion_test.go
+++ b/cli/cmds/completion_test.go
@@ -1,0 +1,78 @@
+package cmds
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
+)
+
+func completionTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	schemeBuilder := runtime.NewSchemeBuilder(
+		clientgoscheme.AddToScheme,
+		v1beta1.AddToScheme,
+	)
+	assert.NoError(t, schemeBuilder.AddToScheme(scheme))
+
+	return scheme
+}
+
+func namespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func cluster(name, ns string) *v1beta1.Cluster {
+	return &v1beta1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+
+func Test_completeNamespaces(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(completionTestScheme(t)).
+		WithObjects(
+			namespace("default"),
+			namespace("k3k-foo"),
+			namespace("k3k-bar"),
+		).
+		Build()
+
+	appCtx := &AppContext{Client: fakeClient}
+
+	names, directive := completeNamespaces(appCtx)(&cobra.Command{}, nil, "")
+
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.ElementsMatch(t, []string{"default", "k3k-foo", "k3k-bar"}, names)
+}
+
+func Test_completeClusterNamespaces(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(completionTestScheme(t)).
+		WithObjects(
+			namespace("default"),
+			namespace("k3k-foo"),
+			namespace("k3k-bar"),
+			cluster("foo", "k3k-foo"),
+			cluster("bar", "k3k-bar"),
+			// second cluster in the same namespace must be deduped
+			cluster("bar-2", "k3k-bar"),
+		).
+		Build()
+
+	appCtx := &AppContext{Client: fakeClient}
+
+	names, directive := completeClusterNamespaces(appCtx)(&cobra.Command{}, nil, "")
+
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	// only namespaces that contain a cluster, deduplicated; "default" is excluded
+	assert.ElementsMatch(t, []string{"k3k-foo", "k3k-bar"}, names)
+}

--- a/cli/cmds/completion_test.go
+++ b/cli/cmds/completion_test.go
@@ -54,6 +54,29 @@ func Test_completeNamespaces(t *testing.T) {
 	assert.ElementsMatch(t, []string{"default", "k3k-foo", "k3k-bar"}, names)
 }
 
+func Test_completeNamespaces_excludesSelected(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(completionTestScheme(t)).
+		WithObjects(
+			namespace("default"),
+			namespace("k3k-foo"),
+			namespace("k3k-bar"),
+		).
+		Build()
+
+	appCtx := &AppContext{Client: fakeClient}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("namespace", nil, "")
+	assert.NoError(t, cmd.Flags().Set("namespace", "k3k-foo"))
+
+	names, directive := completeNamespaces(appCtx)(cmd, nil, "")
+
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	// already-selected "k3k-foo" is filtered out
+	assert.ElementsMatch(t, []string{"default", "k3k-bar"}, names)
+}
+
 func Test_completeClusterNamespaces(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(completionTestScheme(t)).

--- a/cli/cmds/completion_test.go
+++ b/cli/cmds/completion_test.go
@@ -87,7 +87,7 @@ func Test_completeClusterNamespaces(t *testing.T) {
 		).
 		Build()
 
-	names, directive := clusterNamespaceCompletions(fakeClient)
+	names, directive := clusterNamespaceCompletions(t.Context(), fakeClient)
 
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 	// only namespaces that contain a cluster, deduplicated; "default" is excluded

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -56,7 +56,7 @@ func NewKubeconfigGenerateCmd(appCtx *AppContext) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	CobraFlagNamespace(appCtx, cmd.Flags())
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
 	generateKubeconfigFlags(cmd, cfg)
 
 	return cmd

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -56,7 +56,8 @@ func NewKubeconfigGenerateCmd(appCtx *AppContext) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces(appCtx))
+	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces)
+
 	generateKubeconfigFlags(cmd, cfg)
 
 	return cmd

--- a/cli/cmds/policy_create.go
+++ b/cli/cmds/policy_create.go
@@ -51,6 +51,7 @@ func NewPolicyCreateCmd(appCtx *AppContext) *cobra.Command {
 	cmd.Flags().BoolVar(&config.overwrite, "overwrite", false, "Overwrite namespace binding of existing policy")
 
 	mustRegisterFlagCompletion(cmd, "mode", completeClusterMode)
+	mustRegisterFlagCompletion(cmd, "namespace", completeNamespaces(appCtx))
 
 	return cmd
 }

--- a/cli/cmds/policy_create.go
+++ b/cli/cmds/policy_create.go
@@ -51,7 +51,7 @@ func NewPolicyCreateCmd(appCtx *AppContext) *cobra.Command {
 	cmd.Flags().BoolVar(&config.overwrite, "overwrite", false, "Overwrite namespace binding of existing policy")
 
 	mustRegisterFlagCompletion(cmd, "mode", completeClusterMode)
-	mustRegisterFlagCompletion(cmd, "namespace", completeNamespaces(appCtx))
+	mustRegisterFlagCompletion(cmd, "namespace", completeNamespaces)
 
 	return cmd
 }

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -93,8 +93,12 @@ func (ctx *AppContext) Namespace(name string) string {
 	return "k3k-" + name
 }
 
-func CobraFlagNamespace(appCtx *AppContext, flag *pflag.FlagSet) {
-	flag.StringVarP(&appCtx.namespace, "namespace", "n", "", "namespace of the k3k cluster")
+func CobraFlagNamespace(appCtx *AppContext, cmd *cobra.Command, completeFn cobra.CompletionFunc) {
+	cmd.Flags().StringVarP(&appCtx.namespace, "namespace", "n", "", "namespace of the k3k cluster")
+
+	if completeFn != nil {
+		mustRegisterFlagCompletion(cmd, "namespace", completeFn)
+	}
 }
 
 func InitializeConfig(cmd *cobra.Command) {

--- a/cli/cmds/root.go
+++ b/cli/cmds/root.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
@@ -20,6 +21,11 @@ import (
 
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/buildinfo"
+)
+
+const (
+	defaultRequestTimeout    = 30 * time.Second       // normal commands
+	completionRequestTimeout = 100 * time.Millisecond // shell completion, must be fast
 )
 
 type AppContext struct {
@@ -49,7 +55,7 @@ func NewRootCmd() *cobra.Command {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
 
-			restConfig, err := loadRESTConfig(appCtx.Kubeconfig)
+			restConfig, err := loadRESTConfig(appCtx.Kubeconfig, defaultRequestTimeout)
 			if err != nil {
 				return err
 			}
@@ -116,7 +122,7 @@ func InitializeConfig(cmd *cobra.Command) {
 	})
 }
 
-func loadRESTConfig(kubeconfig string) (*rest.Config, error) {
+func loadRESTConfig(kubeconfig string, timeout time.Duration) (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 
@@ -126,7 +132,14 @@ func loadRESTConfig(kubeconfig string) (*rest.Config, error) {
 
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
-	return kubeConfig.ClientConfig()
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig.Timeout = timeout
+
+	return restConfig, nil
 }
 
 func buildClient(restConfig *rest.Config) (client.Client, error) {


### PR DESCRIPTION
This PR adds shell completion for the `--namespace` / `-n` flag across the `k3kcli`.

The `--namespace` / `-n` flag now suggests real namespaces from the cluster. Two completers are wired depending on what the command operates on:

- **`completeNamespaces`**: every namespace in the host cluster. Used where any namespace is a valid target: `cluster create` and `policy create`.
- **`completeClusterNamespaces`**: only the namespaces that already contain a K3k Virtual Cluster. Used where you act on an existing cluster: `cluster delete`, `cluster list`, `cluster update`, and `kubeconfig generate`.

`policy create --namespace` is repeatable (`StringSlice`), so its completion also excludes namespaces already selected on the command line, avoiding duplicate suggestions.

### Note

Cobra does not run `PersistentPreRunE` during completion, so the shared client isn't available. `completionClient` builds its own client, reading the `--kubeconfig` flag so completion targets the same cluster the command would.

[Screencast from 2026-07-21 13-56-16.webm](https://github.com/user-attachments/assets/9e1ae12f-b1b1-4977-b07d-7e35ae0d05d5)
