### PR TITLE
Allow Renovate to use custom rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>rancher/renovate-config//default#main"],
   "baseBranchPatterns": [
     "main",
     "release/v1.2",


### PR DESCRIPTION
by placing default.json in the beginning of the configuration.