### PR TITLE
Fail cluster delete when the cluster name is ambiguous

### DIFF
--- a/cli/cmds/cluster_delete.go
+++ b/cli/cmds/cluster_delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -81,7 +82,7 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 			return errors.New("expected exactly one cluster name")
 		}
 
-		namespace, name, err := resolveClusterArg(appCtx, args[0])
+		namespace, name, err := resolveClusterArg(ctx, appCtx, args[0])
 		if err != nil {
 			return err
 		}
@@ -109,9 +110,9 @@ func delete(appCtx *AppContext) func(cmd *cobra.Command, args []string) error {
 }
 
 // resolveClusterArg splits an arg that may be in "namespace/name" form.
-// A bare "name" falls back to the k3k-<name> convention (respecting the -n flag) via appCtx.Namespace.
 // When both the -n flag and an explicit namespace prefix are given and they disagree an error is returned.
-func resolveClusterArg(appCtx *AppContext, arg string) (namespace, name string, err error) {
+// A bare "name" is looked up across the namespaces the user can see, see resolveClusterNamespace.
+func resolveClusterArg(ctx context.Context, appCtx *AppContext, arg string) (namespace, name string, err error) {
 	if ns, clusterName, ok := strings.Cut(arg, "/"); ok {
 		if appCtx.namespace != "" && appCtx.namespace != ns {
 			return "", "", fmt.Errorf("namespace mismatch: flag --namespace %q conflicts with argument namespace %q", appCtx.namespace, ns)
@@ -120,7 +121,49 @@ func resolveClusterArg(appCtx *AppContext, arg string) (namespace, name string, 
 		return ns, clusterName, nil
 	}
 
-	return appCtx.Namespace(arg), arg, nil
+	if appCtx.namespace != "" {
+		return appCtx.namespace, arg, nil
+	}
+
+	namespace, err = resolveClusterNamespace(ctx, appCtx.Client, arg)
+	if err != nil {
+		return "", "", err
+	}
+
+	return namespace, arg, nil
+}
+
+// resolveClusterNamespace finds the namespace of the cluster named name.
+// Clusters in different namespaces can share the same name, so deleting the one matching the
+// k3k-<name> convention could delete a cluster the user did not mean to: when the name is
+// ambiguous an error asking for --namespace is returned instead.
+// The k3k-<name> convention is kept as a fallback when the clusters cannot be listed, as the
+// user may only have access to their own namespace.
+func resolveClusterNamespace(ctx context.Context, client ctrlclient.Client, name string) (string, error) {
+	defaultNamespace := "k3k-" + name
+
+	var clusters v1beta1.ClusterList
+	if err := client.List(ctx, &clusters); err != nil {
+		return defaultNamespace, nil
+	}
+
+	var namespaces []string
+
+	for _, cluster := range clusters.Items {
+		if cluster.Name == name {
+			namespaces = append(namespaces, cluster.Namespace)
+		}
+	}
+
+	switch len(namespaces) {
+	case 0:
+		return defaultNamespace, nil
+	case 1:
+		return namespaces[0], nil
+	default:
+		sort.Strings(namespaces)
+		return "", fmt.Errorf("multiple clusters named %q found in namespaces %v, specify one with --namespace/-n", name, namespaces)
+	}
 }
 
 // deleteCluster removes a cluster and, unless --keep-data is set, its server PersistentVolumeClaims.

--- a/cli/cmds/cluster_delete_test.go
+++ b/cli/cmds/cluster_delete_test.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -9,17 +10,49 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
 
-func TestDeleteMissingCluster(t *testing.T) {
+func newFakeClient(t *testing.T, clusters ...*v1beta1.Cluster) ctrlclient.Client {
+	t.Helper()
+
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1beta1.AddToScheme(scheme))
 
-	appCtx := &AppContext{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, cluster := range clusters {
+		builder = builder.WithObjects(cluster)
+	}
+
+	return builder.Build()
+}
+
+func testCluster(namespace, name string) *v1beta1.Cluster {
+	return &v1beta1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func TestDeleteMissingCluster(t *testing.T) {
+	appCtx := &AppContext{Client: newFakeClient(t)}
 	err := delete(appCtx)(&cobra.Command{}, []string{"missing"})
 
 	require.EqualError(t, err, `cluster "missing" not found in namespace "k3k-missing"`)
+}
+
+func TestDeleteAmbiguousCluster(t *testing.T) {
+	appCtx := &AppContext{Client: newFakeClient(t, testCluster("default", "foo"), testCluster("k3k-foo", "foo"))}
+	err := delete(appCtx)(&cobra.Command{}, []string{"foo"})
+
+	require.EqualError(t, err, `multiple clusters named "foo" found in namespaces [default k3k-foo], specify one with --namespace/-n`)
+
+	// nothing should have been deleted
+	var clusters v1beta1.ClusterList
+	require.NoError(t, appCtx.Client.List(context.Background(), &clusters))
+	assert.Len(t, clusters.Items, 2)
 }
 
 func Test_resolveClusterArg(t *testing.T) {
@@ -27,6 +60,7 @@ func Test_resolveClusterArg(t *testing.T) {
 		name          string
 		flagNamespace string
 		arg           string
+		clusters      []*v1beta1.Cluster
 		wantNamespace string
 		wantName      string
 		wantErr       bool
@@ -63,13 +97,48 @@ func Test_resolveClusterArg(t *testing.T) {
 			arg:           "k3k-foo/mycluster",
 			wantErr:       true,
 		},
+		{
+			name:          "bare name resolves to the only namespace holding the cluster",
+			arg:           "mycluster",
+			clusters:      []*v1beta1.Cluster{testCluster("default", "mycluster")},
+			wantNamespace: "default",
+			wantName:      "mycluster",
+		},
+		{
+			name:     "bare name matching several namespaces errors",
+			arg:      "mycluster",
+			clusters: []*v1beta1.Cluster{testCluster("default", "mycluster"), testCluster("k3k-mycluster", "mycluster")},
+			wantErr:  true,
+		},
+		{
+			name:          "the namespace flag skips the ambiguity lookup",
+			flagNamespace: "default",
+			arg:           "mycluster",
+			clusters:      []*v1beta1.Cluster{testCluster("default", "mycluster"), testCluster("k3k-mycluster", "mycluster")},
+			wantNamespace: "default",
+			wantName:      "mycluster",
+		},
+		{
+			name:          "namespace/name form skips the ambiguity lookup",
+			arg:           "k3k-mycluster/mycluster",
+			clusters:      []*v1beta1.Cluster{testCluster("default", "mycluster"), testCluster("k3k-mycluster", "mycluster")},
+			wantNamespace: "k3k-mycluster",
+			wantName:      "mycluster",
+		},
+		{
+			name:          "clusters with a different name are ignored",
+			arg:           "mycluster",
+			clusters:      []*v1beta1.Cluster{testCluster("default", "othercluster")},
+			wantNamespace: "k3k-mycluster",
+			wantName:      "mycluster",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			appCtx := &AppContext{namespace: tt.flagNamespace}
+			appCtx := &AppContext{namespace: tt.flagNamespace, Client: newFakeClient(t, tt.clusters...)}
 
-			namespace, name, err := resolveClusterArg(appCtx, tt.arg)
+			namespace, name, err := resolveClusterArg(context.Background(), appCtx, tt.arg)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
## Problem

`k3kcli cluster delete NAME` resolves a bare name to the `k3k-<name>` namespace. When clusters with the same name exist in several namespaces, the command can act on one the user didn't mean to target.

Fixes #448.

## Solution

When no namespace is given (no `-n`, no `namespace/name` arg), look the name up across the namespaces the user can list:

- one match → use it
- several matches → error, asking for `--namespace/-n`
- no match → `k3k-<name>` as before

If the list call fails the `k3k-<name>` convention is kept as a fallback, so users with access to only their own namespace are unaffected.

Note this also changes the single-match case: `delete foo` now finds `default/foo` instead of erroring on `k3k-foo`. Happy to make that stricter if you'd rather only handle the collision.

## Testing

Unit tests in `cli/cmds/cluster_delete_test.go`:

- ambiguous name errors and deletes nothing
- single match resolves to its namespace
- `-n` flag and `namespace/name` arg skip the lookup
- clusters with a different name are ignored

This change was prepared with AI assistance; all changes were reviewed and verified by me.
