### PR TITLE
kubelet: merge a pod's dnsConfig with the virtual cluster DNS instead of skipping the injection

### DIFF
--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -899,26 +900,7 @@ func configureNetworking(hostPod, virtualPod *corev1.Pod, serverIP, dnsIP string
 		},
 	})
 
-	// injecting cluster DNS IP to the pods except for coredns pod
-	if !isCoreDNSPod(*virtualPod) && hostPod.Spec.DNSConfig == nil {
-		hostPod.Spec.DNSPolicy = corev1.DNSNone
-		hostPod.Spec.DNSConfig = &corev1.PodDNSConfig{
-			Nameservers: []string{
-				dnsIP,
-			},
-			Searches: []string{
-				virtualPod.Namespace + ".svc.cluster.local",
-				"svc.cluster.local",
-				"cluster.local",
-			},
-			Options: []corev1.PodDNSConfigOption{
-				{
-					Name:  "ndots",
-					Value: new("5"),
-				},
-			},
-		}
-	}
+	configureDNS(hostPod, virtualPod, dnsIP)
 
 	updatedEnvVars := []corev1.EnvVar{
 		{Name: "KUBERNETES_SERVICE_HOST", Value: serverIP},
@@ -1043,4 +1025,64 @@ func (p *Provider) configureEnvFrom(virtualPod *corev1.Pod, envs []corev1.EnvFro
 	}
 
 	return resultingEnvVars
+}
+
+// Limits the API server enforces on a pod with dnsPolicy None.
+const (
+	maxDNSNameservers = 3
+	maxDNSSearchPaths = 32
+)
+
+// configureDNS points the host pod at the virtual cluster's coredns. It mirrors
+// what the kubelet does for dnsPolicy ClusterFirst: the cluster nameserver and
+// search domains come first, the pod's own dnsConfig entries are appended, and
+// the pod's options are kept (ndots defaults to 5 when the pod sets none).
+//
+// A pod with dnsPolicy None owns its DNS configuration and is left untouched,
+// as is the virtual cluster's own coredns pod.
+func configureDNS(hostPod, virtualPod *corev1.Pod, dnsIP string) {
+	if isCoreDNSPod(*virtualPod) || virtualPod.Spec.DNSPolicy == corev1.DNSNone {
+		return
+	}
+
+	dnsConfig := &corev1.PodDNSConfig{
+		Nameservers: []string{dnsIP},
+		Searches: []string{
+			virtualPod.Namespace + ".svc.cluster.local",
+			"svc.cluster.local",
+			"cluster.local",
+		},
+	}
+
+	if podConfig := virtualPod.Spec.DNSConfig; podConfig != nil {
+		dnsConfig.Nameservers = appendUnique(dnsConfig.Nameservers, podConfig.Nameservers, maxDNSNameservers)
+		dnsConfig.Searches = appendUnique(dnsConfig.Searches, podConfig.Searches, maxDNSSearchPaths)
+		dnsConfig.Options = append(dnsConfig.Options, podConfig.Options...)
+	}
+
+	if !hasDNSOption(dnsConfig.Options, "ndots") {
+		dnsConfig.Options = append(dnsConfig.Options, corev1.PodDNSConfigOption{Name: "ndots", Value: new("5")})
+	}
+
+	hostPod.Spec.DNSPolicy = corev1.DNSNone
+	hostPod.Spec.DNSConfig = dnsConfig
+}
+
+// appendUnique appends the entries of extra that are not yet in base, up to limit entries in total.
+func appendUnique(base, extra []string, limit int) []string {
+	for _, e := range extra {
+		if len(base) >= limit {
+			break
+		}
+
+		if !slices.Contains(base, e) {
+			base = append(base, e)
+		}
+	}
+
+	return base
+}
+
+func hasDNSOption(options []corev1.PodDNSConfigOption, name string) bool {
+	return slices.ContainsFunc(options, func(o corev1.PodDNSConfigOption) bool { return o.Name == name })
 }

--- a/k3k-kubelet/provider/provider_test.go
+++ b/k3k-kubelet/provider/provider_test.go
@@ -405,3 +405,108 @@ func TestUpdateMetadata(t *testing.T) {
 	assert.Equal(t, "my-pod", hostPod.Annotations[translate.ResourceNameAnnotation])
 	assert.Equal(t, "default", hostPod.Annotations[translate.ResourceNamespaceAnnotation])
 }
