### PR TITLE
Exit if virtual or host manager fail for k3k kubelet

### DIFF
--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -193,7 +193,9 @@ func clusterIP(ctx context.Context, serviceName, clusterNamespace string, hostCl
 	return service.Spec.ClusterIP, nil
 }
 
-func (k *kubelet) start(ctx context.Context) {
+func (k *kubelet) start(ctx context.Context) error {
+	errChan := make(chan error, 2)
+
 	// any one of the following 3 tasks (host manager, virtual manager, node) crashing will stop the
 	// program, and all 3 of them block on start, so we start them here in go-routines
 	go func() {
@@ -201,6 +203,7 @@ func (k *kubelet) start(ctx context.Context) {
 		if err != nil {
 			k.logger.Error(err, "host manager stopped")
 		}
+		errChan <- err
 	}()
 
 	go func() {
@@ -208,10 +211,10 @@ func (k *kubelet) start(ctx context.Context) {
 		if err != nil {
 			k.logger.Error(err, "virtual manager stopped")
 		}
+		errChan <- err
 	}()
 
 	// run the node async so that we can wait for it to be ready in another call
-
 	go func() {
 		klog.SetLogger(k.logger.V(1))
 
@@ -223,16 +226,24 @@ func (k *kubelet) start(ctx context.Context) {
 
 	if err := k.node.WaitReady(context.Background(), time.Minute*1); err != nil {
 		k.logger.Error(err, "node was not ready within timeout of 1 minute")
+		return err
 	}
 
-	<-k.node.Done()
+	select {
+	case <-k.node.Done():
+		if err := k.node.Err(); err != nil {
+			k.logger.Error(err, "node stopped with an error")
+			return err
+		}
+		defer k.eb.Shutdown()
 
-	if err := k.node.Err(); err != nil {
-		k.logger.Error(err, "node stopped with an error")
+		k.logger.Info("node exited successfully")
+		return nil
+	case err := <-errChan:
+		k.logger.Error(err, "manager stopped, exiting")
+		return err
 	}
-	defer k.eb.Shutdown()
 
-	k.logger.Info("node exited successfully")
 }
 
 func (k *kubelet) newProviderFunc(cfg config) nodeutil.NewProviderFunc {

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -203,6 +203,7 @@ func (k *kubelet) start(ctx context.Context) error {
 		if err != nil {
 			k.logger.Error(err, "host manager stopped")
 		}
+
 		errChan <- err
 	}()
 
@@ -211,6 +212,7 @@ func (k *kubelet) start(ctx context.Context) error {
 		if err != nil {
 			k.logger.Error(err, "virtual manager stopped")
 		}
+
 		errChan <- err
 	}()
 
@@ -238,12 +240,12 @@ func (k *kubelet) start(ctx context.Context) error {
 		defer k.eb.Shutdown()
 
 		k.logger.Info("node exited successfully")
+
 		return nil
 	case err := <-errChan:
 		k.logger.Error(err, "manager stopped, exiting")
 		return err
 	}
-
 }
 
 func (k *kubelet) newProviderFunc(cfg config) nodeutil.NewProviderFunc {

--- a/k3k-kubelet/main.go
+++ b/k3k-kubelet/main.go
@@ -81,9 +81,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to register new node: %w", err)
 	}
 
-	k.start(ctx)
-
-	return nil
+	return k.start(ctx)
 }
 
 // InitializeConfig sets up viper to read from config file, environment variables, and flags.


### PR DESCRIPTION
In cases of upgrade, the k3k-kubelet start with the new image before the server fully exits, which leads to k3k-kubelet's VirtualManager connecting to the old server and then when the new server comes up it fails with `leaderElection lost` but due to a bug, the virtualManager just logs the error and the goroutine exits but does not exit the k3k-kubelet which leads to failed Get() calls.

The fix just makes sure that errors caused by the goroutines will cause exiting the virtual-kubelet so that it can restart with the correct connection to the host/virtual clusters.

- #1110 