### PR TITLE
Add node syncer for mirrorHostNodes: live cordon/taint/label propagation

### DIFF
--- a/k3k-kubelet/controller/syncer/nodes.go
+++ b/k3k-kubelet/controller/syncer/nodes.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,6 +21,10 @@ import (
 
 const (
 	nodeControllerName = "node-syncer"
+
+	// virtualKubeletAnnotationPrefix marks node annotations owned by the
+	// virtual kubelet itself — never overwritten by the host mirror.
+	virtualKubeletAnnotationPrefix = "virtual-kubelet.io/"
 )
 
 // NodeSyncer keeps mirrored virtual nodes in sync with their host node
@@ -112,8 +117,22 @@ func (s *NodeSyncer) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	patch := ctrlruntimeclient.MergeFrom(virtNode.DeepCopy())
 
+	// Preserve annotations owned by the virtual side: the virtual kubelet
+	// keeps its status bookkeeping (e.g. last-applied-node-status) on the
+	// mirrored node, and wiping it forces needless full status re-applies.
+	annotations := map[string]string{}
+	for k, v := range hostNode.GetAnnotations() {
+		annotations[k] = v
+	}
+
+	for k, v := range virtNode.GetAnnotations() {
+		if strings.HasPrefix(k, virtualKubeletAnnotationPrefix) {
+			annotations[k] = v
+		}
+	}
+
 	virtNode.Labels = hostNode.GetLabels()
-	virtNode.Annotations = hostNode.GetAnnotations()
+	virtNode.Annotations = annotations
 	virtNode.Spec.Taints = hostNode.Spec.Taints
 	virtNode.Spec.Unschedulable = hostNode.Spec.Unschedulable
 

--- a/k3k-kubelet/controller/syncer/nodes.go
+++ b/k3k-kubelet/controller/syncer/nodes.go
@@ -1,0 +1,123 @@
+package syncer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+)
+
+const (
+	nodeControllerName = "node-syncer"
+)
+
+// NodeSyncer keeps mirrored virtual nodes in sync with their host node
+// counterparts while the cluster runs with MirrorHostNodes enabled.
+//
+// ConfigureNode copies the host node object once at kubelet registration;
+// without this syncer any later host change (cordon, taints, labels) is
+// invisible to the virtual cluster until its kubelet restarts. The syncer
+// watches host nodes and re-applies the mirrored metadata (labels,
+// annotations) and scheduling-relevant spec fields (taints, unschedulable)
+// to the matching virtual node. Status is left to the virtual kubelet's
+// own update loop.
+type NodeSyncer struct {
+	*SyncerContext
+}
+
+func (s *NodeSyncer) Name() string {
+	return nodeControllerName
+}
+
+// AddNodeSyncer adds the node syncer controller to the manager of the host
+// cluster. It only acts on host nodes that have a mirrored counterpart in
+// the virtual cluster, so it is a no-op for nodes the cluster's kubelets
+// have not registered.
+func AddNodeSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clusterName, clusterNamespace string) error {
+	reconciler := NodeSyncer{
+		SyncerContext: &SyncerContext{
+			VirtualClient: virtMgr.GetClient(),
+			HostClient:    hostMgr.GetClient(),
+			Translator: translate.ToHostTranslator{
+				ClusterName:      clusterName,
+				ClusterNamespace: clusterNamespace,
+			},
+			ClusterName:      clusterName,
+			ClusterNamespace: clusterNamespace,
+		},
+	}
+
+	name := reconciler.Translator.TranslateName(clusterNamespace, nodeControllerName)
+
+	return ctrl.NewControllerManagedBy(hostMgr).
+		Named(name).
+		For(&corev1.Node{}).
+		WithEventFilter(mirroredFieldsChangedPredicate).
+		Complete(&reconciler)
+}
+
+// mirroredFieldsChangedPredicate skips node updates that do not touch any
+// mirrored field — most notably the periodic status/heartbeat updates.
+var mirroredFieldsChangedPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldNode, okOld := e.ObjectOld.(*corev1.Node)
+		newNode, okNew := e.ObjectNew.(*corev1.Node)
+
+		if !okOld || !okNew {
+			return false
+		}
+
+		return !equality.Semantic.DeepEqual(oldNode.Labels, newNode.Labels) ||
+			!equality.Semantic.DeepEqual(oldNode.Annotations, newNode.Annotations) ||
+			!equality.Semantic.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints) ||
+			oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable
+	},
+}
+
+// Reconcile implements reconcile.Reconciler and mirrors label, annotation,
+// taint and unschedulable changes of a host node onto the virtual node of
+// the same name.
+func (s *NodeSyncer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("cluster", s.ClusterName, "clusterNamespace", s.ClusterNamespace)
+	ctx = ctrl.LoggerInto(ctx, logger)
+
+	var hostNode corev1.Node
+	if err := s.HostClient.Get(ctx, req.NamespacedName, &hostNode); err != nil {
+		// A deleted host node takes its kubelet pod (and thereby the
+		// virtual node lifecycle) with it — nothing to mirror.
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	var virtNode corev1.Node
+	if err := s.VirtualClient.Get(ctx, types.NamespacedName{Name: req.Name}, &virtNode); err != nil {
+		if apierrors.IsNotFound(err) {
+			// No mirrored counterpart (yet) — registration will copy the
+			// full node object when the kubelet for this node starts.
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, err
+	}
+
+	patch := ctrlruntimeclient.MergeFrom(virtNode.DeepCopy())
+
+	virtNode.Labels = hostNode.GetLabels()
+	virtNode.Annotations = hostNode.GetAnnotations()
+	virtNode.Spec.Taints = hostNode.Spec.Taints
+	virtNode.Spec.Unschedulable = hostNode.Spec.Unschedulable
+
+	logger.Info("mirroring host node change to virtual node", "node", req.Name)
+
+	return reconcile.Result{}, s.VirtualClient.Patch(ctx, &virtNode, patch)
+}

--- a/k3k-kubelet/controller/syncer/nodes_test.go
+++ b/k3k-kubelet/controller/syncer/nodes_test.go
@@ -1,0 +1,138 @@
+package syncer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/k3k/k3k-kubelet/translate"
+)
+
+func newNodeSyncer(hostObjs, virtObjs []runtime.Object, scheme *runtime.Scheme) *NodeSyncer {
+	return &NodeSyncer{
+		SyncerContext: &SyncerContext{
+			HostClient:    fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hostObjs...).Build(),
+			VirtualClient: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(virtObjs...).Build(),
+			Translator: translate.ToHostTranslator{
+				ClusterName:      "mycluster",
+				ClusterNamespace: "ns-1",
+			},
+			ClusterName:      "mycluster",
+			ClusterNamespace: "ns-1",
+		},
+	}
+}
+
+func TestNodeSyncerReconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	hostNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node-1",
+			Labels:      map[string]string{"node-role.kubernetes.io/control-plane": "true", "topology.kubernetes.io/zone": "z1"},
+			Annotations: map[string]string{"some": "annotation"},
+		},
+		Spec: corev1.NodeSpec{
+			Unschedulable: true,
+			Taints: []corev1.Taint{
+				{Key: "node.kubernetes.io/unschedulable", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+
+	virtNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"node-role.kubernetes.io/worker": "true"},
+		},
+	}
+
+	t.Run("mirrors labels, annotations, taints and unschedulable", func(t *testing.T) {
+		syncer := newNodeSyncer(
+			[]runtime.Object{hostNode.DeepCopy()},
+			[]runtime.Object{virtNode.DeepCopy()},
+			scheme,
+		)
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-1"}}
+		_, err := syncer.Reconcile(context.Background(), req)
+		require.NoError(t, err)
+
+		var synced corev1.Node
+		require.NoError(t, syncer.VirtualClient.Get(context.Background(), req.NamespacedName, &synced))
+
+		assert.Equal(t, hostNode.Labels, synced.Labels)
+		assert.Equal(t, hostNode.Annotations, synced.Annotations)
+		assert.Equal(t, hostNode.Spec.Taints, synced.Spec.Taints)
+		assert.True(t, synced.Spec.Unschedulable)
+	})
+
+	t.Run("no virtual counterpart is a no-op", func(t *testing.T) {
+		syncer := newNodeSyncer(
+			[]runtime.Object{hostNode.DeepCopy()},
+			nil,
+			scheme,
+		)
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-1"}}
+		_, err := syncer.Reconcile(context.Background(), req)
+		require.NoError(t, err)
+	})
+
+	t.Run("deleted host node is a no-op", func(t *testing.T) {
+		syncer := newNodeSyncer(
+			nil,
+			[]runtime.Object{virtNode.DeepCopy()},
+			scheme,
+		)
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-1"}}
+		_, err := syncer.Reconcile(context.Background(), req)
+		require.NoError(t, err)
+
+		var unchanged corev1.Node
+		require.NoError(t, syncer.VirtualClient.Get(context.Background(), req.NamespacedName, &unchanged))
+		assert.Equal(t, virtNode.Labels, unchanged.Labels)
+	})
+}
+
+func TestMirroredFieldsChangedPredicate(t *testing.T) {
+	base := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"a": "1"},
+		},
+	}
+
+	t.Run("status-only change is filtered out", func(t *testing.T) {
+		updated := base.DeepCopy()
+		updated.Status.NodeInfo.KubeletVersion = "v1.34.9"
+
+		assert.False(t, mirroredFieldsChangedPredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: updated}))
+	})
+
+	t.Run("label change passes", func(t *testing.T) {
+		updated := base.DeepCopy()
+		updated.Labels["b"] = "2"
+
+		assert.True(t, mirroredFieldsChangedPredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: updated}))
+	})
+
+	t.Run("cordon passes", func(t *testing.T) {
+		updated := base.DeepCopy()
+		updated.Spec.Unschedulable = true
+
+		assert.True(t, mirroredFieldsChangedPredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: updated}))
+	})
+}

