### PR TITLE
Keep PersistentVolumeClaim to "varlibrancherk3s"

### DIFF
--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -193,7 +193,7 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 						ReadOnly:  false,
 					},
 					{
-						Name:      "var-lib-rancher-k3s",
+						Name:      "varlibrancherk3s",
 						MountPath: k3sDataDir,
 						ReadOnly:  false,
 					},
@@ -423,7 +423,7 @@ func (s *Server) setupDynamicPersistence() corev1.PersistentVolumeClaim {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "var-lib-rancher-k3s",
+			Name:      "varlibrancherk3s",
 			Namespace: s.cluster.Namespace,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -216,7 +216,7 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 	podSpec.Containers[0].Command = cmd
 	if !persistent {
 		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-			Name: "var-lib-rancher-k3s",
+			Name: "varlibrancherk3s",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},


### PR DESCRIPTION
This PR reverts the name of the PV to `varlibrancherk3s`. Existing clusters will fail to reconcile because the StatefulSet was trying to change this immutable field (see https://github.com/rancher/k3k/issues/1078).