### PR TITLE
feat: import CI images directly into containerd instead of ttl.sh

### DIFF
--- a/.github/workflows/test-conformance-hcp.yaml
+++ b/.github/workflows/test-conformance-hcp.yaml
@@ -94,12 +94,16 @@ jobs:
     - name: Setup K3k (from source)
       if: inputs.k3k_version == ''
       run: |
-        export REPO=ttl.sh/$(uuidgen)
-        export VERSION=1h
+        export REPO=k3k.local
 
         make build
         make package
-        make push
+        make save
+
+        # Import straight into the node's containerd
+        sudo k3s ctr images import k3k-images.tar
+        sudo k3s crictl images | grep k3k
+
         make install
 
         # add k3kcli to $PATH

--- a/.github/workflows/test-conformance-hcp.yaml
+++ b/.github/workflows/test-conformance-hcp.yaml
@@ -102,7 +102,6 @@ jobs:
 
         # Import straight into the node's containerd
         sudo k3s ctr images import k3k-images.tar
-        sudo k3s crictl images | grep k3k
 
         make install
 

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -94,12 +94,16 @@ jobs:
       env:
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       run: |
-        export REPO=ttl.sh/$(uuidgen)
-        export VERSION=1h
+        export REPO=k3k.local
 
         make build
         make package
-        make push
+        make save
+
+        # Import straight into the node's containerd
+        sudo k3s ctr images import k3k-images.tar
+        sudo k3s crictl images | grep k3k
+
         make install
 
         # add k3kcli to $PATH

--- a/.github/workflows/test-conformance-virtual.yaml
+++ b/.github/workflows/test-conformance-virtual.yaml
@@ -102,7 +102,6 @@ jobs:
 
         # Import straight into the node's containerd
         sudo k3s ctr images import k3k-images.tar
-        sudo k3s crictl images | grep k3k
 
         make install
 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -61,8 +61,7 @@ jobs:
 
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
-        echo "REPO=ttl.sh/$(uuidgen)" >> $GITHUB_ENV
-        echo "VERSION=1h" >> $GITHUB_ENV
+        echo "REPO=k3k.local" >> $GITHUB_ENV
         echo "K3S_HOST_VERSION=${{ env.KUBERNETES_VERSION }}+k3s1" >> $GITHUB_ENV
 
     - name: Install k3s
@@ -100,22 +99,30 @@ jobs:
           done
         '
 
-    - name: Build and package and push dev images
+    - name: Build and package and import dev images
       env:
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        REPO: ${{ env.REPO }}
-        VERSION: ${{ env.VERSION }}
       run: |
         make build
         make package
-        make push
+        make save
+
+        # Import straight into each node's containerd
+        sudo k3s ctr images import k3k-images.tar
+        sudo k3s crictl images | grep k3k
+
+        for i in 1 2; do
+          IP="192.168.100.1${i}"
+          scp -i ./id_rsa -o StrictHostKeyChecking=no k3k-images.tar ubuntu@${IP}:/tmp/
+          ssh -i ./id_rsa -o StrictHostKeyChecking=no ubuntu@${IP} \
+            "sudo k3s ctr images import /tmp/k3k-images.tar && sudo k3s crictl images | grep k3k && rm -f /tmp/k3k-images.tar"
+        done
+
         make install
 
     - name: Run e2e tests
       env:
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        REPO: ${{ env.REPO }}
-        VERSION: ${{ env.VERSION }}
       run: make E2E_LABEL_FILTER="${{ matrix.label-filter }}" test-e2e
 
     - name: Convert coverage data

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -109,13 +109,13 @@ jobs:
 
         # Import straight into each node's containerd
         sudo k3s ctr images import k3k-images.tar
-        sudo k3s crictl images | grep k3k
 
+        # The worker VMs have no checkout, so import there directly
         for i in 1 2; do
           IP="192.168.100.1${i}"
           scp -i ./id_rsa -o StrictHostKeyChecking=no k3k-images.tar ubuntu@${IP}:/tmp/
           ssh -i ./id_rsa -o StrictHostKeyChecking=no ubuntu@${IP} \
-            "sudo k3s ctr images import /tmp/k3k-images.tar && sudo k3s crictl images | grep k3k && rm -f /tmp/k3k-images.tar"
+            "sudo k3s ctr images import /tmp/k3k-images.tar && rm -f /tmp/k3k-images.tar"
         done
 
         make install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,6 @@ jobs:
 
         # Import straight into the node's containerd
         sudo k3s ctr images import k3k-images.tar
-        sudo k3s crictl images | grep k3k
 
         make install
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,8 +61,7 @@ jobs:
 
         echo "COVERAGE=true" >> $GITHUB_ENV
         echo "GOCOVERDIR=${{ github.workspace }}/covdata" >> $GITHUB_ENV
-        echo "REPO=ttl.sh/$(uuidgen)" >> $GITHUB_ENV
-        echo "VERSION=1h" >> $GITHUB_ENV
+        echo "REPO=k3k.local" >> $GITHUB_ENV
         echo "K3S_HOST_VERSION=${{ env.KUBERNETES_VERSION }}+k3s1" >> $GITHUB_ENV
 
     - name: Install k3s
@@ -71,11 +70,16 @@ jobs:
 
         echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> $GITHUB_ENV
 
-    - name: Build and package and push dev images
+    - name: Build and package and import dev images
       run: |
         make build
         make package
-        make push
+        make save
+
+        # Import straight into the node's containerd
+        sudo k3s ctr images import k3k-images.tar
+        sudo k3s crictl images | grep k3k
+
         make install
 
         # add k3kcli to $PATH
@@ -88,8 +92,6 @@ jobs:
       env:
         K3S_HOST_VERSION: "${{ env.K3S_HOST_VERSION }}"
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        REPO: ${{ env.REPO }}
-        VERSION: ${{ env.VERSION }}
       run: make test-cli
 
     - name: Convert coverage data

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ REPO ?= rancher
 COVERAGE ?= false
 VERSION ?= $(shell git describe --tags --always --dirty --match="v[0-9]*")
 
+IMAGE_ARCHIVE ?= k3k-images.tar
+
 ## Dependencies
 
 GOLANGCI_LINT_VERSION := v2.12.2
@@ -59,6 +61,10 @@ push-%:
 	docker push $(REPO)/$*:$(VERSION)
 	docker push $(REPO)/$*:latest
 	docker push $(REPO)/$*:dev
+
+.PHONY: save
+save:	## Save the k3k and k3k-kubelet images to a tar archive, to import them without a registry
+	docker save -o $(IMAGE_ARCHIVE) $(REPO)/k3k:$(VERSION) $(REPO)/k3k-kubelet:$(VERSION)
 
 .PHONY: test
 test:	## Run all the tests


### PR DESCRIPTION
Since we have intermittent issues with [ttl.sh](ttl.sh), this PR drops the external registry entirely, to improve reliability, privacy and speed of the tests.

Instead of pushing images and pulling them back, CI now builds them and imports them straight into each node's containerd (make save + k3s ctr images import).

