### PR TITLE
kubelet: don't panic when the serving-cert request times out

### DIFF
--- a/k3k-kubelet/node.go
+++ b/k3k-kubelet/node.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -71,21 +72,42 @@ func loadTLSConfig(cfg config, token, agentIP, podIP string) (*tls.Config, error
 		NodeName: controller.SafeConcatName(cfg.ClusterName, "server-0"),
 	})
 
+	tlsCrt, err := requestServingCert(client.GetServingKubeletCrt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{*tlsCrt},
+	}, nil
+}
+
+// requestServingCert retries the serving-cert request while the server is not
+// ready, tolerating wrapped errors (errors.Is instead of ==).
+func requestServingCert(getCrt func() (*tls.Certificate, error)) (*tls.Certificate, error) {
 	var tlsCrt *tls.Certificate
 
 	if err := retry.OnError(controller.Backoff, func(err error) bool {
-		return err == k3s.ErrServerNotReady
+		return errors.Is(err, k3s.ErrServerNotReady)
 	}, func() error {
 		var err error
 
-		tlsCrt, err = client.GetServingKubeletCrt()
+		tlsCrt, err = getCrt()
 
 		return err
 	}); err != nil {
 		return nil, fmt.Errorf("unable to request serving kubelet certificate: %w", err)
 	}
 
-	return &tls.Config{
-		Certificates: []tls.Certificate{*tlsCrt},
-	}, nil
+	// retry.OnError can return nil without a certificate: when fn fails with
+	// an error that satisfies wait.Interrupted (e.g. a wrapped
+	// context.DeadlineExceeded from the HTTP client) before any retriable
+	// error was recorded, it swallows the error entirely. Guard the
+	// dereference so a network timeout surfaces as an error instead of a
+	// panic.
+	if tlsCrt == nil {
+		return nil, fmt.Errorf("unable to request serving kubelet certificate: no certificate returned")
+	}
+
+	return tlsCrt, nil
 }

--- a/k3k-kubelet/node_test.go
+++ b/k3k-kubelet/node_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/rancher/k3k/pkg/controller"
+	"github.com/rancher/k3k/pkg/k3s"
+)
+
+// withFastBackoff shrinks the package retry backoff so the retry paths run in
+// milliseconds instead of minutes.
+func withFastBackoff(t *testing.T) {
+	t.Helper()
+
+	old := controller.Backoff
+	controller.Backoff = wait.Backoff{
+		Steps:    3,
+		Duration: time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0,
+	}
+
+	t.Cleanup(func() { controller.Backoff = old })
+}
+
+// A first-attempt failure with an error satisfying wait.Interrupted (such as a
+// wrapped context.DeadlineExceeded from the HTTP client) makes retry.OnError
+// return its recorded-but-nil last retriable error: no error, no certificate.
+// Before the nil guard this dereferenced a nil certificate and crashed the
+// kubelet with a SIGSEGV.
+func TestRequestServingCertSwallowedTimeout(t *testing.T) {
+	withFastBackoff(t)
+
+	_, err := requestServingCert(func() (*tls.Certificate, error) {
+		return nil, fmt.Errorf("Head \"https://server:6443\": %w", context.DeadlineExceeded)
+	})
+	if err == nil {
+		t.Fatal("expected an error for a timed-out certificate request, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "no certificate returned") {
+		t.Fatalf("expected the nil-certificate guard error, got: %v", err)
+	}
+}
+
+// ErrServerNotReady arrives wrapped (fmt.Errorf %w chains); the retriable
+// check must use errors.Is, not equality, or the retry never happens.
+func TestRequestServingCertRetriesWrappedServerNotReady(t *testing.T) {
+	withFastBackoff(t)
+
+	calls := 0
+	want := &tls.Certificate{}
+
+	got, err := requestServingCert(func() (*tls.Certificate, error) {
+		calls++
+		if calls < 3 {
+			return nil, fmt.Errorf("server returned 503: %w", k3s.ErrServerNotReady)
+		}
+
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != want {
+		t.Fatal("returned certificate is not the one the getter produced")
+	}
+
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts (2 retries), got %d", calls)
+	}
+}
+
+// Non-retriable errors must surface to the caller wrapped, not be retried.
+func TestRequestServingCertNonRetriableError(t *testing.T) {
+	withFastBackoff(t)
+
+	boom := errors.New("boom")
+	calls := 0
+
+	_, err := requestServingCert(func() (*tls.Certificate, error) {
+		calls++
+		return nil, boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected the getter error wrapped, got: %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt for a non-retriable error, got %d", calls)
+	}
+}


### PR DESCRIPTION
The kubelet crashes with a SIGSEGV instead of a clean error when its very
first serving-certificate request fails with a timeout-class error:

```
panic: runtime error: invalid memory address or nil pointer dereference
main.loadTLSConfig(...) k3k-kubelet/node.go:89
```

Mechanism: `loadTLSConfig` wraps `GetServingKubeletCrt` in
`retry.OnError(..., err == k3s.ErrServerNotReady, ...)`. When the request
fails with an error satisfying `wait.Interrupted` (e.g. a wrapped
`context.DeadlineExceeded` from the HTTP client) before any retriable
error was recorded, client-go's `OnError` replaces the returned error with
the *nil* last-retriable-error — so it returns `nil` without a
certificate, and the `*tlsCrt` dereference panics.

Reproduced on a 6-node host cluster where a network policy dropped
cross-node kubelet→server traffic: every kubelet whose first cert request
timed out crashed with the stack above.

Fix: guard the nil certificate (clean error instead of SIGSEGV) and make
the retriable check wrap-tolerant (`errors.Is` instead of `==`). The
retry+guard is extracted into `requestServingCert` so all three paths are
unit-tested (swallowed timeout, wrapped-error retry, non-retriable
passthrough).

---
_Transparency: this PR was authored by Claude (Anthropic's Claude Fable 5) operating the max06 account, with human review by max06._
