### PR TITLE
Strip service account name from host pod unconditionally

### DIFF
--- a/k3k-kubelet/provider/token.go
+++ b/k3k-kubelet/provider/token.go
@@ -29,6 +29,14 @@ func (p *Provider) transformTokens(ctx context.Context, virtualPod, hostPod *cor
 	logger := p.logger.WithValues("namespace", virtualPod.Namespace, "name", virtualPod.Name, "serviceAccountName", virtualPod.Spec.ServiceAccountName)
 	logger.V(1).Info("Transforming service account tokens")
 
+	// The virtual pod's service account does not exist on the host cluster, so the
+	// pod must never reference it there — even when it has no kube-api-access volume
+	// (e.g. automountServiceAccountToken: false), otherwise host admission rejects
+	// the pod with "serviceaccount not found".
+	hostPod.Spec.ServiceAccountName = ""
+	hostPod.Spec.DeprecatedServiceAccount = ""
+	hostPod.Spec.AutomountServiceAccountToken = ptr.To(false)
+
 	// transform projected service account token
 	if err := p.transformProjectedTokens(ctx, virtualPod, hostPod); err != nil {
 		return err
@@ -76,10 +84,6 @@ func (p *Provider) transformKubeAccessToken(ctx context.Context, virtualPod, hos
 	if err != nil {
 		return err
 	}
-
-	hostPod.Spec.ServiceAccountName = ""
-	hostPod.Spec.DeprecatedServiceAccount = ""
-	hostPod.Spec.AutomountServiceAccountToken = ptr.To(false)
 
 	removeKubeAccessVolume(hostPod)
 	addKubeAccessVolume(hostPod, hostSecret.Name)


### PR DESCRIPTION
## Problem

In shared mode, a virtual pod whose service account sets `automountServiceAccountToken: false` (no `kube-api-access` volume) is never schedulable on the host cluster. `transformKubeAccessToken` returns early when the pod has no `kube-api-access` volume, so `spec.serviceAccountName` is never stripped from the translated host pod. The referenced service account only exists inside the virtual cluster, so host admission rejects the pod permanently:

```
pods "..." is forbidden: error looking up service account <ns>/<sa>: serviceaccount "<sa>" not found
```

The pod stays in `ProviderFailed` forever, with the kubelet retrying uselessly. Hit in practice with kgateway proxy deployments (their gateway service account uses `automountServiceAccountToken: false`); any workload with automount disabled reproduces it.

## Reproduction

1. k3k shared-mode cluster (observed on v1.1.0; the affected code is unchanged on main)
2. In the virtual cluster:
   ```yaml
   apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: noauto
   automountServiceAccountToken: false
   ---
   apiVersion: v1
   kind: Pod
   metadata:
     name: repro
   spec:
     serviceAccountName: noauto
     containers:
       - name: pause
         image: registry.k8s.io/pause:3.9
   ```
3. Pod never starts; host events show the admission rejection above.

## Fix

Move the service-account stripping (`ServiceAccountName`, `DeprecatedServiceAccount`, `AutomountServiceAccountToken=false`) from `transformKubeAccessToken` into `transformTokens` so it applies to every synced pod, regardless of whether a token volume needs translation. The host apiserver then defaults the SA to `default` with automount disabled — no token is mounted, matching the virtual pod's intent.

## Testing

- `go test ./k3k-kubelet/provider/` passes
- Verified live on a dual-stack RKE2 host cluster (k3k v1.1.0 + this patch): kgateway proxy pod went from permanent `ProviderCreateFailed` to Running in ~20s; translated host pod has `serviceAccountName: default`, `automountServiceAccountToken: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)