### PR TITLE
cluster: never deadlock etcdpod finalizer processing on a dead cluster

### DIFF
--- a/pkg/controller/cluster/statefulset.go
+++ b/pkg/controller/cluster/statefulset.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -93,6 +94,21 @@ func (p *StatefulSetReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		return reconcile.Result{}, err
 	}
 
+	// Pods already being deleted are processed FIRST: the server-config
+	// fetch below needs the cluster's live bootstrap endpoint, which is
+	// exactly what a fully-down cluster lacks. Gating finalizer removal
+	// on it deadlocks recovery (finalizer never removed -> StatefulSet
+	// never recreates pods -> the cluster can never come back).
+	for i := range podList.Items {
+		if podList.Items[i].DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		if err := p.handleServerPod(ctx, cluster, &podList.Items[i]); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	if len(podList.Items) == 1 {
 		serverPod := podList.Items[0]
 		if !serverPod.DeletionTimestamp.IsZero() {
@@ -155,6 +171,28 @@ func (p *StatefulSetReconciler) handleServerPod(ctx context.Context, cluster v1b
 	if cluster.Name == "" {
 		if controllerutil.RemoveFinalizer(pod, etcdPodFinalizerName) {
 			log.V(1).Info("Cluster was deleted. Deleting Server Pod removing finalizer", "pod", pod.Name, "namespace", pod.Namespace)
+
+			if err := p.Client.Update(ctx, pod); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	// Member removal needs a live quorum. When NO server of this cluster
+	// is ready, there is no quorum to serve the removal — and none is
+	// needed: the members restart together with their PVCs intact, so no
+	// bookkeeping is missing. Blocking here kept whole clusters dead
+	// (ivx observation: 9 pods of 3 vcs stuck Unknown for 8 days).
+	anyReady, err := p.anyServerPodReady(ctx, pod)
+	if err != nil {
+		return err
+	}
+
+	if !anyReady {
+		if controllerutil.RemoveFinalizer(pod, etcdPodFinalizerName) {
+			log.Info("no ready server for this cluster; skipping etcd member removal and removing finalizer", "pod", pod.Name, "namespace", pod.Namespace)
 
 			if err := p.Client.Update(ctx, pod); err != nil {
 				return err
@@ -301,6 +339,39 @@ func (p *StatefulSetReconciler) handleDeletion(ctx context.Context, sts *appsv1.
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// anyServerPodReady reports whether any non-deleting server pod of the same
+// cluster as the given pod is Ready.
+func (p *StatefulSetReconciler) anyServerPodReady(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	var podList corev1.PodList
+
+	listOpts := &ctrlruntimeclient.ListOptions{
+		Namespace: pod.Namespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set{
+			"cluster": pod.Labels["cluster"],
+			"role":    "server",
+		}),
+	}
+
+	if err := p.Client.List(ctx, &podList, listOpts); err != nil {
+		return false, err
+	}
+
+	for i := range podList.Items {
+		other := &podList.Items[i]
+		if !other.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		for _, cond := range other.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }
 
 func (p *StatefulSetReconciler) listPods(ctx context.Context, sts *appsv1.StatefulSet) (*corev1.PodList, error) {

--- a/pkg/controller/cluster/statefulset_test.go
+++ b/pkg/controller/cluster/statefulset_test.go
@@ -1,0 +1,86 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func serverPod(name string, ready bool, deleting bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "vc1",
+			Labels:    map[string]string{"cluster": "vc1", "role": "server"},
+		},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+		}
+	}
+	if deleting {
+		now := metav1.Now()
+		pod.DeletionTimestamp = &now
+		pod.Finalizers = []string{etcdPodFinalizerName}
+	}
+	return pod
+}
+
+func Test_anyServerPodReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name string
+		pods []*corev1.Pod
+		want bool
+	}{
+		{
+			name: "all servers down",
+			pods: []*corev1.Pod{
+				serverPod("k3k-vc1-server-0", false, false),
+				serverPod("k3k-vc1-server-1", false, false),
+				serverPod("k3k-vc1-server-2", false, true),
+			},
+			want: false,
+		},
+		{
+			name: "one healthy server",
+			pods: []*corev1.Pod{
+				serverPod("k3k-vc1-server-0", true, false),
+				serverPod("k3k-vc1-server-1", false, true),
+			},
+			want: true,
+		},
+		{
+			name: "ready but deleting server does not count",
+			pods: []*corev1.Pod{
+				serverPod("k3k-vc1-server-0", true, true),
+				serverPod("k3k-vc1-server-1", false, false),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for _, pod := range tt.pods {
+				builder = builder.WithObjects(pod)
+			}
+
+			r := StatefulSetReconciler{Client: builder.Build()}
+
+			got, err := r.anyServerPodReady(context.Background(), tt.pods[len(tt.pods)-1])
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
When ALL server pods of a cluster are down, deleting them deadlocks
permanently:

1. `StatefulSetReconciler.Reconcile` calls `GetServerConfig()` (the
   cluster's bootstrap endpoint) before handling deleting pods. On a dead
   cluster that call fails, so pods carrying `etcdpod.k3k.io/finalizer`
   are never processed at all.
2. Even when reached, `handleServerPod` requires a successful etcd member
   removal before releasing the finalizer — which requires the quorum
   that a fully-down cluster does not have.

Result: finalizer never removed → StatefulSet never recreates the pods →
the cluster can never self-recover. We observed 9 pods of 3 virtual
clusters stuck in `Unknown` with deletionTimestamps for 8 days; recovery
required manually stripping finalizers.

Fix:
- Handle deleting pods *before* the server-config fetch.
- Skip etcd member removal and release the finalizer when no server pod
  of the cluster is Ready: with no quorum there is nothing to serve the
  removal, and none is needed — the members restart together with their
  PVCs intact, so no membership bookkeeping is missing.

Unit tests included for the no-ready-server detection.

---
_Transparency: this PR was authored by Claude (Anthropic's Claude Fable 5) operating the max06 account, with human review by max06._
