### PR TITLE
fix: sync virtual node KubeletVersion when cluster version is updated in shared mode

### DIFF
--- a/k3k-kubelet/provider/configure_capacity.go
+++ b/k3k-kubelet/provider/configure_capacity.go
@@ -141,6 +141,13 @@ func updateNodeCapacity(ctx context.Context, logger logr.Logger, hostClient clie
 	virtualNode.Status.Capacity = allocatable
 	virtualNode.Status.Allocatable = allocatable
 
+	var currentCluster v1beta1.Cluster
+	if err := hostClient.Get(ctx, types.NamespacedName{Name: virtualCluster.Name, Namespace: virtualCluster.Namespace}, &currentCluster); err == nil {
+		if currentCluster.Spec.Version != "" && virtualNode.Status.NodeInfo.KubeletVersion != currentCluster.Spec.Version {
+			virtualNode.Status.NodeInfo.KubeletVersion = currentCluster.Spec.Version
+		}
+	}
+
 	if err := virtualClient.Status().Update(ctx, &virtualNode); err != nil {
 		logger.Error(err, "error updating node capacity")
 	}


### PR DESCRIPTION
## Description
In shared mode, when a virtual cluster version was updated via `k3kcli cluster update --version ...` or `kubectl patch`, `kubectl version` showed the updated server version, but `kubectl get nodes` retained the original version because `k3k-kubelet` set `node.Status.NodeInfo.KubeletVersion` only once during initial startup.

This PR updates the periodic node status update loop in `k3k-kubelet` (`updateNodeCapacity`) to re-fetch the latest `Cluster` resource spec from the host cluster and dynamically synchronize `node.Status.NodeInfo.KubeletVersion` whenever the cluster version changes.

Fixes #666