### PR TITLE
Removed some revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
   - wsl_v5
   - importas
   - revive
-  - govet
   exclusions:
     rules:
     # Allow dot imports for Ginkgo/Gomega in tests dir
@@ -19,21 +18,18 @@ linters:
     revive:
       enable-all-rules: true
       rules:
-        - {name: add-constant, disabled: true}
-        - {name: cognitive-complexity, disabled: true}
-        - {name: confusing-naming, disabled: true}
-        - {name: confusing-results, disabled: true}
-        - {name: cyclomatic, disabled: true}
-        - {name: early-return, disabled: true}
-        - {name: enforce-switch-style, disabled: true}
-        - {name: flag-parameter, disabled: true}
-        - {name: function-length, disabled: true}
-        - {name: import-shadowing, disabled: true}
-        - {name: line-length-limit, disabled: true}
-        - {name: unused-parameter, disabled: true}
-        - {name: unused-receiver, disabled: true}
-        - {name: unnecessary-format, disabled: true}
-        - {name: unhandled-error, arguments: ["fmt\\.Print.*", "fmt\\.Fprint.*"]}
+      - { name: cyclomatic, arguments: [ 30 ] }
+      - { name: unhandled-error, arguments: [ "fmt\\.Print.*", "fmt\\.Fprint.*" ] }
+      # disabled rules
+      - { name: add-constant, disabled: true }
+      - { name: cognitive-complexity, disabled: true }
+      - { name: confusing-naming, disabled: true }
+      - { name: confusing-results, disabled: true }
+      - { name: flag-parameter, disabled: true }
+      - { name: function-length, disabled: true }
+      - { name: import-shadowing, disabled: true }
+      - { name: line-length-limit, disabled: true }
+      - { name: unused-parameter, disabled: true }
     importas:
       # Enforce import aliases for k8s packages
       alias:
@@ -68,3 +64,8 @@ formatters:
       rewrite-rules:
       - pattern: 'interface{}'
         replacement: 'any'
