### PR TITLE
fix: reject negative storageRequestSize in CLI and controller validation

### DIFF
--- a/cli/cmds/cluster_create_flags.go
+++ b/cli/cmds/cluster_create_flags.go
@@ -67,8 +67,12 @@ func validateCreateConfig(cfg *CreateConfig) error {
 	}
 
 	if cfg.storageRequestSize != "" {
-		if _, err := resource.ParseQuantity(cfg.storageRequestSize); err != nil {
+		qty, err := resource.ParseQuantity(cfg.storageRequestSize)
+		if err != nil {
 			return errors.New(`invalid storage size, should be a valid resource quantity e.g "10Gi"`)
+		}
+		if qty.Sign() <= 0 {
+			return errors.New(`invalid storage size: must be greater than zero`)
 		}
 	}
 

--- a/cli/cmds/cluster_create_flags_test.go
+++ b/cli/cmds/cluster_create_flags_test.go
@@ -67,6 +67,22 @@ func Test_validateCreateConfig(t *testing.T) {
 			wantErr: `invalid storage size, should be a valid resource quantity e.g "10Gi"`,
 		},
 		{
+			name: "negative storage size",
+			cfg: CreateConfig{
+				servers:            1,
+				storageRequestSize: "-1G",
+			},
+			wantErr: `invalid storage size: must be greater than zero`,
+		},
+		{
+			name: "zero storage size",
+			cfg: CreateConfig{
+				servers:            1,
+				storageRequestSize: "0",
+			},
+			wantErr: `invalid storage size: must be greater than zero`,
+		},
+		{
 			name: "empty mode",
 			cfg: CreateConfig{
 				servers:            1,

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -990,6 +990,8 @@ func (c *ClusterReconciler) validate(cluster *v1beta1.Cluster, policy v1beta1.Vi
 		if err := c.validateCustomCACerts(cluster.Spec.CustomCAs.Sources); err != nil {
 			return fmt.Errorf("%w: %w", ErrClusterValidation, err)
 		}
+	if cluster.Spec.Persistence.StorageRequestSize != nil && cluster.Spec.Persistence.StorageRequestSize.Sign() <= 0 {
+		return fmt.Errorf("%w: storageRequestSize must be greater than zero", ErrClusterValidation)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Currently, `k3kcli` and the Cluster CR allow creating clusters with negative storage sizes (e.g. `--storage-request-size -1G`). Cluster creation is attempted, but it fails downstream when Kubernetes rejects negative PVC storage sizes in StatefulSet specs.

This PR adds upfront validation logic to reject negative or zero `storageRequestSize` values in both:
1. `validateCreateConfig` in `k3kcli` CLI flag validation.
2. `ClusterReconciler.validate` in the cluster controller reconciler.

Unit tests have also been added in `cluster_create_flags_test.go` to cover negative and zero storage size inputs.

Fixes #729