### PR TITLE
feat(cli): enhance k3kcli kubeconfig management and shell autocompletions

### DIFF
--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -26,8 +26,9 @@ func NewClusterDeleteCmd(appCtx *AppContext) *cobra.Command {
 		Use:     "delete",
 		Short:   "Delete an existing cluster.",
 		Example: "k3kcli cluster delete [command options] NAME",
-		RunE:    delete(appCtx),
-		Args:    cobra.ExactArgs(1),
+		RunE:              delete(appCtx),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeClusterNames,
 	}
 
 	cmd.Flags().BoolVar(&keepData, "keep-data", false, "keeps persistence volumes created for the cluster after deletion")

--- a/cli/cmds/completion.go
+++ b/cli/cmds/completion.go
@@ -152,3 +152,48 @@ func completionClient(cmd *cobra.Command) (client.Client, error) {
 
 	return client, nil
 }
+
+// completeClusterNames is a cobra.CompletionFunc that completes with the names of clusters in the selected namespace.
+func completeClusterNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cl, err := completionClient(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	namespace := "default"
+	if ns, err := cmd.Flags().GetString("namespace"); err == nil && ns != "" {
+		namespace = ns
+	}
+
+	var clusters v1beta1.ClusterList
+	if err := cl.List(cmd.Context(), &clusters, client.InNamespace(namespace)); err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	names := make([]string, 0, len(clusters.Items))
+	for _, c := range clusters.Items {
+		names = append(names, c.Name)
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completePolicyNames is a cobra.CompletionFunc that completes with the names of VirtualClusterPolicies.
+func completePolicyNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cl, err := completionClient(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var policies v1beta1.VirtualClusterPolicyList
+	if err := cl.List(cmd.Context(), &policies); err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	names := make([]string, 0, len(policies.Items))
+	for _, p := range policies.Items {
+		names = append(names, p.Name)
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cli/cmds/kubeconfig.go
+++ b/cli/cmds/kubeconfig.go
@@ -26,6 +26,7 @@ import (
 type GenerateKubeconfigConfig struct {
 	name                 string
 	configName           string
+	out                  string
 	cn                   string
 	org                  []string
 	altNames             []string
@@ -50,15 +51,17 @@ func NewKubeconfigGenerateCmd(appCtx *AppContext) *cobra.Command {
 	cfg := &GenerateKubeconfigConfig{}
 
 	cmd := &cobra.Command{
-		Use:   "generate",
-		Short: "Generate kubeconfig for clusters.",
-		RunE:  generate(appCtx, cfg),
-		Args:  cobra.NoArgs,
+		Use:               "generate [NAME]",
+		Short:             "Generate kubeconfig for clusters.",
+		RunE:              generate(appCtx, cfg),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeClusterNames,
 	}
 
 	CobraFlagNamespace(appCtx, cmd, completeClusterNamespaces)
 
 	generateKubeconfigFlags(cmd, cfg)
+	mustRegisterFlagCompletion(cmd, "name", completeClusterNames)
 
 	return cmd
 }
@@ -66,6 +69,7 @@ func NewKubeconfigGenerateCmd(appCtx *AppContext) *cobra.Command {
 func generateKubeconfigFlags(cmd *cobra.Command, cfg *GenerateKubeconfigConfig) {
 	cmd.Flags().StringVar(&cfg.name, "name", "", "cluster name")
 	cmd.Flags().StringVar(&cfg.configName, "config-name", "", "the name of the generated kubeconfig file")
+	cmd.Flags().StringVar(&cfg.out, "out", "", "the path where to save the generated kubeconfig file")
 	cmd.Flags().StringVar(&cfg.cn, "cn", controller.AdminCommonName, "Common name (CN) of the generated certificates for the kubeconfig")
 	cmd.Flags().StringSliceVar(&cfg.org, "org", nil, "Organization name (ORG) of the generated certificates for the kubeconfig")
 	cmd.Flags().StringSliceVar(&cfg.altNames, "altNames", nil, "altNames of the generated certificates for the kubeconfig")
@@ -77,6 +81,14 @@ func generate(appCtx *AppContext, cfg *GenerateKubeconfigConfig) func(cmd *cobra
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client := appCtx.Client
+
+		if len(args) > 0 && cfg.name == "" {
+			cfg.name = args[0]
+		}
+
+		if cfg.name == "" {
+			return errors.New("cluster name is required")
+		}
 
 		clusterKey := types.NamespacedName{
 			Name:      cfg.name,
@@ -122,7 +134,7 @@ func generate(appCtx *AppContext, cfg *GenerateKubeconfigConfig) func(cmd *cobra
 			return err
 		}
 
-		if err := writeKubeconfigFile(&cluster, kubeconfig, cfg.configName); err != nil {
+		if err := writeKubeconfigFile(&cluster, kubeconfig, cfg.configName, cfg.out); err != nil {
 			return err
 		}
 
@@ -150,13 +162,25 @@ func resolveServerHost(restConfigHost, override string) (string, error) {
 	return u.Hostname(), nil
 }
 
-func writeKubeconfigFile(cluster *v1beta1.Cluster, kubeconfig *clientcmdapi.Config, configName string) error {
-	if configName == "" {
-		configName = cluster.Namespace + "-" + cluster.Name + "-kubeconfig.yaml"
+func writeKubeconfigFile(cluster *v1beta1.Cluster, kubeconfig *clientcmdapi.Config, configName, outPath string) error {
+	var targetPath string
+	if outPath != "" {
+		targetPath = outPath
+	} else if configName != "" {
+		targetPath = configName
+	} else {
+		configDir := os.Getenv("XDG_CONFIG_HOME")
+		if configDir == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+			configDir = filepath.Join(homeDir, ".config")
+		}
+		targetPath = filepath.Join(configDir, "k3k", cluster.Namespace, cluster.Name+".yaml")
 	}
 
-	pwd, err := os.Getwd()
-	if err != nil {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 		return err
 	}
 
@@ -164,12 +188,12 @@ func writeKubeconfigFile(cluster *v1beta1.Cluster, kubeconfig *clientcmdapi.Conf
 
 	export KUBECONFIG=%s
 	kubectl cluster-info
-	`, filepath.Join(pwd, configName))
+	`, targetPath)
 
 	kubeconfigData, err := clientcmd.Write(*kubeconfig)
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile(configName, kubeconfigData, 0o644)
+	return os.WriteFile(targetPath, kubeconfigData, 0o644)
 }

--- a/cli/cmds/policy_delete.go
+++ b/cli/cmds/policy_delete.go
@@ -16,8 +16,9 @@ func NewPolicyDeleteCmd(appCtx *AppContext) *cobra.Command {
 		Use:     "delete",
 		Short:   "Delete an existing policy.",
 		Example: "k3kcli policy delete [command options] NAME",
-		RunE:    policyDeleteAction(appCtx),
-		Args:    cobra.ExactArgs(1),
+		RunE:              policyDeleteAction(appCtx),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completePolicyNames,
 	}
 }
 


### PR DESCRIPTION
## Description
This PR implements key enhancements for `k3kcli` as outlined in Epic #471:

### 1. Kubeconfig Management
- Saved kubeconfig files now default to `$XDG_CONFIG_HOME/k3k/<namespace>/<cluster>.yaml` (falling back to `$HOME/.config/k3k/<namespace>/<cluster>.yaml`) rather than dumping files into the working directory.
- Added a `--out` flag to `k3kcli kubeconfig generate` allowing users to specify custom output file paths.

### 2. Shell Autocompletions
- Added argument autocompletions for:
  - `k3kcli cluster delete [NAME]` (completing virtual cluster names in selected namespace)
  - `k3kcli kubeconfig generate [NAME]` (completing virtual cluster names)
  - `k3kcli policy delete [NAME]` (completing `VirtualClusterPolicy` names)
- Registered flag autocompletions for `--name` and `--out` flags.

Fixes #471