+
+func Test_configureDNS(t *testing.T) {
+	const dnsIP = "10.197.77.73"
+
+	vcSearches := []string{"tenant.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+	ndots := func(v string) corev1.PodDNSConfigOption {
+		return corev1.PodDNSConfigOption{Name: "ndots", Value: new(v)}
+	}
+	pod := func(policy corev1.DNSPolicy, cfg *corev1.PodDNSConfig) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "tenant"},
+			Spec:       corev1.PodSpec{DNSPolicy: policy, DNSConfig: cfg},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		virtualPod *corev1.Pod
+		wantPolicy corev1.DNSPolicy
+		wantConfig *corev1.PodDNSConfig
+	}{
+		{
+			name:       "no dnsConfig gets the virtual cluster DNS",
+			virtualPod: pod(corev1.DNSClusterFirst, nil),
+			wantPolicy: corev1.DNSNone,
+			wantConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{dnsIP},
+				Searches:    vcSearches,
+				Options:     []corev1.PodDNSConfigOption{ndots("5")},
+			},
+		},
+		{
+			name: "dnsConfig with options only keeps the options and still gets the virtual cluster DNS",
+			virtualPod: pod(corev1.DNSClusterFirst, &corev1.PodDNSConfig{
+				Options: []corev1.PodDNSConfigOption{ndots("1")},
+			}),
+			wantPolicy: corev1.DNSNone,
+			wantConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{dnsIP},
+				Searches:    vcSearches,
+				Options:     []corev1.PodDNSConfigOption{ndots("1")},
+			},
+		},
+		{
+			name: "extra nameservers and searches are appended after the virtual cluster ones",
+			virtualPod: pod(corev1.DNSClusterFirst, &corev1.PodDNSConfig{
+				Nameservers: []string{"192.0.2.53", dnsIP},
+				Searches:    []string{"example.internal", "svc.cluster.local"},
+				Options:     []corev1.PodDNSConfigOption{{Name: "timeout", Value: new("2")}},
+			}),
+			wantPolicy: corev1.DNSNone,
+			wantConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{dnsIP, "192.0.2.53"},
+				Searches:    append(vcSearches, "example.internal"),
+				Options:     []corev1.PodDNSConfigOption{{Name: "timeout", Value: new("2")}, ndots("5")},
+			},
+		},
+		{
+			name: "nameservers are capped at three",
+			virtualPod: pod(corev1.DNSClusterFirst, &corev1.PodDNSConfig{
+				Nameservers: []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"},
+			}),
+			wantPolicy: corev1.DNSNone,
+			wantConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{dnsIP, "192.0.2.1", "192.0.2.2"},
+				Searches:    vcSearches,
+				Options:     []corev1.PodDNSConfigOption{ndots("5")},
+			},
+		},
+		{
+			name: "dnsPolicy None is left untouched",
+			virtualPod: pod(corev1.DNSNone, &corev1.PodDNSConfig{
+				Nameservers: []string{"192.0.2.53"},
+			}),
+			wantPolicy: corev1.DNSNone,
+			wantConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{"192.0.2.53"},
+			},
+		},
+		{
+			name: "the coredns pod is left untouched",
+			virtualPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "coredns",
+					Namespace: metav1.NamespaceSystem,
+					Labels:    map[string]string{"k8s-app": "kube-dns"},
+				},
+				Spec: corev1.PodSpec{DNSPolicy: corev1.DNSDefault},
+			},
+			wantPolicy: corev1.DNSDefault,
+			wantConfig: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostPod := tt.virtualPod.DeepCopy()
+
+			configureDNS(hostPod, tt.virtualPod, dnsIP)
+
+			assert.Equal(t, tt.wantPolicy, hostPod.Spec.DNSPolicy)
+			assert.Equal(t, tt.wantConfig, hostPod.Spec.DNSConfig)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

In shared mode, `configureNetworking` injects the virtual cluster's CoreDNS into every synced pod, but only when the virtual pod has no `dnsConfig` at all:

```go
if !isCoreDNSPod(*virtualPod) && hostPod.Spec.DNSConfig == nil {
```

This guard came in with #354 to fix #341 (a pod with `dnsPolicy: None` and its own nameservers). As a side effect it also applies to pods that keep `dnsPolicy: ClusterFirst` and only add a `dnsConfig` with options, which is a common Helm chart pattern (`options: [{name: ndots, value: "1"}]`). For such a pod the host pod stays on `ClusterFirst`, so the host kubelet writes the **host** cluster's resolv.conf into it: host CoreDNS IP and host search domains. The pod then cannot resolve virtual cluster services (and, with host-side network policies in place, cannot resolve anything).

We may be missing a reason why any `dnsConfig` should switch off the injection, so this PR is a recommendation rather than a plain bug fix. If the current behavior is intentional, a note in the docs would help users who hit this.

## Proposed behavior

Mirror what the kubelet does for `dnsPolicy: ClusterFirst`:

- nameservers: virtual cluster CoreDNS first, then the pod's own nameservers (capped at the API limit of 3)
- search domains: virtual cluster domains first, then the pod's own (capped at 32)
- options: the pod's options are kept; `ndots: 5` is added only when the pod sets no `ndots`
- a pod with `dnsPolicy: None` owns its DNS configuration and stays untouched (the #341 case)
- the virtual cluster's CoreDNS pod stays untouched, as before

`KUBERNETES_SERVICE_HOST` injection is not affected.

## Testing

- `Test_configureDNS` covers: no dnsConfig, options-only dnsConfig, extra nameservers/searches appended after the cluster ones, the 3-nameserver cap, `dnsPolicy: None` untouched, CoreDNS pod untouched.
- Verified on a shared-mode cluster: a Deployment with `dnsConfig.options ndots=1` gets `dnsPolicy: None` with the virtual CoreDNS as nameserver and the virtual search domains on the host pod, and resolves a Service in another virtual namespace. Without the change the same pod receives the host cluster's resolv.conf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
