### PR TITLE
Preserve translator identity metadata on host pod updates

### DIFF
--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -617,6 +617,23 @@ func (p *Provider) updatePod(ctx context.Context, pod *corev1.Pod) error {
 
 	updatePod(&hostPod, pod)
 
+	// updatePod copies the virtual pod's labels/annotations verbatim; re-assert
+	// the translator-owned identity metadata the virtual pod does not carry,
+	// otherwise every update strips it from the host pod (breaking label-selector
+	// services like k3k-<cluster>-kube-dns and any policy selecting on it).
+	if hostPod.Labels == nil {
+		hostPod.Labels = map[string]string{}
+	}
+
+	hostPod.Labels[translate.ClusterNameLabel] = p.ClusterName
+
+	if hostPod.Annotations == nil {
+		hostPod.Annotations = map[string]string{}
+	}
+
+	hostPod.Annotations[translate.ResourceNameAnnotation] = pod.Name
+	hostPod.Annotations[translate.ResourceNamespaceAnnotation] = pod.Namespace
+
 	if err := p.Host.Client.Update(ctx, &hostPod); err != nil {
 		logger.Error(err, "Unable to update Pod in host cluster")
 		return err


### PR DESCRIPTION
## Problem

`updatePod` copies the virtual pod's labels and annotations verbatim onto the host pod. The virtual pod never carries the translator-added `k3k.io/clusterName` label or the `k3k.io/name` / `k3k.io/namespace` annotations, so any pod update (image bump, label/annotation change, kubelet restart re-sync) strips them from the host pod.

Observed impact on a live shared-mode cluster (v1.1.0; the affected code is unchanged on main): after a k3k-kubelet restart, every synced workload pod lost `k3k.io/clusterName`. The synced `k3k-<cluster>-kube-dns` service (selector includes that label) lost all endpoints — DNS inside the virtual cluster went completely dark, taking external-dns and everything else DNS-dependent with it. Any NetworkPolicy selecting on the label silently stops matching affected pods, too.

## Reproduction

1. Shared-mode virtual cluster with running workloads
2. Restart the k3k-kubelet pods (or update any virtual pod's labels/annotations)
3. Host-side synced pods lose `k3k.io/clusterName` + `k3k.io/name`/`k3k.io/namespace`; `kubectl -n <cluster-ns> get endpointslices` shows the kube-dns slice empty; DNS inside the virtual cluster fails

## Fix

After the label/annotation copy in the host-pod update path, re-assert the translator-owned identity keys. Virtual label changes still propagate; host-side identity survives.

## Testing

- `go test ./k3k-kubelet/provider/` passes
- Verified live: with the patch, pod updates keep `k3k.io/clusterName`; kube-dns endpoints stay populated across kubelet restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)