### PR TITLE
server: readiness probe checks /readyz instead of a bare TCP socket

### DIFF
--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -10,7 +10,6 @@ import (
 	"text/template"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -223,14 +222,24 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 		)
 	}
 
-	// Adding readiness probes to statefulset
+	// Adding readiness probes to statefulset.
+	// /readyz includes the apiserver's etcd health checks; a bare TCP
+	// check stays green while raft has no quorum (the listener accepts
+	// connections and every handler times out), so ordered StatefulSet
+	// rolls proceeded into a quorum-less cluster. k3s runs the apiserver
+	// with anonymous-auth=false (an HTTP probe gets 401), so the check
+	// goes through k3s' own admin credentials via an exec probe.
 	podSpec.Containers[0].ReadinessProbe = &corev1.Probe{
 		InitialDelaySeconds: 60,
 		FailureThreshold:    5,
 		TimeoutSeconds:      10,
 		ProbeHandler: corev1.ProbeHandler{
-			TCPSocket: &corev1.TCPSocketAction{
-				Port: intstr.FromInt(6443),
+			Exec: &corev1.ExecAction{
+				Command: []string{
+					"/bin/sh",
+					"-c",
+					"kubectl get --raw=/readyz",
+				},
 			},
 		},
 	}

--- a/pkg/controller/cluster/server/server_test.go
+++ b/pkg/controller/cluster/server/server_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
+)
+
+// The server readiness probe must check /readyz (which includes the
+// apiserver's etcd health checkers), not a bare TCP socket: the 6443
+// listener accepts connections while raft has no quorum, so a TCP probe
+// reports Ready for servers whose etcd is already dead and ordered
+// StatefulSet rolls proceed into a quorum-less cluster. k3s runs the
+// apiserver with anonymous-auth=false, so the check must exec kubectl
+// (the k3s multicall binary does not dispatch "k3s kubectl" correctly in
+// the server image) instead of probing over HTTPS, which would get a 401.
+func TestPodSpecReadinessProbeChecksReadyz(t *testing.T) {
+	cluster := &v1beta1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: "ns",
+		},
+	}
+
+	s := New(cluster, nil, "token", "rancher/k3s:v1.33.5-k3s1", "IfNotPresent", nil)
+	podSpec := s.podSpec(context.Background(), "rancher/k3s:v1.33.5-k3s1", "k3k-mycluster-server", false, "")
+
+	if len(podSpec.Containers) == 0 {
+		t.Fatal("podSpec has no containers")
+	}
+
+	probe := podSpec.Containers[0].ReadinessProbe
+	if probe == nil {
+		t.Fatal("server container has no readiness probe")
+	}
+
+	if probe.TCPSocket != nil {
+		t.Fatal("readiness probe is a bare TCP check — blind to etcd quorum loss")
+	}
+
+	if probe.Exec == nil {
+		t.Fatalf("expected an exec readiness probe, got: %+v", probe.ProbeHandler)
+	}
+
+	cmd := strings.Join(probe.Exec.Command, " ")
+	if !strings.Contains(cmd, "kubectl get --raw=/readyz") {
+		t.Fatalf("readiness probe does not check /readyz via kubectl: %q", cmd)
+	}
+
+	if strings.Contains(cmd, "k3s kubectl") {
+		t.Fatalf("probe must exec kubectl directly, not the k3s multicall: %q", cmd)
+	}
+}


### PR DESCRIPTION
The server StatefulSet's readiness probe is a TCP check on 6443. The
apiserver's listener accepts connections while etcd has no quorum (every
handler just times out), so "Ready" is reported for servers whose raft is
already dead. Consequences we hit in production-like testing:

- Ordered StatefulSet rolls proceed through quorum-less servers. When
  every member restarts before re-membership completes, the etcd member
  registry strands on stale pod-IP peer URLs and the cluster can never
  re-form quorum on its own (peer-URL updates need the quorum that no
  longer exists).
- Supervisor 503s (kubelet cert requests fail, agents crash-loop) while
  all server pods show 1/1 Running.

Fix: probe `/readyz` via an exec check (`kubectl get --raw=/readyz`)
— it includes the apiserver's etcd health checkers. An HTTPS probe is not
possible: k3s runs the apiserver with `anonymous-auth=false`, so an
unauthenticated probe gets 401 (we shipped that version to our staging
lab first and it wedged cluster bring-up — the exec variant is the
validated one). A unit test pins the probe shape.

Related: a follow-up worth discussing is stable peer identities
(headless-service DNS names instead of pod IPs) so pod-IP churn cannot
strand the member registry at all; happy to open a separate issue.
Additional evidence from the lab: even a SINGLE-member cluster bricks on
a plain pod restart when the pod IP changes — k3s refuses to start with
"this server is not a member of the etcd cluster. Found
[...=https://<old-ip>:2380], expect ...=https://<new-ip>:2380" and
there is no quorum path out; only deleting the data dir recovers a
fresh cluster. The existing per-cluster headless service
(`k3k-<name>-service-headless`) already provides the stable per-pod DNS
names an `--etcd-arg`-based peer-URL fix would need.

---
_Transparency: this PR was authored by Claude (Anthropic's Claude Fable 5) operating the max06 account, with human review by max06._
