### PR TITLE
Skip expensive CI for Markdown-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
+    - 'docs/**'
     - '**/*.md'
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+    - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
+    - 'docs/**'
     - '**/*.md'
   workflow_dispatch:
 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+    - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
+    - 'docs/**'
     - '**/*.md'
   workflow_dispatch:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+    - '**/*.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Skip the Build, Tests, and Tests E2E workflows when a pull request changes only Markdown files. The Validate workflow remains active for documentation checks, while expensive compilation and test jobs no longer run for docs-only updates.

Fixes #674

## Testing

- `actionlint -shellcheck= .github/workflows/build.yml .github/workflows/test.yaml .github/workflows/test-e2e.yaml`
- `git diff --check`
