### PR TITLE
Unpin package versioning for VM provisioning

### DIFF
--- a/.github/actions/provision-k3s-vm-workers/action.yml
+++ b/.github/actions/provision-k3s-vm-workers/action.yml
@@ -33,19 +33,10 @@ runs:
       echo "CIDR_PREFIX=${{ inputs.bridge-cidr-prefix }}" >> "$GITHUB_ENV"
 
       sudo apt-get update
-
-      # Pinned to the versions available on the runner's Ubuntu 24.04 (noble) image at the
-      # time of writing. These come from Ubuntu's regular archive, which does not retain
-      # superseded versions — a routine security update to any of these will make the pin
-      # unresolvable and fail the install below. If that happens, check the versions
-      # currently available (logged on every run) and update the pins to match.
-      echo "Available versions for pinned packages:"
-      apt-cache madison qemu-kvm qemu-utils cloud-image-utils
-
-      sudo apt-get install -y \
-        qemu-kvm=1:8.2.2+ds-0ubuntu1.17 \
-        qemu-utils=1:8.2.2+ds-0ubuntu1.17 \
-        cloud-image-utils=0.33-1
+      sudo apt-get install -y --no-install-recommends \
+        qemu-kvm \
+        qemu-utils \
+        cloud-image-utils
       sudo usermod -aG kvm $USER
 
       kvm-ok

--- a/.github/actions/provision-k3s-vm-workers/action.yml
+++ b/.github/actions/provision-k3s-vm-workers/action.yml
@@ -36,7 +36,8 @@ runs:
       sudo apt-get install -y --no-install-recommends \
         qemu-kvm \
         qemu-utils \
-        cloud-image-utils
+        cloud-image-utils \
+        cpu-checker
       sudo usermod -aG kvm $USER
 
       kvm-ok


### PR DESCRIPTION
Our CI broke ([see](https://github.com/rancher/k3k/actions/runs/31089078582/job/92575435005)) because of a new version of the `qemu-kvm` and `qemu-utils` were released, and the pinned version was removed.

```
  Available versions for pinned packages:
  qemu-utils | 1:8.2.2+ds-0ubuntu1.18 | mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 Packages
  qemu-utils | 1:8.2.2+ds-0ubuntu1.16 | mirror+file:/etc/apt/apt-mirrors.txt noble-security/main amd64 Packages
  qemu-utils | 1:8.2.2+ds-0ubuntu1 | mirror+file:/etc/apt/apt-mirrors.txt noble/main amd64 Packages
  cloud-image-utils |     0.33-1 | mirror+file:/etc/apt/apt-mirrors.txt noble/main amd64 Packages
  Reading package lists...
  Building dependency tree...
  Reading state information...
  Package qemu-utils is not available, but is referred to by another package.
  This may mean that the package is missing, has been obsoleted, or
  is only available from another source
  
  Package qemu-kvm is a virtual package provided by:
    qemu-system-x86 1:8.2.2+ds-0ubuntu1.18 (= 1:8.2.2+ds-0ubuntu1.18)
  
  E: Version '1:8.2.2+ds-0ubuntu1.17' for 'qemu-kvm' was not found
  E: Version '1:8.2.2+ds-0ubuntu1.17' for 'qemu-utils' was not found
```


This was expected, but from a quick investigation it looks like a bad practice.

> Pinning exact OS-level packages (like those installed via apt) in a CI pipeline is generally considered an anti-pattern. While your goal of protecting against supply chain attacks is valid, applying exact version pinning to Ubuntu/Debian packages creates a false sense of security and guarantees constant CI breakage.
> 
> Unlike application-level package registries (like `npm`, `PyPI`, or `crates.io`) which keep historical versions forever, standard Linux distribution mirrors purge old package revisions as soon as a new update is released.
> 
> - By pinning the exact revision, you are explicitly preventing your CI from receiving critical upstream security fixes.
> - To keep your CI green, you have to manually bump the version every time Ubuntu patches a CVE.
> - OS-level packages in Debian/Ubuntu are already digitally signed by Canonical via release GPG keys and vetted by distribution maintainers. The risk of a supply chain attack here is vastly lower than in unvetted registries like `npm`.

This PR removes the pinned versions, and add the `--no-install-recommends` to reduce the number of installed packages.