### PR TITLE
remove empty dir filtering on kata

### DIFF
--- a/pkg/controller/cluster/agent/virtual.go
+++ b/pkg/controller/cluster/agent/virtual.go
@@ -342,8 +342,6 @@ func (v *VirtualAgent) podSpec(ctx context.Context, image, name string) corev1.P
 
 	if podSpec.RuntimeClassName != nil && strings.HasPrefix(*podSpec.RuntimeClassName, "kata") {
 		mounts.AddKmsgMount(&podSpec)
-
-		mounts.FilterEmptyDirVolumes(&podSpec)
 	}
 
 	return podSpec

--- a/pkg/controller/cluster/agent/virtual_test.go
+++ b/pkg/controller/cluster/agent/virtual_test.go
@@ -125,60 +125,23 @@ func baseVirtualAgentPodSpec(v VirtualAgent) corev1.PodSpec {
 }
 
 func kataVirtualAgentPodSpec(v VirtualAgent) corev1.PodSpec {
-	return corev1.PodSpec{
-		Affinity:         nil,
-		NodeSelector:     v.cluster.Spec.NodeSelector,
-		RuntimeClassName: new("kata"),
-		Volumes: []corev1.Volume{
-			{
-				Name: "config",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: configSecretName(v.cluster.Name),
-						Items: []corev1.KeyToPath{
-							{
-								Key:  "config.yaml",
-								Path: "config.yaml",
-							},
-						},
-					},
-				},
-			},
-			{
-				Name: "dev-kmsg",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/dev/kmsg",
-					},
-				},
+	spec := baseVirtualAgentPodSpec(v)
+	spec.RuntimeClassName = new("kata")
+	spec.Volumes = append(spec.Volumes, corev1.Volume{
+		Name: "dev-kmsg",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/dev/kmsg",
 			},
 		},
-		Containers: []corev1.Container{
-			{
-				Name:            "k3k-agent",
-				Image:           v.Image,
-				ImagePullPolicy: corev1.PullPolicy(v.ImagePullPolicy),
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: new(true),
-				},
-				Args: []string{"agent", "--config", "/opt/rancher/k3s/config.yaml"},
-				Command: []string{
-					"/bin/k3s",
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "config",
-						MountPath: "/opt/rancher/k3s/",
-						ReadOnly:  false,
-					},
-					{
-						Name:      "dev-kmsg",
-						MountPath: "/dev/kmsg",
-					},
-				},
-			},
-		},
-	}
+	})
+
+	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "dev-kmsg",
+		MountPath: "/dev/kmsg",
+	})
+
+	return spec
 }
 
 func Test_virtualAgentData(t *testing.T) {

--- a/pkg/controller/cluster/mounts/mounts.go
+++ b/pkg/controller/cluster/mounts/mounts.go
@@ -68,36 +68,6 @@ func buildSecretMountVolume(secretMount v1beta1.SecretMount) (corev1.Volume, cor
 	return vol, volMount
 }
 
-// FilterEmptyDirVolumes strips every EmptyDir volume from the pod spec, along with the
-// container mounts that referenced them.
-func FilterEmptyDirVolumes(podSpec *corev1.PodSpec) {
-	emptyDirNames := make(map[string]bool)
-
-	var filteredVolumes []corev1.Volume
-
-	for _, vol := range podSpec.Volumes {
-		if vol.EmptyDir != nil {
-			emptyDirNames[vol.Name] = true
-		} else {
-			filteredVolumes = append(filteredVolumes, vol)
-		}
-	}
-
-	podSpec.Volumes = filteredVolumes
-
-	for i := range podSpec.Containers {
-		var filteredMounts []corev1.VolumeMount
-
-		for _, mount := range podSpec.Containers[i].VolumeMounts {
-			if !emptyDirNames[mount.Name] {
-				filteredMounts = append(filteredMounts, mount)
-			}
-		}
-
-		podSpec.Containers[i].VolumeMounts = filteredMounts
-	}
-}
-
 // AddKmsgMount mounts the host's /dev/kmsg into the pod's first container.
 func AddKmsgMount(podSpec *corev1.PodSpec) {
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -322,8 +322,6 @@ func (s *Server) podSpec(ctx context.Context, image, name string, persistent boo
 
 	if podSpec.RuntimeClassName != nil && strings.HasPrefix(*podSpec.RuntimeClassName, "kata") {
 		mounts.AddKmsgMount(&podSpec)
-
-		mounts.FilterEmptyDirVolumes(&podSpec)
 	}
 
 	return podSpec


### PR DESCRIPTION
This is no longer required since the instructions where updated to use block-plain emptydir volumes. The SRA build has excluded this filter for some time, and inclusion causes issues with CoCo.