### PR TITLE
fix: ensure k3k.io/clusterName label is consistently applied across resources

### DIFF
--- a/pkg/controller/cluster/agent/shared.go
+++ b/pkg/controller/cluster/agent/shared.go
@@ -128,9 +128,10 @@ func sharedAgentData(cluster *v1beta1.Cluster, serviceName, token, ip string, ku
 
 func (s *SharedAgent) daemonset(ctx context.Context) error {
 	labels := map[string]string{
-		"cluster": s.cluster.Name,
-		"type":    "agent",
-		"mode":    "shared",
+		"cluster":                  s.cluster.Name,
+		translate.ClusterNameLabel: s.cluster.Name,
+		"type":                     "agent",
+		"mode":                     "shared",
 	}
 
 	deploy := &appsv1.DaemonSet{

--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/rancher/k3k/k3k-kubelet/translate"
 	"github.com/rancher/k3k/pkg/controller"
 	"github.com/rancher/k3k/pkg/controller/cluster/mounts"
 )
@@ -110,9 +111,10 @@ func (v *VirtualAgent) deployment(ctx context.Context) error {
 
 	selector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"cluster": v.cluster.Name,
-			"type":    "agent",
-			"mode":    "virtual",
+			"cluster":                  v.cluster.Name,
+			translate.ClusterNameLabel: v.cluster.Name,
+			"type":                     "agent",
+			"mode":                     "virtual",
 		},
 	}
 	podSpec := v.podSpec(ctx, image, name)

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/rancher/k3k/k3k-kubelet/translate"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
 	"github.com/rancher/k3k/pkg/controller/cluster/mounts"
@@ -373,8 +374,9 @@ func (s *Server) StatefulServer(ctx context.Context) (*appsv1.StatefulSet, error
 
 	selector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"cluster": s.cluster.Name,
-			"role":    "server",
+			"cluster":                  s.cluster.Name,
+			translate.ClusterNameLabel: s.cluster.Name,
+			"role":                     "server",
 		},
 	}
 

--- a/pkg/controller/cluster/server/service.go
+++ b/pkg/controller/cluster/server/service.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/rancher/k3k/k3k-kubelet/translate"
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	"github.com/rancher/k3k/pkg/controller"
 )
@@ -28,8 +29,9 @@ func Service(cluster *v1beta1.Cluster) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"cluster": cluster.Name,
-				"role":    "server",
+				"cluster":                  cluster.Name,
+				translate.ClusterNameLabel: cluster.Name,
+				"role":                     "server",
 			},
 		},
 	}
@@ -147,8 +149,9 @@ func (s *Server) StatefulServerService() *corev1.Service {
 			Type:      corev1.ServiceTypeClusterIP,
 			ClusterIP: corev1.ClusterIPNone,
 			Selector: map[string]string{
-				"cluster": s.cluster.Name,
-				"role":    "server",
+				"cluster":                  s.cluster.Name,
+				translate.ClusterNameLabel: s.cluster.Name,
+				"role":                     "server",
 			},
 			Ports: []corev1.ServicePort{
 				{


### PR DESCRIPTION
## Description
Previously, k3k-created resources had inconsistent label keys (e.g. server pods and services used plain `cluster=name`, while translated workloads used `k3k.io/clusterName=name`).

This PR adds `translate.ClusterNameLabel` (`k3k.io/clusterName`) across:
- Server StatefulSets
- Server Services (ClusterIP & Headless)
- Agent DaemonSets (shared mode)
- Agent Deployments (virtual mode)

This ensures all k3k infrastructure and translated resources carry the consistent `k3k.io/clusterName` label key while preserving backwards-compatible selector keys.

Fixes #165