### PR TITLE
Reference Renovate release config files from Rancher

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>rancher/renovate-config#release"
-  ],
   "baseBranchPatterns": [
-    "main",
+    "$default",
     "release/v1.2",
     "release/v1.1"
   ],
-  "prHourlyLimit": 2
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "matchBaseBranches": ["$default"],
+      "extends": ["github>rancher/renovate-config//rancher-main#release"]
+    },
+    {
+      "description": "Apply Rancher 2.15 update constraints (Kubernetes 1.36)",
+      "matchBaseBranches": ["release/v1.2"],
+      "extends": ["github>rancher/renovate-config//rancher-2.15#release"]
+    },
+    {
+      "description": "Apply Rancher 2.14 update constraints (Kubernetes 1.35)",
+      "matchBaseBranches": ["release/v1.1"],
+      "extends": ["github>rancher/renovate-config//rancher-2.14#release"]
+    }
+  ]
 }

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -8,24 +8,24 @@ on:
         default: info
         type: choice
         options:
-          - info
-          - debug
+        - info
+        - debug
       overrideSchedule:
         description: "Override all schedules"
         required: false
         default: "false"
         type: choice
         options:
-          - "false"
-          - "true"
+        - "false"
+        - "true"
       configMigration:
         description: "Toggle PRs for config migration"
         required: false
         default: "true"
         type: choice
         options:
-          - "false"
-          - "true"
+        - "false"
+        - "true"
       renovateConfig:
         description: "Define a custom renovate config file"
         required: false
@@ -38,7 +38,7 @@ on:
         type: string
 
   schedule:
-    - cron: '30 4,6 * * 1-5'
+  - cron: '30 4,6 * * 1-5'
 
 permissions:
   contents: read

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -8,24 +8,24 @@ on:
         default: info
         type: choice
         options:
-        - info
-        - debug
+          - info
+          - debug
       overrideSchedule:
         description: "Override all schedules"
         required: false
         default: "false"
         type: choice
         options:
-        - "false"
-        - "true"
+          - "false"
+          - "true"
       configMigration:
         description: "Toggle PRs for config migration"
         required: false
         default: "true"
         type: choice
         options:
-        - "false"
-        - "true"
+          - "false"
+          - "true"
       renovateConfig:
         description: "Define a custom renovate config file"
         required: false
@@ -36,14 +36,9 @@ on:
         required: false
         default: "null"
         type: string
-      extendsPreset:
-        description: "Override renovate extends preset (default: 'github>rancher/renovate-config#release')."
-        required: false
-        default: "github>rancher/renovate-config#release"
-        type: string
 
   schedule:
-  - cron: '30 4,6 * * 1-5'
+    - cron: '30 4,6 * * 1-5'
 
 permissions:
   contents: read
@@ -51,13 +46,12 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@97a4f8da34a047d885fbf2b4443c1909af645257 # release
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@a1a645d20a4c3d46bc5d1a00f45b87362fce5abc # v1.0.9
     with:
       configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
       renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
       minimumReleaseAge: ${{ inputs.minimumReleaseAge || 'null' }}
-      extendsPreset: ${{ inputs.extendsPreset || 'github>rancher/renovate-config#release' }}
     secrets:
       override-token: "${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}"


### PR DESCRIPTION
Reference the Renovate configs for the Rancher release branches which represent the same Kubernetes version as required.

I would use the shared configs as base, so your release branches only get security bumps and Kubernetes and Go patch level bumps - but not everything else.

And when Go is EOL and needs to be bumped, we increase the version reference in the config, and you will get it too.

I have also update the renovate-vault.yml to have versioning, so Renovate is able to only bump it for new tags and not every time the commit changes.