### PR TITLE
Fix cluster delete for missing clusters

### DIFF
--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -47,14 +48,22 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 
 		namespace := appCtx.Namespace(name)
 
-		logrus.Infof("Deleting '%s' cluster in namespace '%s'", name, namespace)
-
 		cluster := v1beta1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
 		}
+		if err := client.Get(ctx, ctrlclient.ObjectKeyFromObject(&cluster), &cluster); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("cluster %q not found in namespace %q; specify the correct namespace with --namespace", name, namespace)
+			}
+
+			return err
+		}
+
+		logrus.Infof("Deleting '%s' cluster in namespace '%s'", name, namespace)
+
 		// keep bootstrap secrets and tokens if --keep-data flag is passed
 		if keepData {
 			// skip removing tokenSecret

--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -56,7 +56,7 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 		}
 		if err := client.Get(ctx, ctrlclient.ObjectKeyFromObject(&cluster), &cluster); err != nil {
 			if apierrors.IsNotFound(err) {
-				return fmt.Errorf("cluster %q not found in namespace %q; specify the correct namespace with --namespace", name, namespace)
+				return fmt.Errorf("cluster %q not found in namespace %q", name, namespace)
 			}
 
 			return err

--- a/cli/cmds/cluster_delete_test.go
+++ b/cli/cmds/cluster_delete_test.go
@@ -1,0 +1,22 @@
+package cmds
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
+)
+
+func TestDeleteMissingCluster(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	appCtx := &AppContext{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	err := delete(appCtx)(&cobra.Command{}, []string{"missing"})
+
+	require.EqualError(t, err, `cluster "missing" not found in namespace "k3k-missing"; specify the correct namespace with --namespace`)
+}

--- a/cli/cmds/cluster_delete_test.go
+++ b/cli/cmds/cluster_delete_test.go
@@ -18,5 +18,5 @@ func TestDeleteMissingCluster(t *testing.T) {
 	appCtx := &AppContext{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
 	err := delete(appCtx)(&cobra.Command{}, []string{"missing"})
 
-	require.EqualError(t, err, `cluster "missing" not found in namespace "k3k-missing"; specify the correct namespace with --namespace`)
+	require.EqualError(t, err, `cluster "missing" not found in namespace "k3k-missing"`)
 }


### PR DESCRIPTION
## Summary

- verify the target cluster exists before logging deletion or removing related PVCs
- return an actionable error that names the attempted namespace and points to `--namespace`
- cover the missing-cluster behavior with a focused unit test

Fixes #536

## Testing

- `go test ./cli/cmds -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m ./cli/cmds`