+
+issues:
+  # Report everything: the defaults (50 per linter, 3 per rule) silently truncate
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cli/cmds/cluster_create.go
+++ b/cli/cmds/cluster_create.go
@@ -148,11 +148,11 @@ func createAction(appCtx *AppContext, config *CreateConfig) func(cmd *cobra.Comm
 		cluster.Spec.TLSSANs = uniqueStrings(sans)
 
 		if err := client.Create(ctx, cluster); err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				logrus.Infof("Cluster '%s' already exists", name)
-			} else {
+			if !apierrors.IsAlreadyExists(err) {
 				return err
 			}
+
+			logrus.Infof("Cluster '%s' already exists", name)
 		}
 
 		if err := waitForClusterReconciled(ctx, client, cluster, config.timeout); err != nil {

--- a/cli/cmds/cluster_update.go
+++ b/cli/cmds/cluster_update.go
@@ -182,7 +182,7 @@ func confirmClusterUpdate(cluster *v1beta1.Cluster) bool {
 
 	fmt.Printf("\nNew %s\n", clusterDetails)
 
-	fmt.Printf("\nDo you want to update the cluster? [y/N]: ")
+	fmt.Print("\nDo you want to update the cluster? [y/N]: ")
 
 	scanner := bufio.NewScanner(os.Stdin)
 
@@ -194,7 +194,7 @@ func confirmClusterUpdate(cluster *v1beta1.Cluster) bool {
 		return false
 	}
 
-	fmt.Printf("\n")
+	fmt.Println()
 
 	return strings.ToLower(strings.TrimSpace(scanner.Text())) == "y"
 }

--- a/k3k-kubelet/controller/syncer/configmap.go
+++ b/k3k-kubelet/controller/syncer/configmap.go
@@ -30,11 +30,6 @@ type ConfigMapSyncer struct {
 	*Context
 }
 
-// Name returns the name of the controller.
-func (c *ConfigMapSyncer) Name() string {
-	return configMapControllerName
-}
-
 // AddConfigMapSyncer adds configmap syncer controller to the manager of the virtual cluster
 func AddConfigMapSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clusterName, clusterNamespace string) error {
 	reconciler := ConfigMapSyncer{

--- a/k3k-kubelet/controller/syncer/events.go
+++ b/k3k-kubelet/controller/syncer/events.go
@@ -33,11 +33,6 @@ type EventSyncer struct {
 	*Context
 }
 
-// Name returns the name of the controller.
-func (s *EventSyncer) Name() string {
-	return eventControllerName
-}
-
 // AddEventSyncer adds event syncer controller to the manager of the virtual
 // cluster.
 func AddEventSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clusterName, clusterNamespace string, virtEventRecorder record.EventRecorder) error {

--- a/k3k-kubelet/controller/syncer/secret.go
+++ b/k3k-kubelet/controller/syncer/secret.go
@@ -30,11 +30,6 @@ type SecretSyncer struct {
 	*Context
 }
 
-// Name returns the name of the controller.
-func (s *SecretSyncer) Name() string {
-	return secretControllerName
-}
-
 // AddSecretSyncer adds secret syncer controller to the manager of the virtual cluster
 func AddSecretSyncer(ctx context.Context, virtMgr, hostMgr manager.Manager, clusterName, clusterNamespace string) error {
 	reconciler := SecretSyncer{

--- a/k3k-kubelet/provider/collectors/kubelet_resource_metrics.go
+++ b/k3k-kubelet/provider/collectors/kubelet_resource_metrics.go
@@ -92,7 +92,7 @@ type resourceMetricsCollector struct {
 var _ compbasemetrics.StableCollector = &resourceMetricsCollector{}
 
 // DescribeWithStability implements compbasemetrics.StableCollector
-func (rc *resourceMetricsCollector) DescribeWithStability(ch chan<- *compbasemetrics.Desc) {
+func (*resourceMetricsCollector) DescribeWithStability(ch chan<- *compbasemetrics.Desc) {
 	descs := []*compbasemetrics.Desc{
 		nodeCPUUsageDesc,
 		nodeMemoryUsageDesc,
@@ -138,7 +138,7 @@ func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- compbasemetri
 
 // implement collector methods and validate that correct data is used
 
-func (rc *resourceMetricsCollector) collectNodeCPUMetrics(ch chan<- compbasemetrics.Metric, s stats.NodeStats) {
+func (*resourceMetricsCollector) collectNodeCPUMetrics(ch chan<- compbasemetrics.Metric, s stats.NodeStats) {
 	if s.CPU == nil || s.CPU.UsageCoreNanoSeconds == nil {
 		return
 	}
@@ -147,7 +147,7 @@ func (rc *resourceMetricsCollector) collectNodeCPUMetrics(ch chan<- compbasemetr
 		compbasemetrics.NewLazyConstMetric(nodeCPUUsageDesc, compbasemetrics.CounterValue, float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second)))
 }
 
-func (rc *resourceMetricsCollector) collectNodeMemoryMetrics(ch chan<- compbasemetrics.Metric, s stats.NodeStats) {
+func (*resourceMetricsCollector) collectNodeMemoryMetrics(ch chan<- compbasemetrics.Metric, s stats.NodeStats) {
 	if s.Memory == nil || s.Memory.WorkingSetBytes == nil {
 		return
 	}
@@ -156,7 +156,7 @@ func (rc *resourceMetricsCollector) collectNodeMemoryMetrics(ch chan<- compbasem
 		compbasemetrics.NewLazyConstMetric(nodeMemoryUsageDesc, compbasemetrics.GaugeValue, float64(*s.Memory.WorkingSetBytes)))
 }
 
-func (rc *resourceMetricsCollector) collectContainerStartTime(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
+func (*resourceMetricsCollector) collectContainerStartTime(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
 	if s.StartTime.Unix() <= 0 {
 		return
 	}
@@ -165,7 +165,7 @@ func (rc *resourceMetricsCollector) collectContainerStartTime(ch chan<- compbase
 		compbasemetrics.NewLazyConstMetric(containerStartTimeDesc, compbasemetrics.GaugeValue, float64(s.StartTime.UnixNano())/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
 }
 
-func (rc *resourceMetricsCollector) collectContainerCPUMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
+func (*resourceMetricsCollector) collectContainerCPUMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
 	if s.CPU == nil || s.CPU.UsageCoreNanoSeconds == nil {
 		return
 	}
@@ -175,7 +175,7 @@ func (rc *resourceMetricsCollector) collectContainerCPUMetrics(ch chan<- compbas
 			float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
 }
 
-func (rc *resourceMetricsCollector) collectContainerMemoryMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
+func (*resourceMetricsCollector) collectContainerMemoryMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats, s stats.ContainerStats) {
 	if s.Memory == nil || s.Memory.WorkingSetBytes == nil {
 		return
 	}
@@ -185,7 +185,7 @@ func (rc *resourceMetricsCollector) collectContainerMemoryMetrics(ch chan<- comp
 			float64(*s.Memory.WorkingSetBytes), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
 }
 
-func (rc *resourceMetricsCollector) collectPodCPUMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats) {
+func (*resourceMetricsCollector) collectPodCPUMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats) {
 	if pod.CPU == nil || pod.CPU.UsageCoreNanoSeconds == nil {
 		return
 	}
@@ -195,7 +195,7 @@ func (rc *resourceMetricsCollector) collectPodCPUMetrics(ch chan<- compbasemetri
 			float64(*pod.CPU.UsageCoreNanoSeconds)/float64(time.Second), pod.PodRef.Name, pod.PodRef.Namespace))
 }
 
-func (rc *resourceMetricsCollector) collectPodMemoryMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats) {
+func (*resourceMetricsCollector) collectPodMemoryMetrics(ch chan<- compbasemetrics.Metric, pod stats.PodStats) {
 	if pod.Memory == nil || pod.Memory.WorkingSetBytes == nil {
 		return
 	}

--- a/k3k-kubelet/provider/node.go
+++ b/k3k-kubelet/provider/node.go
@@ -12,7 +12,7 @@ type Node struct {
 }
 
 // Ping is called to check if the node is healthy - in the current format it always is
-func (n *Node) Ping(context.Context) error {
+func (*Node) Ping(context.Context) error {
 	return nil
 }
 

--- a/k3k-kubelet/provider/provider.go
+++ b/k3k-kubelet/provider/provider.go
@@ -385,7 +385,7 @@ func (p *Provider) PortForward(ctx context.Context, namespace, name string, port
 
 // CreatePod executes createPod with retry
 func (p *Provider) CreatePod(ctx context.Context, pod *corev1.Pod) error {
-	return p.withRetry(ctx, p.createPod, pod)
+	return withRetry(ctx, p.createPod, pod)
 }
 
 func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
@@ -529,7 +529,7 @@ func (p *Provider) createPod(ctx context.Context, pod *corev1.Pod) error {
 }
 
 // withRetry retries passed function with interval and timeout
-func (p *Provider) withRetry(ctx context.Context, f func(context.Context, *corev1.Pod) error, pod *corev1.Pod) error {
+func withRetry(ctx context.Context, f func(context.Context, *corev1.Pod) error, pod *corev1.Pod) error {
 	const (
 		interval = time.Second
 		timeout  = 10 * time.Second
@@ -582,6 +582,8 @@ func (p *Provider) transformVolumes(podNamespace string, volumes []corev1.Volume
 					source.ConfigMap.Name = p.translator.TranslateName(podNamespace, source.ConfigMap.Name)
 				case source.Secret != nil:
 					source.Secret.Name = p.translator.TranslateName(podNamespace, source.Secret.Name)
+				default:
+					// other projected sources reference no host resource by name
 				}
 			}
 
@@ -593,16 +595,23 @@ func (p *Provider) transformVolumes(podNamespace string, volumes []corev1.Volume
 						downwardAPI.FieldRef.FieldPath = fmt.Sprintf("metadata.annotations['%s']", translate.ResourceNameAnnotation)
 					case translate.MetadataNamespaceField:
 						downwardAPI.FieldRef.FieldPath = fmt.Sprintf("metadata.annotations['%s']", translate.ResourceNamespaceAnnotation)
+					default:
+						// other field paths are the same in the host cluster
 					}
 				}
 			}
+
+		default:
+			// Volumes that reference namespaced resources through other fields
+			// (CSI NodePublishSecretRef, Ephemeral VolumeClaimTemplate, the
+			// in-tree SecretRefs) are not translated yet.
 		}
 	}
 }
 
 // UpdatePod executes updatePod with retry
 func (p *Provider) UpdatePod(ctx context.Context, pod *corev1.Pod) error {
-	return p.withRetry(ctx, p.updatePod, pod)
+	return withRetry(ctx, p.updatePod, pod)
 }
 
 func (p *Provider) updatePod(ctx context.Context, pod *corev1.Pod) error {
@@ -736,7 +745,7 @@ func updateContainerImages(dst, src []corev1.Container) {
 
 // DeletePod executes deletePod with retry
 func (p *Provider) DeletePod(ctx context.Context, pod *corev1.Pod) error {
-	return p.withRetry(ctx, p.deletePod, pod)
+	return withRetry(ctx, p.deletePod, pod)
 }
 
 // deletePod takes a Kubernetes Pod and deletes it from the provider. Once a pod is deleted, the provider is
@@ -1009,6 +1018,8 @@ func (p *Provider) configureEnv(virtualPod *corev1.Pod, envs []corev1.EnvVar) []
 				case "metadata.namespace":
 					resultingEnvVar.Value = virtualPod.Namespace
 					resultingEnvVar.ValueFrom = nil
+				default:
+					// other field paths are the same in the host cluster
 				}
 
 			case from.ConfigMapKeyRef != nil:
@@ -1016,6 +1027,9 @@ func (p *Provider) configureEnv(virtualPod *corev1.Pod, envs []corev1.EnvVar) []
 
 			case from.SecretKeyRef != nil:
 				resultingEnvVar.ValueFrom.SecretKeyRef.Name = p.translator.TranslateName(virtualPod.Namespace, resultingEnvVar.ValueFrom.SecretKeyRef.Name)
+
+			default:
+				// other sources reference no host resource by name
 			}
 		}
 

--- a/k3k-kubelet/translate/host.go
+++ b/k3k-kubelet/translate/host.go
@@ -92,7 +92,7 @@ func (t *ToHostTranslator) TranslateTo(obj client.Object) {
 
 // TranslateFrom reverses TranslateTo, restoring the original name and namespace an
 // object had in the virtual cluster.
-func (t *ToHostTranslator) TranslateFrom(obj client.Object) {
+func (*ToHostTranslator) TranslateFrom(obj client.Object) {
 	// owning objects may be in the virtual cluster, but may not be in the host cluster
 	obj.SetOwnerReferences(nil)
 

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -375,7 +375,7 @@ func (c *Reconciler) reconcile(ctx context.Context, cluster *v1beta1.Cluster) er
 		}
 	}
 
-	if err := c.validate(cluster, vcp); err != nil {
+	if err := validate(cluster, vcp); err != nil {
 		return err
 	}
 
@@ -1004,7 +1004,7 @@ func (c *Reconciler) ensureAgent(ctx context.Context, cluster *v1beta1.Cluster, 
 // validate validates a Cluster before reconciling it. The policy is nil when the namespace
 // of the Cluster is not bound to any VirtualClusterPolicy: only the checks that depend on it
 // are skipped in that case.
-func (c *Reconciler) validate(cluster *v1beta1.Cluster, policy *v1beta1.VirtualClusterPolicy) error {
+func validate(cluster *v1beta1.Cluster, policy *v1beta1.VirtualClusterPolicy) error {
 	if cluster.Name == ClusterInvalidName {
 		return fmt.Errorf("%w: invalid cluster name %q", ErrClusterValidation, cluster.Name)
 	}
@@ -1014,7 +1014,7 @@ func (c *Reconciler) validate(cluster *v1beta1.Cluster, policy *v1beta1.VirtualC
 	}
 
 	if cluster.Spec.CustomCAs != nil && cluster.Spec.CustomCAs.Enabled {
-		if err := c.validateCustomCACerts(cluster.Spec.CustomCAs.Sources); err != nil {
+		if err := validateCustomCACerts(cluster.Spec.CustomCAs.Sources); err != nil {
 			return fmt.Errorf("%w: %w", ErrClusterValidation, err)
 		}
 	}
@@ -1110,7 +1110,7 @@ func (c *Reconciler) lookupServiceCIDR(ctx context.Context) (string, error) {
 }
 
 // validateCustomCACerts will make sure that all the cert secrets exists
-func (c *Reconciler) validateCustomCACerts(credentialSources v1beta1.CredentialSources) error {
+func validateCustomCACerts(credentialSources v1beta1.CredentialSources) error {
 	if credentialSources.ClientCA.SecretName == "" ||
 		credentialSources.ServerCA.SecretName == "" ||
 		credentialSources.EtcdPeerCA.SecretName == "" ||

--- a/pkg/controller/cluster/cluster_test.go
+++ b/pkg/controller/cluster/cluster_test.go
@@ -100,11 +100,7 @@ func Test_validate(t *testing.T) {
 				},
 			}
 
-			// the Client is only needed to validate the customCAs secrets,
-			// which none of these clusters enable
-			reconciler := &Reconciler{}
-
-			err := reconciler.validate(cluster, tt.policy)
+			err := validate(cluster, tt.policy)
 
 			if tt.wantErr == "" {
 				assert.NoError(t, err)

--- a/pkg/controller/cluster/hcp.go
+++ b/pkg/controller/cluster/hcp.go
@@ -70,14 +70,15 @@ func (c *Reconciler) ensureHCPKubernetesEndpointSlice(ctx context.Context, clust
 
 	var addressType discoveryv1.AddressType
 
-	if ip := net.ParseIP(addr.IP); ip != nil {
-		if ip.To4() != nil {
-			addressType = discoveryv1.AddressTypeIPv4
-		} else {
-			addressType = discoveryv1.AddressTypeIPv6
-		}
-	} else {
+	ip := net.ParseIP(addr.IP)
+	if ip == nil {
 		return fmt.Errorf("invalid IP address %q", addr.IP)
+	}
+
+	if ip.To4() != nil {
+		addressType = discoveryv1.AddressTypeIPv4
+	} else {
+		addressType = discoveryv1.AddressTypeIPv6
 	}
 
 	virtClient, err := newVirtualClient(ctx, c.Client, cluster.Name, cluster.Namespace)

--- a/pkg/controller/cluster/server/config.go
+++ b/pkg/controller/cluster/server/config.go
@@ -100,8 +100,8 @@ func buildServerConfig(cluster *v1beta1.Cluster, initServer bool, serviceIP, tok
 		// own default/kubernetes Endpoints and point it at the externally
 		// reachable host:port (NodePort / LB / Ingress).
 		serverConfig.KubeAPIServerArg = append(serverConfig.KubeAPIServerArg, "endpoint-reconciler-type=none")
-	case v1beta1.VirtualClusterMode:
-		// no extra config for virtual mode
+	default:
+		// virtual mode needs no extra config, and any other mode is rejected by the CRD validation
 	}
 
 	return serverConfig

--- a/pkg/controller/cluster/server/endpoint.go
+++ b/pkg/controller/cluster/server/endpoint.go
@@ -108,6 +108,10 @@ func URL(ctx context.Context, c client.Client, cluster *v1beta1.Cluster, hostSer
 				log.V(1).Info("No usable ingress address found in LoadBalancer service.")
 			}
 		}
+
+	default:
+		// ExternalName services expose no routable address, so keep the host server IP
+		log.V(1).Info("Unsupported service type, falling back to the host server IP", "type", k3kService.Spec.Type)
 	}
 
 	if !slices.Contains(cluster.Status.TLSSANs, host) {

--- a/pkg/controller/cluster/server/server.go
+++ b/pkg/controller/cluster/server/server.go
@@ -531,7 +531,7 @@ func (s *Server) buildCABundleVolumes(ctx context.Context) ([]corev1.Volume, []c
 
 		volumeName := certName + "-vol"
 
-		vol, certMounts := s.mountCACert(volumeName, certName, secretName, "tls")
+		vol, certMounts := mountCACert(volumeName, certName, secretName, "tls")
 		volumes = append(volumes, *vol)
 		mounts = append(mounts, certMounts...)
 	}
@@ -539,7 +539,7 @@ func (s *Server) buildCABundleVolumes(ctx context.Context) ([]corev1.Volume, []c
 	return volumes, mounts, nil
 }
 
-func (s *Server) mountCACert(volumeName, certName, secretName string, subPathMount string) (*corev1.Volume, []corev1.VolumeMount) {
+func mountCACert(volumeName, certName, secretName string, subPathMount string) (*corev1.Volume, []corev1.VolumeMount) {
 	var (
 		volume *corev1.Volume
 		mounts []corev1.VolumeMount

--- a/pkg/controller/policy/namespace.go
+++ b/pkg/controller/policy/namespace.go
@@ -19,7 +19,7 @@ import (
 )
 
 // reconcileNamespacePodSecurityLabels will update the labels of the namespace to reconcile the PSA level specified in the VirtualClusterPolicy
-func (c *VirtualClusterPolicyReconciler) reconcileNamespacePodSecurityLabels(ctx context.Context, namespace *corev1.Namespace, policy *v1beta1.VirtualClusterPolicy) {
+func reconcileNamespacePodSecurityLabels(ctx context.Context, namespace *corev1.Namespace, policy *v1beta1.VirtualClusterPolicy) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling PSA labels")
 

--- a/pkg/controller/policy/policy.go
+++ b/pkg/controller/policy/policy.go
@@ -356,7 +356,7 @@ func (c *VirtualClusterPolicyReconciler) reconcileMatchingNamespaces(ctx context
 			return err
 		}
 
-		c.reconcileNamespacePodSecurityLabels(ctx, &ns, policy)
+		reconcileNamespacePodSecurityLabels(ctx, &ns, policy)
 
 		if !reflect.DeepEqual(orig, &ns) {
 			log.Info("Updating Namespace")


### PR DESCRIPTION
This PR removes `govet` from the enabled list (since it's enabled by default) and removes some `revive` rules, which fixes the following issues:

The rules now enabled are:
- `early-return`
- `enforce-switch-style`
- `unnecessary-format`
- `unused-receiver`

The `cyclomatic` rule was also enabled, but with a higher threshold (30, compared to the default of 10).