### PR TITLE
Sync LoadBalancer status to virtual service, preserve host IP families

### DIFF
--- a/k3k-kubelet/controller/syncer/service.go
+++ b/k3k-kubelet/controller/syncer/service.go
@@ -2,7 +2,9 @@ package syncer
 
 import (
 	"context"
+	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -109,7 +111,11 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	if err := r.HostClient.Get(ctx, types.NamespacedName{Name: syncedService.Name, Namespace: r.ClusterNamespace}, &hostService); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("creating the service for the first time on the host cluster")
-			return reconcile.Result{}, r.HostClient.Create(ctx, syncedService)
+			if err := r.HostClient.Create(ctx, syncedService); err != nil {
+				return reconcile.Result{}, err
+			}
+			// requeue to pick up host-assigned status (e.g. LoadBalancer ingress)
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
 		return reconcile.Result{}, err
@@ -117,7 +123,46 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	log.Info("updating service on the host cluster")
 
-	return reconcile.Result{}, r.HostClient.Update(ctx, syncedService)
+	// The host apiserver owns IP-family allocation: the host service may have been
+	// expanded to dual-stack while the virtual service is single-stack. Re-submitting
+	// the virtual family fields is rejected ("must be 'SingleStack' to release the
+	// secondary cluster IP"), so preserve the host-allocated values on update.
+	syncedService.Spec.ClusterIP = hostService.Spec.ClusterIP
+	syncedService.Spec.ClusterIPs = hostService.Spec.ClusterIPs
+	syncedService.Spec.IPFamilies = hostService.Spec.IPFamilies
+	syncedService.Spec.IPFamilyPolicy = hostService.Spec.IPFamilyPolicy
+	syncedService.Spec.HealthCheckNodePort = hostService.Spec.HealthCheckNodePort
+
+	if err := r.HostClient.Update(ctx, syncedService); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return r.syncStatus(ctx, &virtService, &hostService)
+}
+
+// syncStatus copies the host service's LoadBalancer status back to the virtual
+// service so in-cluster consumers (e.g. external-dns) see the assigned ingress.
+// The controller only watches virtual services, so as long as the ingress is
+// empty it requeues to poll the host side.
+func (r *ServiceReconciler) syncStatus(ctx context.Context, virtService, hostService *corev1.Service) (reconcile.Result, error) {
+	if virtService.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return reconcile.Result{}, nil
+	}
+
+	if !equality.Semantic.DeepEqual(virtService.Status.LoadBalancer, hostService.Status.LoadBalancer) {
+		orig := virtService.DeepCopy()
+		virtService.Status.LoadBalancer = hostService.Status.LoadBalancer
+
+		if err := r.VirtualClient.Status().Patch(ctx, virtService, ctrlruntimeclient.MergeFrom(orig)); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	if len(hostService.Status.LoadBalancer.Ingress) == 0 {
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	return reconcile.Result{}, nil
 }
 
 func (r *ServiceReconciler) filterResources(object ctrlruntimeclient.Object) bool {


### PR DESCRIPTION
## Problems

Two related defects in the service syncer (`k3k-kubelet/controller/syncer/service.go`):

**1. LoadBalancer status is never synced back to the virtual cluster.** The syncer creates/updates the host service but never copies `status.loadBalancer` back, so a `LoadBalancer` service inside the virtual cluster shows `<pending>` EXTERNAL-IP forever even after the host assigned VIPs. Anything consuming service status inside the virtual cluster (external-dns, operators watching their own services) is blocked permanently.

**2. Reconciliation loops on dual-stack host clusters.** The syncer re-submits the virtual service's `ipFamilies`/`ipFamilyPolicy` on every host update. When the host cluster expanded the service to dual-stack (virtual service `PreferDualStack` + `[IPv4]` on a single-stack virtual cluster, host allocated `[IPv4, IPv6]`), every subsequent update is rejected by the host apiserver:

```
Service "..." is invalid: spec.ipFamilyPolicy: Invalid value: "PreferDualStack": must be 'SingleStack' to release the secondary cluster IP
```

and the reconciler errors in a tight loop (~every 10-20s per service).

## Fix

- On update, preserve the host-allocated fields the host apiserver owns: `clusterIP`/`clusterIPs`, `ipFamilies`, `ipFamilyPolicy`, `healthCheckNodePort`.
- After create/update, copy the host service's `status.loadBalancer` to the virtual service (skipped unless type `LoadBalancer`, patched only on change).
- The controller only watches virtual services — a host-side status change emits no virtual watch event — so while a `LoadBalancer` service has empty ingress the reconciler requeues (30s) to poll the host side (10s after initial create). A host-manager watch on synced services would be the event-driven alternative; happy to rework in that direction if preferred.

## Testing

- `go test ./k3k-kubelet/...` passes
- Verified live on a dual-stack RKE2 host cluster (k3k v1.1.0 + this patch): virtual `LoadBalancer` service went from `<pending>` to showing the host-assigned IPv4+IPv6 VIPs within seconds, the ipFamilyPolicy error loop stopped, and in-cluster external-dns proceeded normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)