--- a/k3k-kubelet/controller/syncer/nodes_test.go
+++ b/k3k-kubelet/controller/syncer/nodes_test.go
@@ -78,6 +78,29 @@ func TestNodeSyncerReconcile(t *testing.T) {
 		assert.True(t, synced.Spec.Unschedulable)
 	})
 
+	t.Run("preserves virtual-kubelet annotations", func(t *testing.T) {
+		virtWithVKAnnotation := virtNode.DeepCopy()
+		virtWithVKAnnotation.Annotations = map[string]string{
+			"virtual-kubelet.io/last-applied-node-status": "{...}",
+		}
+
+		syncer := newNodeSyncer(
+			[]runtime.Object{hostNode.DeepCopy()},
+			[]runtime.Object{virtWithVKAnnotation},
+			scheme,
+		)
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-1"}}
+		_, err := syncer.Reconcile(context.Background(), req)
+		require.NoError(t, err)
+
+		var synced corev1.Node
+		require.NoError(t, syncer.VirtualClient.Get(context.Background(), req.NamespacedName, &synced))
+
+		assert.Equal(t, "{...}", synced.Annotations["virtual-kubelet.io/last-applied-node-status"])
+		assert.Equal(t, "annotation", synced.Annotations["some"])
+	})
+
 	t.Run("no virtual counterpart is a no-op", func(t *testing.T) {
 		syncer := newNodeSyncer(
 			[]runtime.Object{hostNode.DeepCopy()},

--- a/k3k-kubelet/kubelet.go
+++ b/k3k-kubelet/kubelet.go
@@ -348,5 +348,13 @@ func addControllers(ctx context.Context, hostMgr, virtualMgr manager.Manager, c 
 		return fmt.Errorf("failed to add event syncer controller: %w", err)
 	}
 
+	if c.MirrorHostNodes {
+		logger.Info("adding node syncer controller")
+
+		if err := syncer.AddNodeSyncer(ctx, virtualMgr, hostMgr, c.ClusterName, c.ClusterNamespace); err != nil {
+			return fmt.Errorf("failed to add node syncer controller: %w", err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Addresses the node-state half of #1123.

With `mirrorHostNodes`, `ConfigureNode` copies the host node object once at kubelet registration — any later host change (cordon, taints, labels) stays invisible to the virtual cluster until its kubelet restarts. That defeats the main operational use case: workloads inside the virtual cluster (kubevirt, database operators, …) reacting to host node maintenance.

This adds a `NodeSyncer` to the kubelet's existing syncer framework, enabled only with `MirrorHostNodes`:

- watches **host** nodes; on change re-applies the mirrored metadata (labels, annotations) and scheduling-relevant spec fields (**taints**, **unschedulable**) to the virtual node of the same name
- a predicate skips status-only/heartbeat updates, so reconciles fire only on mirrored-field changes
- node **status** stays owned by the virtual kubelet's own update loop (no fighting)
- host nodes without a mirrored counterpart are a no-op (registration handles the initial full copy)

Unit tests included, following the existing fake-client syncer test style.

Validated on a live shared-mode cluster (k3s v1.34.9 on RKE2 v1.32.13, 3 nodes): `kubectl cordon` + label on the host propagated to the virtual node in ~1s (`SchedulingDisabled`, `node.kubernetes.io/unschedulable` taint, label all visible inside the vc), uncordon cleared it in ~1s — no kubelet restarts involved.

Note on semantics: labels/annotations are mirrored wholesale (same as registration), so virtual-cluster-side edits to mirrored node objects get overwritten on the next host change — consistent with `mirrorHostNodes` being a mirror. The PDB/drain-coordination half of #1123 is intentionally out of scope here.
