### PR TITLE
Update Ginkgo to `v2.32.1` and docs scripts

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -53,7 +53,7 @@ jobs:
         go-version-file: go.mod
 
     - name: Install Ginkgo
-      run: go install github.com/onsi/ginkgo/v2/ginkgo@9ff1646a26f77a4c0d33ddba3e6368c42c0e8842 # v2.32.0
+      run: go install github.com/onsi/ginkgo/v2/ginkgo@f2d0f65b6d1e99c58d1f9a31b41c53a2754a6c2c # v2.32.1
 
     - name: Setup environment
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
         go-version-file: go.mod
 
     - name: Install Ginkgo
-      run: go install github.com/onsi/ginkgo/v2/ginkgo@9ff1646a26f77a4c0d33ddba3e6368c42c0e8842 # v2.32.0
+      run: go install github.com/onsi/ginkgo/v2/ginkgo@f2d0f65b6d1e99c58d1f9a31b41c53a2754a6c2c # v2.32.1
 
     - name: Setup environment
       run: |

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_ARCHIVE ?= k3k-images.tar
 ## Dependencies
 
 GOLANGCI_LINT_VERSION := v2.12.2
-GINKGO_VERSION ?= v2.32.0
+GINKGO_VERSION ?= v2.32.1
 GINKGO_FLAGS ?= -v -r --coverprofile=cover.out --coverpkg=./...
 ENVTEST_VERSION ?= v0.0.0-20250505003155-b6c5897febe5
 ENVTEST_K8S_VERSION := 1.31.0
@@ -106,14 +106,18 @@ generate:	## Generate the CRDs specs
 docs: docs-crds docs-cli	## Build the CRDs and CLI docs
 
 .PHONY: docs-crds
+# the default max-depth (10) is not enough to resolve the types nested under Affinity,
+# and crd-ref-docs logs "reaching max recursion depth" warnings
 docs-crds:	## Build the CRDs docs
 	$(CRD_REF_DOCS) --config=./docs/crds/config.yaml \
 		--renderer=markdown \
+		--max-depth=12 \
 		--source-path=./pkg/apis/k3k.io/v1beta1 \
 		--output-path=./docs/crds/crds.md
 
 	$(CRD_REF_DOCS) --config=./docs/crds/config.yaml \
 		--renderer=asciidoctor \
+		--max-depth=12 \
 		--templates-dir=./docs/crds/templates/asciidoctor \
 		--source-path=./pkg/apis/k3k.io/v1beta1 \
 		--output-path=./docs/crds/crds.adoc

--- a/docs/cli/convert.lua
+++ b/docs/cli/convert.lua
@@ -8,7 +8,12 @@ function Header(el)
     end
     -- If we hit any other header, stop deleting
     deleting_see_also = false
-    return el
+
+    -- Forces the section markers. Pandoc >= 3.7 writes one extra '=' than
+    -- previous versions, as it reserves the single '=' for the document title.
+    -- Emitting them ourselves keeps the output stable across pandoc versions.
+    local marker = string.rep("=", el.level)
+    return pandoc.RawBlock('asciidoc', marker .. " " .. pandoc.utils.stringify(el) .. "\n\n")
 end
 
 function BulletList(el)

--- a/docs/crds/crds.adoc
+++ b/docs/crds/crds.adoc
@@ -1,6 +1,6 @@
 [id="k3k-api-reference"]
 = API Reference
-:revdate: "2006-01-02"
+:revdate: 2006-01-02
 :page-revdate: {revdate}
 :anchor_prefix: k8s-api
 

--- a/docs/crds/templates/asciidoctor/gv_list.tpl
+++ b/docs/crds/templates/asciidoctor/gv_list.tpl
@@ -3,7 +3,7 @@
 
 [id="k3k-api-reference"]
 = API Reference
-:revdate: "2006-01-02"
+:revdate: 2006-01-02
 :page-revdate: {revdate}
 :anchor_prefix: k8s-api
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0
-	github.com/onsi/ginkgo/v2 v2.32.0
+	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/rancher/dynamiclistener v1.27.5
 	github.com/rancher/k3k/pkg/apis v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.32.0 h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
-github.com/onsi/ginkgo/v2 v2.32.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/ginkgo/v2 v2.32.1 h1:6tlvcDm/3sE8lGJbZ4+d4mO3RLy24/tQWOFzVSQNIfw=
+github.com/onsi/ginkgo/v2 v2.32.1/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=
 github.com/onsi/gomega v1.42.1/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
This PR bumps gingko and updates the `convert.lua` script used by `pandoc`.

On newer versions of Pandoc (>=3.7) the headers are handled differently, so this change was to keep the original behavior. The `--max-depth=12` is just used to silence a warning due to a deep nesting of some Kubernetes CRDs when generating the CRD docs.