### PR TITLE
fix(kubelet): refresh shared node version

### DIFF
--- a/k3k-kubelet/provider/configure_capacity.go
+++ b/k3k-kubelet/provider/configure_capacity.go
@@ -73,6 +73,15 @@ func startNodeCapacityUpdater(ctx context.Context, logger logr.Logger, hostClien
 // updateNodeCapacity will update the virtual node capacity (and the allocatable field) with the sum of all the resource in the host nodes.
 // If the nodeLabels are specified only the matching nodes will be considered.
 func updateNodeCapacity(ctx context.Context, logger logr.Logger, hostClient client.Client, virtualClient client.Client, virtualCluster v1beta1.Cluster, virtualNodeName string) {
+	var currentCluster v1beta1.Cluster
+	if err := hostClient.Get(ctx, types.NamespacedName{
+		Name:      virtualCluster.Name,
+		Namespace: virtualCluster.Namespace,
+	}, &currentCluster); err != nil {
+		logger.Error(err, "error getting cluster for updating node status")
+		return
+	}
+
 	// by default we get the resources of the same Node where the kubelet is running
 	var node corev1.Node
 	if err := hostClient.Get(ctx, types.NamespacedName{Name: virtualNodeName}, &node); err != nil {
@@ -86,7 +95,7 @@ func updateNodeCapacity(ctx context.Context, logger logr.Logger, hostClient clie
 	// If so we will use the minimum resources
 
 	var quotas corev1.ResourceQuotaList
-	if err := hostClient.List(ctx, &quotas, &client.ListOptions{Namespace: virtualCluster.Namespace}); err != nil {
+	if err := hostClient.List(ctx, &quotas, &client.ListOptions{Namespace: currentCluster.Namespace}); err != nil {
 		logger.Error(err, "error getting namespace for updating node capacity")
 		return
 	}
@@ -140,6 +149,11 @@ func updateNodeCapacity(ctx context.Context, logger logr.Logger, hostClient clie
 
 	virtualNode.Status.Capacity = allocatable
 	virtualNode.Status.Allocatable = allocatable
+	if currentCluster.Spec.Version != "" {
+		virtualNode.Status.NodeInfo.KubeletVersion = currentCluster.Spec.Version
+	} else if currentCluster.Status.HostVersion != "" {
+		virtualNode.Status.NodeInfo.KubeletVersion = currentCluster.Status.HostVersion
+	}
 
 	if err := virtualClient.Status().Update(ctx, &virtualNode); err != nil {
 		logger.Error(err, "error updating node capacity")

--- a/k3k-kubelet/provider/configure_capacity_test.go
+++ b/k3k-kubelet/provider/configure_capacity_test.go
@@ -1,14 +1,117 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
+
+func TestUpdateNodeCapacity(t *testing.T) {
+	tests := []struct {
+		name            string
+		specVersion     string
+		hostVersion     string
+		currentVersion  string
+		expectedVersion string
+	}{
+		{
+			name:            "uses configured cluster version",
+			specVersion:     "v1.32.1+k3s1",
+			hostVersion:     "v1.31.5+k3s1",
+			currentVersion:  "v1.30.0+k3s1",
+			expectedVersion: "v1.32.1+k3s1",
+		},
+		{
+			name:            "falls back to host version",
+			hostVersion:     "v1.31.5+k3s1",
+			currentVersion:  "v1.30.0+k3s1",
+			expectedVersion: "v1.31.5+k3s1",
+		},
+		{
+			name:            "preserves current version when cluster versions are empty",
+			currentVersion:  "v1.30.0+k3s1",
+			expectedVersion: "v1.30.0+k3s1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, v1beta1.AddToScheme(scheme))
+
+			const (
+				clusterName      = "test-cluster"
+				clusterNamespace = "test-namespace"
+				nodeName         = "test-node"
+			)
+
+			hostAllocatable := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}
+			cluster := &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterNamespace,
+				},
+				Spec: v1beta1.ClusterSpec{
+					Version: tt.specVersion,
+				},
+				Status: v1beta1.ClusterStatus{
+					HostVersion: tt.hostVersion,
+				},
+			}
+			staleCluster := cluster.DeepCopy()
+			staleCluster.Spec.Version = "v1.29.0+k3s1"
+			staleCluster.Status.HostVersion = "v1.29.0+k3s1"
+			hostNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Status: corev1.NodeStatus{
+					Allocatable: hostAllocatable,
+				},
+			}
+			virtualNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KubeletVersion: tt.currentVersion,
+					},
+				},
+			}
+
+			hostClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(cluster, hostNode).
+				Build()
+			virtualClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&corev1.Node{}).
+				WithObjects(virtualNode).
+				Build()
+
+			updateNodeCapacity(context.Background(), logr.Discard(), hostClient, virtualClient, *staleCluster, nodeName)
+
+			var updatedNode corev1.Node
+			require.NoError(t, virtualClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, &updatedNode))
+			assert.Equal(t, tt.expectedVersion, updatedNode.Status.NodeInfo.KubeletVersion)
+			assert.Equal(t, hostAllocatable, updatedNode.Status.Capacity)
+			assert.Equal(t, hostAllocatable, updatedNode.Status.Allocatable)
+		})
+	}
+}
 
 func Test_distributeQuotas(t *testing.T) {
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
## Summary

- reload the current `Cluster` during periodic shared-node status updates
- refresh the virtual node kubelet version from `spec.version`, falling back to `status.hostVersion`
- preserve the existing virtual-node version when both cluster version fields are empty
- keep the existing capacity and allocatable refresh behavior

Closes #666

## Verification

- `gofmt -d k3k-kubelet/provider/configure_capacity.go k3k-kubelet/provider/configure_capacity_test.go`
- `go test ./k3k-kubelet/provider`
- `go vet ./k3k-kubelet/provider`
- `go test ./k3k-kubelet/...`
- `git diff --check`

No e2e or cluster-dependent suites were run; the change is covered by focused controller-runtime fake-client tests.
