### PR TITLE
[v1.1] Update release tag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-    - "v*"
+    - "v1.1.*-rc*"
   workflow_dispatch:
     inputs:
       commit:


### PR DESCRIPTION
Move `v1.1` to **Maintenance** (delivering only RCs to community).